### PR TITLE
Use absolute MADE workspace paths

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -21,8 +21,8 @@ jobs:
     env:
       PREVIEW_TIMEOUT_MINUTES: ${{ github.event.inputs.timeout_minutes || '5' }}
       NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
-      MADE_HOME: workspace/.made
-      MADE_WORKSPACE_HOME: workspace/
+      MADE_HOME: ${{ format('{0}/workspace/.made', github.workspace) }}
+      MADE_WORKSPACE_HOME: ${{ format('{0}/workspace/', github.workspace) }}
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ PORT ?= 3000
 FRONTEND_PORT ?= 5173
 HOST ?= 0.0.0.0
 PYBACKEND_DIR := packages/pybackend
-MADE_HOME ?= workspace/.made
-MADE_WORKSPACE_HOME ?= workspace/
+MADE_HOME ?= $(abspath $(CURDIR)/workspace/.made)
+MADE_WORKSPACE_HOME ?= $(abspath $(CURDIR)/workspace/)
 
 export MADE_HOME
 export MADE_WORKSPACE_HOME


### PR DESCRIPTION
## Summary
- default MADE_HOME and MADE_WORKSPACE_HOME to absolute paths in the Makefile
- set NodeJS preview workflow environment variables to absolute workspace paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ad736d1188332b5de819a6a70b47a)