### PR TITLE
Improve tab layout responsiveness on mobile

### DIFF
--- a/packages/frontend/src/styles/tabview.css
+++ b/packages/frontend/src/styles/tabview.css
@@ -33,3 +33,19 @@
   flex-direction: column;
   gap: 1.5rem;
 }
+
+@media (max-width: 640px) {
+  .tabview-tabs {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    border-radius: 1rem;
+  }
+
+  .tabview-tab {
+    width: 100%;
+    text-align: center;
+    border-radius: 0.8rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive styling to stack tab buttons vertically on small screens
- ensure mobile tab controls span full width for easier tapping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945519a1b488332b1a362e5014e8bbb)