### PR TITLE
Add ngrok auth token configuration to preview workflow

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -68,6 +68,17 @@ jobs:
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         run: npm install -g ngrok@4
 
+      - name: Configure ngrok auth token
+        if: ${{ steps.detect.outputs.frontend_found == 'true' }}
+        run: |
+          if [ -n "${{ secrets.NGROK_AUTHTOKEN }}" ]; then
+            echo "🔐 Adding ngrok auth token..."
+            ngrok config add-authtoken ${{ secrets.NGROK_AUTHTOKEN }}
+          else
+            echo "::error::Missing NGROK_AUTHTOKEN secret. Please add it to repo secrets."
+            exit 1
+          fi
+
       - name: Start ngrok tunnel
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         id: ngrok


### PR DESCRIPTION
## Summary
- add a workflow step to configure ngrok using the NGROK_AUTHTOKEN secret before creating the tunnel
- fail early with a clear error when the secret is missing

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f4404db483329b847b5d6ff0dfb5)