### PR TITLE
Containerize the MADE web app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+npm-debug.log
+Dockerfile*
+dist
+.git
+.gitignore
+README.md
+LICENSE
+*.md
+examples
+playwright-report
+packages/frontend/dist
+packages/backend/dist
+coverage
+.env
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Access the web interface at `http://localhost:5173` to:
 4. **Define Constitutions** - Set development rules and guidelines
 5. **Edit Files** - Use the integrated editor with live preview
 
+## Docker Deployment
+
+Container images are provided for both the API backend and the static frontend. The [`docker-compose.yml`](./docker-compose.yml) file builds and runs the complete stack with one command.
+
+```bash
+# Build images and start the containers
+docker compose up --build
+
+# Backend API:    http://localhost:3000
+# Frontend (Nginx): http://localhost:8080
+```
+
+The backend persists its `.made` workspace inside the named `made-data` volume defined in the compose file. Environment variables such as `MADE_HOME`, `MADE_WORKSPACE_HOME`, or `PORT` can be overridden by editing the `backend` service configuration.
+
 ## Configuration
 
 Required environment variables / config:
@@ -88,6 +102,7 @@ Required environment variables / config:
 - `MADE_WORKSPACE_HOME` — string — default: `process.cwd()` — Root directory where repositories are stored
 - `PORT` — number — default: `3000` — Port for the backend API server
 - `NODE_ENV` — string — default: `development` — Environment mode (development/production)
+- `VITE_API_BASE` — string — default: `/api` — Frontend build-time override for the backend API base URL (used for containerized deployments)
 
 The application automatically creates a `.made` directory structure:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: docker/backend.Dockerfile
+    environment:
+      PORT: 3000
+      NODE_ENV: production
+    volumes:
+      - made-data:/app/.made
+    ports:
+      - "3000:3000"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/frontend.Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - "8080:80"
+
+volumes:
+  made-data:

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM node:18-alpine
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace manifests first to leverage Docker layer caching
+COPY package.json package-lock.json ./
+COPY packages/backend/package.json packages/backend/package.json
+
+# Install only the backend workspace dependencies
+RUN npm ci --omit=dev --workspace packages/backend --include-workspace-root=false \
+  && npm cache clean --force
+
+# Copy backend source code
+COPY packages/backend packages/backend
+
+EXPOSE 3000
+
+CMD ["node", "packages/backend/src/server.js"]

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+# Install dependencies for the frontend workspace
+COPY package.json package-lock.json ./
+COPY packages/frontend/package.json packages/frontend/package.json
+RUN npm ci --workspace packages/frontend --include-workspace-root=false \
+  && npm cache clean --force
+
+# Copy frontend source and build the production bundle
+COPY packages/frontend packages/frontend
+RUN npm run build --workspace packages/frontend
+
+FROM nginx:1.27-alpine
+
+# Copy custom Nginx configuration to route API calls to the backend service
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy the built frontend assets
+COPY --from=build /app/packages/frontend/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,19 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location /api/ {
+    proxy_pass http://backend:3000/api/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-const API_BASE = '/api';
+const API_BASE = (import.meta.env?.VITE_API_BASE as string | undefined) || '/api';
 
 async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(`${API_BASE}${endpoint}`, {


### PR DESCRIPTION
## Summary
- add Docker build targets for the backend API and the frontend bundle (served by nginx)
- introduce docker-compose orchestration and ignore unnecessary build context files
- allow configuring the frontend API base URL and document Docker deployment steps

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120029399483328da4542af0170e0a)