### PR TITLE
Add chat processing locks and surface status in UI

### DIFF
--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
@@ -21,6 +27,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
+  const [agentStatus, setAgentStatus] = useState<string | null>(null);
   const [chatLoading, setChatLoading] = useState(false);
   const chatWindowRef = useRef<HTMLDivElement>(null);
 
@@ -46,10 +53,29 @@ export const KnowledgeArtefactPage: React.FC = () => {
         setContent(data.content ?? "");
       })
       .catch((error) => {
-        console.error("Failed to load artefact", error);
-        setStatus("Failed to load artefact");
-      });
+      console.error("Failed to load artefact", error);
+      setStatus("Failed to load artefact");
+    });
   }, [name, navigate]);
+
+  const refreshAgentStatus = useCallback(async () => {
+    if (!name) return false;
+    try {
+      const status = await api.getKnowledgeAgentStatus(name);
+      setChatLoading(status.processing);
+      setAgentStatus(
+        status.processing ? "Agent is still processing the previous message." : null,
+      );
+      return status.processing;
+    } catch (error) {
+      console.error("Failed to load agent status", error);
+      return false;
+    }
+  }, [name]);
+
+  useEffect(() => {
+    refreshAgentStatus();
+  }, [refreshAgentStatus]);
 
   const handleSave = async () => {
     if (!name) return;
@@ -86,11 +112,19 @@ export const KnowledgeArtefactPage: React.FC = () => {
         },
       ]);
       setActiveTab("agent");
+      setAgentStatus(null);
+      setChatLoading(false);
     } catch (error) {
       console.error("Failed to contact agent", error);
-      setStatus("Agent unavailable");
-    } finally {
-      setChatLoading(false);
+      const message = error instanceof Error ? error.message : "";
+      const busy = message.toLowerCase().includes("processing");
+      setAgentStatus(
+        busy ? "Agent is still processing the previous message." : "Agent unavailable",
+      );
+      const processing = await refreshAgentStatus();
+      if (!processing) {
+        setChatLoading(false);
+      }
     }
   };
 
@@ -212,6 +246,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
                     </div>
                   )}
                 </div>
+                {agentStatus && <div className="alert">{agentStatus}</div>}
                 <textarea
                   value={prompt}
                   onChange={(event) => setPrompt(event.target.value)}

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -1,7 +1,7 @@
 from fastapi import Body, FastAPI, HTTPException, Query, status
 from fastapi.middleware.cors import CORSMiddleware
 
-from agent_service import send_agent_message
+from agent_service import ChannelBusyError, get_channel_status, send_agent_message
 from constitution_service import (
     list_constitutions,
     read_constitution,
@@ -195,7 +195,15 @@ def repository_agent(name: str, payload: dict = Body(...)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
-    return send_agent_message(name, message)
+    try:
+        return send_agent_message(name, message)
+    except ChannelBusyError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+
+
+@app.get("/api/repositories/{name}/agent/status")
+def repository_agent_status(name: str):
+    return get_channel_status(name)
 
 
 @app.get("/api/knowledge")
@@ -234,7 +242,15 @@ def knowledge_agent(name: str, payload: dict = Body(...)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
-    return send_agent_message(f"knowledge:{name}", message)
+    try:
+        return send_agent_message(f"knowledge:{name}", message)
+    except ChannelBusyError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+
+
+@app.get("/api/knowledge/{name}/agent/status")
+def knowledge_agent_status(name: str):
+    return get_channel_status(f"knowledge:{name}")
 
 
 @app.get("/api/constitutions")
@@ -273,7 +289,15 @@ def constitution_agent(name: str, payload: dict = Body(...)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
-    return send_agent_message(f"constitution:{name}", message)
+    try:
+        return send_agent_message(f"constitution:{name}", message)
+    except ChannelBusyError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+
+
+@app.get("/api/constitutions/{name}/agent/status")
+def constitution_agent_status(name: str):
+    return get_channel_status(f"constitution:{name}")
 
 
 @app.get("/api/settings")


### PR DESCRIPTION
## Summary
- add server-side per-chat processing locks and expose status endpoints for repositories, knowledge, and constitutions
- update front-end chats to read processing status on load, handle 409 busy errors, and show user-facing warnings
- improve API error parsing so chat errors reflect backend messages

## Testing
- uv run pytest tests/unit/test_api.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b10200848332b58b7504dfff7711)