### PR TITLE
Fix agent chat working directories

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from config import get_made_home, get_workspace_home
+from config import ensure_directory, get_made_directory, get_workspace_home
 
 _active_conversations: set[str] = set()
 
@@ -28,8 +28,13 @@ def _get_working_directory(channel: str) -> Path:
 
         return Path(__file__).parent
 
-    # For knowledge/constitution chats, run in the MADE_HOME directory to provide the correct context
-    return get_made_home()
+    made_dir = get_made_directory()
+
+    if channel.startswith("knowledge:"):
+        return ensure_directory(made_dir / "knowledge")
+
+    # For constitution chats, default to the constitutions directory inside .made
+    return ensure_directory(made_dir / "constitutions")
 
 
 def send_agent_message(channel: str, message: str):

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -124,33 +124,41 @@ class TestAgentService:
         # Should fall back to backend directory
         assert result == mock_backend_path.parent
 
-    @patch('agent_service.get_made_home')
-    def test_get_working_directory_knowledge_chat(self, mock_get_made_home):
+    @patch('agent_service.ensure_directory')
+    @patch('agent_service.get_made_directory')
+    def test_get_working_directory_knowledge_chat(self, mock_get_made_directory, mock_ensure_directory):
         """Test working directory selection for knowledge chats."""
         from agent_service import _get_working_directory
 
-        made_home = Path("/test/made/home")
-        mock_get_made_home.return_value = made_home
+        made_dir = Path("/test/made/home/.made")
+        knowledge_dir = made_dir / "knowledge"
+        mock_get_made_directory.return_value = made_dir
+        mock_ensure_directory.return_value = knowledge_dir
 
         # Test knowledge chat
         result = _get_working_directory("knowledge:some-artefact")
 
-        mock_get_made_home.assert_called_once()
-        assert result == made_home
+        mock_get_made_directory.assert_called_once()
+        mock_ensure_directory.assert_called_once_with(knowledge_dir)
+        assert result == knowledge_dir
 
-    @patch('agent_service.get_made_home')
-    def test_get_working_directory_constitution_chat(self, mock_get_made_home):
+    @patch('agent_service.ensure_directory')
+    @patch('agent_service.get_made_directory')
+    def test_get_working_directory_constitution_chat(self, mock_get_made_directory, mock_ensure_directory):
         """Test working directory selection for constitution chats."""
         from agent_service import _get_working_directory
 
-        made_home = Path("/test/made/home")
-        mock_get_made_home.return_value = made_home
+        made_dir = Path("/test/made/home/.made")
+        const_dir = made_dir / "constitutions"
+        mock_get_made_directory.return_value = made_dir
+        mock_ensure_directory.return_value = const_dir
 
         # Test constitution chat
         result = _get_working_directory("constitution:some-constitution")
 
-        mock_get_made_home.assert_called_once()
-        assert result == made_home
+        mock_get_made_directory.assert_called_once()
+        mock_ensure_directory.assert_called_once_with(const_dir)
+        assert result == const_dir
 
     @patch('agent_service._get_working_directory')
     @patch('agent_service.subprocess.run')


### PR DESCRIPTION
## Summary
- route knowledge and constitution agent chats to their respective .made subdirectories
- ensure working directories are created before use
- update unit tests for knowledge and constitution chat paths

## Testing
- python -m pytest tests/unit/test_unit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae8431d04833295151915855f6b5b)