### PR TITLE
Display MADE paths on dashboard

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -39,6 +39,7 @@ export const api = {
       repositories: RepositorySummary[];
       madeHome: string;
       workspaceHome: string;
+      madeDirectory: string;
     }>("/dashboard"),
   listRepositories: () =>
     request<{ repositories: RepositorySummary[] }>("/repositories"),

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ type DashboardData = {
   agentConnection: boolean;
   madeHome: string;
   workspaceHome: string;
+  madeDirectory: string;
 };
 
 export const DashboardPage: React.FC = () => {
@@ -18,14 +19,15 @@ export const DashboardPage: React.FC = () => {
   useEffect(() => {
     api
       .getDashboard()
-      .then((res) =>
-        setData({
-          projectCount: res.projectCount,
-          agentConnection: res.agentConnection,
-          madeHome: res.madeHome,
-          workspaceHome: res.workspaceHome,
-        }),
-      )
+          .then((res) =>
+            setData({
+              projectCount: res.projectCount,
+              agentConnection: res.agentConnection,
+              madeHome: res.madeHome,
+              workspaceHome: res.workspaceHome,
+              madeDirectory: res.madeDirectory,
+            }),
+          )
       .catch((error) => console.error("Failed to load dashboard", error));
   }, []);
 
@@ -57,6 +59,9 @@ export const DashboardPage: React.FC = () => {
                 </Panel>
                 <Panel title="Workspace Home">
                   <div className="path-info">{data?.workspaceHome ?? "—"}</div>
+                </Panel>
+                <Panel title=".made Folder">
+                  <div className="path-info">{data?.madeDirectory ?? "—"}</div>
                 </Panel>
               </div>
             ),

--- a/packages/pybackend/dashboard_service.py
+++ b/packages/pybackend/dashboard_service.py
@@ -1,5 +1,5 @@
 from repository_service import list_repositories
-from config import get_made_home, get_workspace_home
+from config import get_made_directory, get_made_home, get_workspace_home
 
 
 def get_dashboard_summary():
@@ -8,6 +8,7 @@ def get_dashboard_summary():
         "projectCount": len(repositories),
         "agentConnection": True,
         "repositories": repositories,
-        "madeHome": get_made_home(),
-        "workspaceHome": get_workspace_home(),
+        "madeHome": str(get_made_home()),
+        "workspaceHome": str(get_workspace_home()),
+        "madeDirectory": str(get_made_directory()),
     }


### PR DESCRIPTION
## Summary
- expose MADE_HOME, workspace home, and .made directory paths from the dashboard API
- render the MADE home and .made folder locations on the dashboard alongside workspace information

## Testing
- pytest *(fails: pytest-cov option unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae492a5b883328c3d3a451ddf9f93)