### PR TITLE
Persist agent chat history locally

### DIFF
--- a/packages/frontend/src/hooks/usePersistentChat.ts
+++ b/packages/frontend/src/hooks/usePersistentChat.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { ChatMessage } from "../types/chat";
+
+const EMPTY_CHAT: ChatMessage[] = [];
+
+const parseChat = (
+  storageKey: string | undefined,
+  fallback: ChatMessage[]
+): ChatMessage[] => {
+  if (!storageKey) return fallback;
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        return parsed as ChatMessage[];
+      }
+    }
+  } catch (error) {
+    console.warn("Failed to read chat history from localStorage", error);
+  }
+  return fallback;
+};
+
+export const usePersistentChat = (
+  storageKey: string | undefined,
+  fallback: ChatMessage[] = EMPTY_CHAT
+) => {
+  const [chat, setChat] = useState<ChatMessage[]>(() =>
+    parseChat(storageKey, fallback)
+  );
+
+  useEffect(() => {
+    setChat(parseChat(storageKey, fallback));
+  }, [storageKey, fallback]);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    localStorage.setItem(storageKey, JSON.stringify(chat));
+  }, [chat, storageKey]);
+
+  return [chat, setChat] as const;
+};

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -1,17 +1,12 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
+import { usePersistentChat } from "../hooks/usePersistentChat";
 import { api } from "../hooks/useApi";
+import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
-
-interface ChatMessage {
-  id: string;
-  role: "user" | "agent";
-  text: string;
-  timestamp: string;
-}
 
 export const ConstitutionPage: React.FC = () => {
   const { name } = useParams();
@@ -19,7 +14,11 @@ export const ConstitutionPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
-  const [chat, setChat] = useState<ChatMessage[]>([]);
+  const chatStorageKey = useMemo(
+    () => (name ? `constitution-chat-${name}` : "constitution-chat"),
+    [name]
+  );
+  const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [chatLoading, setChatLoading] = useState(false);

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -1,17 +1,12 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
+import { usePersistentChat } from "../hooks/usePersistentChat";
 import { api } from "../hooks/useApi";
+import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
-
-interface ChatMessage {
-  id: string;
-  role: "user" | "agent";
-  text: string;
-  timestamp: string;
-}
 
 export const KnowledgeArtefactPage: React.FC = () => {
   const { name } = useParams();
@@ -19,7 +14,11 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
-  const [chat, setChat] = useState<ChatMessage[]>([]);
+  const chatStorageKey = useMemo(
+    () => (name ? `knowledge-chat-${name}` : "knowledge-chat"),
+    [name]
+  );
+  const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [chatLoading, setChatLoading] = useState(false);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1,18 +1,13 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { Modal } from "../components/Modal";
+import { usePersistentChat } from "../hooks/usePersistentChat";
 import { api, FileNode, RepositorySummary } from "../hooks/useApi";
+import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
-
-interface ChatMessage {
-  id: string;
-  role: "user" | "agent";
-  text: string;
-  timestamp: string;
-}
 
 const PUBLISHMENT_ACTIONS = [
   {
@@ -54,7 +49,11 @@ export const RepositoryPage: React.FC = () => {
   const [repository, setRepository] = useState<RepositorySummary | null>(null);
   const [fileTree, setFileTree] = useState<FileNode | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(["."]));
-  const [chat, setChat] = useState<ChatMessage[]>([]);
+  const chatStorageKey = useMemo(
+    () => (name ? `repository-chat-${name}` : "repository-chat"),
+    [name]
+  );
+  const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [pendingPrompt, setPendingPrompt] = useState("");
   const [chatError, setChatError] = useState<string | null>(null);
   const [chatLoading, setChatLoading] = useState(false);

--- a/packages/frontend/src/types/chat.ts
+++ b/packages/frontend/src/types/chat.ts
@@ -1,0 +1,6 @@
+export interface ChatMessage {
+  id: string;
+  role: "user" | "agent";
+  text: string;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
- add a reusable chat message type and hook for persisting agent conversations in localStorage
- persist chat history across repository, knowledge artefact, and constitution agent tabs

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458d9c211c83328afaa91610fc461f)