### PR TITLE
Fix Telegram message Markdown escaping

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -157,7 +157,7 @@ jobs:
           ESCAPED_AUTHOR=$(echo "$AUTHOR" | sed 's/[_*\[\]()~`>#+=|{}.!-]/\\&/g')
 
           MSG=$(printf '%s\n' \
-            "🚀 *Preview ready for PR #$PR_NUMBER in $REPO*" \
+            "🚀 *Preview ready for PR \\#$PR_NUMBER in $REPO*" \
             "" \
             "*Title:* $ESCAPED_TITLE" \
             "*Author:* $ESCAPED_AUTHOR" \


### PR DESCRIPTION
## Summary
- escape the literal hash symbol in the Telegram notification to satisfy MarkdownV2 parsing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911909d58988332ae772ce7f52e5e01)