### PR TITLE
Fix default MADE_HOME path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ PORT ?= 3000
 FRONTEND_PORT ?= 5173
 HOST ?= 0.0.0.0
 PYBACKEND_DIR := packages/pybackend
-MADE_HOME ?= $(abspath $(CURDIR)/workspace)
-MADE_WORKSPACE_HOME ?= $(abspath $(CURDIR)/workspace/)
+MADE_HOME ?= $(abspath $(CURDIR))
+MADE_WORKSPACE_HOME ?= $(abspath $(CURDIR))
 
 export MADE_HOME
 export MADE_WORKSPACE_HOME


### PR DESCRIPTION
## Summary
- set MAKEFILE default MADE_HOME to workspace root so .made structure is created correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ad9eef1888332a366b72db47a3ab7)