### PR TITLE
Adjust mobile panel spacing for improved content area

### DIFF
--- a/packages/frontend/src/styles/layout.css
+++ b/packages/frontend/src/styles/layout.css
@@ -36,6 +36,6 @@
 
 @media (max-width: 640px) {
   .app-content {
-    padding: 1.25rem;
+    padding: 0.9rem;
   }
 }

--- a/packages/frontend/src/styles/panel.css
+++ b/packages/frontend/src/styles/panel.css
@@ -67,16 +67,16 @@
 
 @media (max-width: 640px) {
   .panel {
-    padding: 1.1rem;
-    border-radius: 1.1rem;
-    gap: 0.9rem;
+    padding: 0.85rem;
+    border-radius: 0.95rem;
+    gap: 0.7rem;
   }
 
   .panel-header h3 {
-    font-size: 1rem;
+    font-size: 0.95rem;
   }
 
   .panel-body {
-    gap: 0.75rem;
+    gap: 0.65rem;
   }
 }


### PR DESCRIPTION
## Summary
- reduce panel padding, radius, and gaps on small screens to allow more content
- shrink mobile app content padding for tighter layout on phones

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455ec0c4c88332827d7de3c90e37a8)