### PR TITLE
Authenticate GitHub CLI in frontend preview workflow

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -28,6 +28,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
+      - name: Authenticate GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | gh auth login --with-token
+          gh auth status
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- add GitHub CLI authentication to the NodeJS frontend preview workflow using the GH_AUTH_TOKEN secret

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69293b8ac7fc83329437432e3d66d8b7)