### PR TITLE
Remove agent timeout limit

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -42,7 +42,6 @@ def send_agent_message(channel: str, message: str):
             command,
             capture_output=True,
             text=True,
-            timeout=30,  # 30 second timeout
             cwd=working_dir,  # Run in the correct directory
         )
 
@@ -56,8 +55,6 @@ def send_agent_message(channel: str, message: str):
                 else "Command failed with no output"
             )
 
-    except subprocess.TimeoutExpired:
-        response = "Error: Command timed out after 30 seconds"
     except FileNotFoundError:
         response = "Error: 'opencode' command not found. Please ensure it is installed and in PATH."
     except Exception as e:

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -177,7 +177,6 @@ class TestAgentService:
             ["opencode", "run", "Hello agent"],
             capture_output=True,
             text=True,
-            timeout=30,
             cwd=mock_working_dir
         )
         
@@ -210,14 +209,12 @@ class TestAgentService:
             ["opencode", "run", "Hello agent"],
             capture_output=True,
             text=True,
-            timeout=30,
             cwd=mock_working_dir,
         )
         assert mock_subprocess_run.call_args_list[1] == call(
             ["opencode", "run", "-c", "Follow up"],
             capture_output=True,
             text=True,
-            timeout=30,
             cwd=mock_working_dir,
         )
 
@@ -240,31 +237,9 @@ class TestAgentService:
         
         # Test failed command
         result = send_agent_message("test-repo", "Hello agent")
-        
+
         # Verify error response
         assert result["response"] == "Error: Command error"
-
-    @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.run')
-    def test_send_agent_message_timeout(self, mock_subprocess_run, mock_get_working_dir):
-        """Test agent message sending with timeout."""
-        from agent_service import _active_conversations, send_agent_message
-        
-        # Setup mocks
-        mock_working_dir = Path("/test/workspace/repo")
-        mock_get_working_dir.return_value = mock_working_dir
-
-        mock_subprocess_run.side_effect = subprocess.TimeoutExpired(
-            ["opencode", "run", "Hello agent"], 30
-        )
-
-        _active_conversations.clear()
-        
-        # Test timeout
-        result = send_agent_message("test-repo", "Hello agent")
-        
-        # Verify timeout response
-        assert result["response"] == "Error: Command timed out after 30 seconds"
 
     @patch('agent_service._get_working_directory')
     @patch('agent_service.subprocess.run')


### PR DESCRIPTION
## Summary
- allow agent subprocesses to run without a hard 30-second timeout
- update agent service unit tests to reflect the unlimited runtime

## Testing
- PYTHONPATH=packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k send_agent_message


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ace552b788332a2a620e4da123b07)