### PR TITLE
Fix GitHub CLI auth token handling in preview workflow

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -30,9 +30,9 @@ jobs:
 
       - name: Authenticate GitHub CLI
         env:
-          GH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
+          GH_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
         run: |
-          echo "$GH_TOKEN" | gh auth login --with-token
+          echo "$GH_AUTH_TOKEN" | gh auth login --with-token
           gh auth status
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- update the NodeJS preview workflow to avoid GH CLI warnings about environment-provided tokens by using a non-reserved env variable

## Testing
- not run (workflow change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a11d2a5248332a60552cde70efaa5)