### PR TITLE
Add workflow run link to Telegram notification

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -158,6 +158,7 @@ jobs:
           AUTHOR="${{ github.event.pull_request.user.login }}"
           PREVIEW_URL="${{ steps.ngrok.outputs.preview_url }}"
           TIMEOUT_MINUTES=${{ env.PREVIEW_TIMEOUT_MINUTES }}
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
           ESCAPED_AUTHOR=$(echo "$AUTHOR" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
@@ -170,6 +171,7 @@ jobs:
             "*Author:* $ESCAPED_AUTHOR" \
             "" \
             "*Live Preview:* [Open Preview]($PREVIEW_URL)" \
+            "*Workflow:* [View Run]($WORKFLOW_URL)" \
             "⏳ *This preview will expire in ${TIMEOUT_MINUTES} minutes\.*" \
             "" \
             "[View on GitHub](https://github.com/$REPO/pull/$PR_NUMBER)"


### PR DESCRIPTION
## Summary
- include the GitHub Actions workflow run URL when composing the Telegram message
- provide a deep link so reviewers can open the running workflow that maintains the ngrok tunnel

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911cf3d46588332a63b8d9706d23d5a)