### PR TITLE
Add Vite environment type definitions for frontend

### DIFF
--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add Vite client type reference to provide ImportMeta typings in the frontend

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ec3175cc83328611e1674bae7639)