### PR TITLE
Use MADE_HOME for knowledge and constitution contexts

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from config import get_workspace_home
+from config import get_made_home, get_workspace_home
 
 _active_conversations: set[str] = set()
 
@@ -26,9 +26,10 @@ def _get_working_directory(channel: str) -> Path:
         if repo_path.exists() and repo_path.is_dir():
             return repo_path
 
-    # For knowledge/constitution chats or if repository doesn't exist,
-    # run in the backend directory (current behavior)
-    return Path(__file__).parent
+        return Path(__file__).parent
+
+    # For knowledge/constitution chats, run in the MADE_HOME directory to provide the correct context
+    return get_made_home()
 
 
 def send_agent_message(channel: str, message: str):

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -124,33 +124,33 @@ class TestAgentService:
         # Should fall back to backend directory
         assert result == mock_backend_path.parent
 
-    @patch('agent_service.Path')
-    def test_get_working_directory_knowledge_chat(self, mock_path_class):
+    @patch('agent_service.get_made_home')
+    def test_get_working_directory_knowledge_chat(self, mock_get_made_home):
         """Test working directory selection for knowledge chats."""
         from agent_service import _get_working_directory
-        
-        mock_backend_path = Mock()
-        mock_path_class.return_value = mock_backend_path
-        
+
+        made_home = Path("/test/made/home")
+        mock_get_made_home.return_value = made_home
+
         # Test knowledge chat
         result = _get_working_directory("knowledge:some-artefact")
-        
-        # Should use backend directory (don't check exact path, just that it's the parent)
-        assert result == mock_backend_path.parent
 
-    @patch('agent_service.Path')
-    def test_get_working_directory_constitution_chat(self, mock_path_class):
+        mock_get_made_home.assert_called_once()
+        assert result == made_home
+
+    @patch('agent_service.get_made_home')
+    def test_get_working_directory_constitution_chat(self, mock_get_made_home):
         """Test working directory selection for constitution chats."""
         from agent_service import _get_working_directory
-        
-        mock_backend_path = Mock()
-        mock_path_class.return_value = mock_backend_path
-        
+
+        made_home = Path("/test/made/home")
+        mock_get_made_home.return_value = made_home
+
         # Test constitution chat
         result = _get_working_directory("constitution:some-constitution")
-        
-        # Should use backend directory (don't check exact path, just that it's the parent)
-        assert result == mock_backend_path.parent
+
+        mock_get_made_home.assert_called_once()
+        assert result == made_home
 
     @patch('agent_service._get_working_directory')
     @patch('agent_service.subprocess.run')


### PR DESCRIPTION
## Summary
- run knowledge and constitution agent chats from the MADE_HOME directory
- update agent service tests to reflect the new working directory selection

## Testing
- python -m pytest -o addopts="" tests/unit/test_unit.py::TestAgentService::test_get_working_directory_knowledge_chat tests/unit/test_unit.py::TestAgentService::test_get_working_directory_constitution_chat


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692acf5650b48332a745f92612a11345)