### PR TITLE
Use Playwright GitHub Action in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        uses: microsoft/playwright-github-action@v1
       - name: Run system tests
         env:
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173


### PR DESCRIPTION
## Summary
- replace the manual Playwright installation step with microsoft/playwright-github-action@v1 in the tests workflow

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157984ae30833287222fd050535cd6)