### PR TITLE
Allow dispatch timeout override for frontend preview

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -9,8 +9,7 @@ on:
     inputs:
       timeout_minutes:
         description: 'Preview timeout in minutes'
-        required: false
-        default: '5'
+        required: true
         type: string
 
 jobs:
@@ -19,7 +18,7 @@ jobs:
     timeout-minutes: 20  # small buffer above 10-minute tunnel lifetime
 
     env:
-      PREVIEW_TIMEOUT_MINUTES: ${{ github.event.inputs.timeout_minutes || '5' }}
+      PREVIEW_TIMEOUT_MINUTES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.timeout_minutes || '5' }}
       NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
 
     steps:


### PR DESCRIPTION
## Summary
- require specifying a preview timeout when manually dispatching the NodeJS preview workflow
- ensure workflow uses the dispatch-provided timeout while keeping the default for pull requests

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ab0931e408332a84dc12b83e90f5b)