### PR TITLE
Add repository cloning flow

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -48,6 +48,11 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ name }),
     }),
+  cloneRepository: (url: string) =>
+    request<RepositorySummary>("/repositories/clone", {
+      method: "POST",
+      body: JSON.stringify({ url }),
+    }),
   getRepository: (name: string) =>
     request<RepositorySummary>(`/repositories/${name}`),
   getRepositoryFiles: (name: string) =>

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -16,6 +16,7 @@ from knowledge_service import (
 from repository_service import (
     create_repository,
     create_repository_file,
+    clone_repository,
     delete_repository_file,
     get_repository_info,
     list_repositories,
@@ -82,6 +83,20 @@ def create_repo(payload: dict = Body(...)):
         )
     try:
         return create_repository(name)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@app.post("/api/repositories/clone", status_code=status.HTTP_201_CREATED)
+def clone_repo(payload: dict = Body(...)):
+    repo_url = payload.get("url")
+    if not repo_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Repository URL is required",
+        )
+    try:
+        return clone_repository(repo_url)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 

--- a/packages/pybackend/tests/system/test_system.py
+++ b/packages/pybackend/tests/system/test_system.py
@@ -108,9 +108,23 @@ class TestServiceIntegration:
         
         for response in responses:
             assert response.status_code == 200
-            
+
         # Verify all services were called
         mock_repositories.assert_called_once()
         mock_knowledge.assert_called_once()
         mock_constitutions.assert_called_once()
         mock_dashboard.assert_called_once()
+
+    @patch('app.clone_repository')
+    def test_clone_repository_endpoint(self, mock_clone_repository):
+        """Test the clone repository endpoint wiring."""
+        mock_clone_repository.return_value = {"name": "cloned"}
+
+        response = client.post(
+            "/api/repositories/clone",
+            json={"url": "https://example.com/repo.git"},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["name"] == "cloned"
+        mock_clone_repository.assert_called_once_with("https://example.com/repo.git")

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -1,0 +1,94 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from repository_service import clone_repository
+
+
+def _init_local_repo(repo_path: Path) -> None:
+    repo_path.mkdir(parents=True)
+    subprocess.check_call(
+        ["git", "init"],
+        cwd=repo_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    (repo_path / "README.md").write_text("hello", encoding="utf-8")
+    subprocess.check_call(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.check_call(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.check_call(
+        ["git", "add", "README.md"],
+        cwd=repo_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.check_call(
+        ["git", "commit", "-m", "init"],
+        cwd=repo_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_clone_repository_from_local_source(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source_repo = tmp_path / "source_repo"
+    _init_local_repo(source_repo)
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+
+    result = clone_repository(str(source_repo))
+
+    cloned_repo = workspace / "source_repo"
+    assert cloned_repo.exists()
+    assert result["name"] == "source_repo"
+    assert result["hasGit"] is True
+
+
+def test_clone_repository_existing_target(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "existing").mkdir()
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+
+    with pytest.raises(ValueError, match="Repository already exists"):
+        clone_repository("https://example.com/existing.git")
+
+
+def test_clone_repository_requires_url(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+
+    with pytest.raises(ValueError, match="Repository URL is required"):
+        clone_repository("")
+
+
+def test_clone_repository_handles_failure(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    monkeypatch.setattr(
+        "repository_service.subprocess.check_call",
+        lambda *_, **__: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(1, "git clone")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Failed to clone repository"):
+        clone_repository("https://example.com/sample.git")


### PR DESCRIPTION
## Summary
- add a clone repository flow in the frontend with a modal, validation, and feedback messages
- expose a backend endpoint to clone repositories into the workspace and reuse from the UI API layer
- cover the clone workflow with new backend unit and system tests

## Testing
- uv run pytest tests/unit -v
- uv run pytest tests/system -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b18b2bc883329b6bcfbe0eedcfc8)