### PR TITLE
Fix Telegram Markdown escaping

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -153,17 +153,18 @@ jobs:
           PREVIEW_URL="${{ steps.ngrok.outputs.preview_url }}"
           TIMEOUT_MINUTES=${{ env.PREVIEW_TIMEOUT_MINUTES }}
 
-          ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[_*\[\]()~`>#+=|{}.!-]/\\&/g')
-          ESCAPED_AUTHOR=$(echo "$AUTHOR" | sed 's/[_*\[\]()~`>#+=|{}.!-]/\\&/g')
+          ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
+          ESCAPED_AUTHOR=$(echo "$AUTHOR" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
+          ESCAPED_REPO=$(echo "$REPO" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
 
           MSG=$(printf '%s\n' \
-            "🚀 *Preview ready for PR \\#$PR_NUMBER in $REPO*" \
+            "🚀 *Preview ready for PR \\#$PR_NUMBER in $ESCAPED_REPO*" \
             "" \
             "*Title:* $ESCAPED_TITLE" \
             "*Author:* $ESCAPED_AUTHOR" \
             "" \
             "*Live Preview:* [Open Preview]($PREVIEW_URL)" \
-            "⏳ *This preview will expire in ${TIMEOUT_MINUTES} minutes.*" \
+            "⏳ *This preview will expire in ${TIMEOUT_MINUTES} minutes\.*" \
             "" \
             "[View on GitHub](https://github.com/$REPO/pull/$PR_NUMBER)"
           )


### PR DESCRIPTION
## Summary
- escape the repository name before inserting it into the Telegram Markdown message
- escape the static period in the expiration sentence to satisfy Telegram Markdown rules
- consolidate the Markdown escaping pattern used for all user-supplied values

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691197e6096083328fa96dfd7b15dcc5)