### PR TITLE
Update Vite dev server startup options in preview workflow

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -65,16 +65,22 @@ jobs:
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         working-directory: ${{ steps.detect.outputs.frontend_dir }}
         run: |
-          echo "🚀 Starting npm run dev in background..."
-          nohup npm run dev > server.log 2>&1 &
+          echo "🚀 Starting Vite dev server (allowing all hosts for ngrok)..."
+          
+          # Run Vite in background with permissive host options
+          nohup npm run dev -- --host 0.0.0.0 --allowedHosts all > server.log 2>&1 &
+          
           echo "⏳ Waiting for dev server to become available..."
           for i in {1..30}; do
             if nc -z localhost 5173 2>/dev/null || nc -z localhost 3000 2>/dev/null || nc -z localhost 8080 2>/dev/null; then
-              echo "✅ Dev server is ready."
+              echo "✅ Dev server is ready and externally accessible."
               break
             fi
             sleep 2
           done
+
+          echo "🔍 Last few lines of server.log:"
+          tail -n 15 server.log || true
 
       - name: Start ngrok tunnel (v4 CLI, verbose)
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}


### PR DESCRIPTION
## Summary
- run the Vite dev server with permissive host options for ngrok access
- print the tail of the dev server log after waiting for readiness

## Testing
- not run (workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911a24f6a088332be035636486f8516)