### PR TITLE
Improve panel spacing on mobile

### DIFF
--- a/packages/frontend/src/styles/layout.css
+++ b/packages/frontend/src/styles/layout.css
@@ -33,3 +33,9 @@
       "content";
   }
 }
+
+@media (max-width: 640px) {
+  .app-content {
+    padding: 1.25rem;
+  }
+}

--- a/packages/frontend/src/styles/panel.css
+++ b/packages/frontend/src/styles/panel.css
@@ -64,3 +64,19 @@
   flex-direction: column;
   gap: 1rem;
 }
+
+@media (max-width: 640px) {
+  .panel {
+    padding: 1.1rem;
+    border-radius: 1.1rem;
+    gap: 0.9rem;
+  }
+
+  .panel-header h3 {
+    font-size: 1rem;
+  }
+
+  .panel-body {
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- reduce panel padding, radius, and spacing on small screens to keep more content visible
- tighten overall content padding on narrow viewports for a less cramped mobile layout

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945541e17988332820f5058086f46b5)