### PR TITLE
Make opencode check non-blocking in NodeJS workflow

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -165,6 +165,7 @@ jobs:
 
       - name: Run opencode success check
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
+        continue-on-error: true
         run: "opencode run 'Say: ✅ SUCCESS!'"
       
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- allow the opencode success check step in the NodeJS frontend preview workflow to continue on error so it no longer fails the workflow when it fails

## Testing
- not run (CI workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e2e044808332b6209c3133cbe93a)