### PR TITLE
Use emojis for file action buttons

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -312,7 +312,7 @@ export const RepositoryPage: React.FC = () => {
                 className="link-button"
                 onClick={() => openFile(node.path)}
               >
-                Edit
+                📝
               </button>
             )}
             <button
@@ -322,7 +322,7 @@ export const RepositoryPage: React.FC = () => {
                 setRenameModal({ open: true, from: node.path });
               }}
             >
-              Rename
+              🏷️
             </button>
             <button
               className="link-button"
@@ -331,13 +331,13 @@ export const RepositoryPage: React.FC = () => {
                 setMoveModal({ open: true, from: node.path });
               }}
             >
-              Move
+              ↔️
             </button>
             <button
               className="link-button"
               onClick={() => setDeleteModal({ open: true, target: node.path })}
             >
-              Delete
+              🗑
             </button>
           </div>
         </div>

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -104,6 +104,7 @@
 .file-actions {
   display: flex;
   gap: 0.5rem;
+  margin-left: auto;
 }
 
 .editor-grid,


### PR DESCRIPTION
## Summary
- replace file action labels in the repository browser with compact emoji icons
- align file action controls to the right side of each file row for consistent layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947dc070bc08332a57f6678f930fec8)