### PR TITLE
Add tests for knowledge and constitution file creation

### DIFF
--- a/packages/pybackend/tests/unit/test_matter_storage.py
+++ b/packages/pybackend/tests/unit/test_matter_storage.py
@@ -1,0 +1,59 @@
+import frontmatter
+
+
+def test_write_constitution_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("MADE_HOME", str(tmp_path))
+
+    from constitution_service import (
+        get_constitution_directory,
+        read_constitution,
+        write_constitution,
+    )
+
+    name = "governance.md"
+    content = "# Rules\n- Always test"
+    metadata = {"type": "global", "tags": ["policy"]}
+
+    write_constitution(name, metadata, content)
+
+    constitution_dir = get_constitution_directory()
+    file_path = constitution_dir / name
+
+    assert file_path.exists()
+
+    parsed = frontmatter.loads(file_path.read_text(encoding="utf-8"))
+    assert parsed.content == content
+    assert parsed.metadata == metadata
+
+    stored = read_constitution(name)
+    assert stored["content"] == content
+    assert stored["frontmatter"] == metadata
+
+
+def test_write_knowledge_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("MADE_HOME", str(tmp_path))
+
+    from knowledge_service import (
+        get_knowledge_directory,
+        read_knowledge_artefact,
+        write_knowledge_artefact,
+    )
+
+    name = "notes.md"
+    content = "# Notes\nDetails about the system."
+    metadata = {"type": "internal", "tags": ["notes", "docs"]}
+
+    write_knowledge_artefact(name, metadata, content)
+
+    knowledge_dir = get_knowledge_directory()
+    file_path = knowledge_dir / name
+
+    assert file_path.exists()
+
+    parsed = frontmatter.loads(file_path.read_text(encoding="utf-8"))
+    assert parsed.content == content
+    assert parsed.metadata == metadata
+
+    stored = read_knowledge_artefact(name)
+    assert stored["content"] == content
+    assert stored["frontmatter"] == metadata


### PR DESCRIPTION
## Summary
- add unit tests to ensure saving constitutions writes markdown files with metadata
- add unit tests to ensure saving knowledge artefacts writes markdown files with metadata

## Testing
- uv run pytest tests/unit/test_matter_storage.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ad895e58c833288aa44cc29f10c88)