### PR TITLE
Fix file tree icon visibility

### DIFF
--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -107,6 +107,7 @@
   width: 20px;
   height: 20px;
   display: block;
+  fill: currentColor;
 }
 
 .file-name {


### PR DESCRIPTION
## Summary
- ensure repository file and folder icons inherit the current text color so they are visible

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e05365e88332904311fe79a3432b)