### PR TITLE
Add disabled button color

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -68,6 +68,14 @@ button {
   cursor: pointer;
 }
 
+button:disabled {
+  background: #2f3447;
+  color: #c3c8d4;
+  cursor: not-allowed;
+  box-shadow: none;
+  border: 1px solid transparent;
+}
+
 input,
 textarea,
 select {


### PR DESCRIPTION
## Summary
- add consistent disabled button styling to match agent chat send button mock
- apply accessible cursor and shadow updates for deactivated states

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694710ee7bfc8332a18799215d42c4d0)