### PR TITLE
Adjust mobile chat panel spacing

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -328,3 +328,41 @@ textarea {
     transform: rotate(360deg);
   }
 }
+
+@media (max-width: 640px) {
+  input,
+  textarea,
+  select {
+    padding: 0.65rem;
+    border-radius: 0.8rem;
+  }
+
+  textarea {
+    min-height: 120px;
+  }
+
+  .markdown {
+    padding: 1rem;
+    border-radius: 0.95rem;
+  }
+
+  .chat-window {
+    padding: 0.75rem;
+    gap: 0.75rem;
+    border-radius: 0.9rem;
+  }
+
+  .chat-message {
+    padding: 0.65rem 0.85rem;
+    border-radius: 0.8rem;
+  }
+
+  .chat-meta {
+    margin-bottom: 0.35rem;
+  }
+
+  .button-bar {
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+}

--- a/packages/frontend/src/styles/panel.css
+++ b/packages/frontend/src/styles/panel.css
@@ -67,9 +67,9 @@
 
 @media (max-width: 640px) {
   .panel {
-    padding: 0.85rem;
+    padding: 0.75rem;
     border-radius: 0.95rem;
-    gap: 0.7rem;
+    gap: 0.6rem;
   }
 
   .panel-header h3 {


### PR DESCRIPTION
## Summary
- reduce panel padding and gaps on small screens to reclaim space
- tighten chat-related element spacing for better mobile content fit

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945642519948332ba9c8a1be4480b7c)