### PR TITLE
Fix alignment of file browser rows

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -317,7 +317,7 @@ export const RepositoryPage: React.FC = () => {
         <div className="file-row">
           {isFolder ? (
             <button
-              className="icon-button"
+              className="icon-button file-toggle"
               onClick={() => toggleFolder(node.path)}
             >
               {isExpanded ? "▾" : "▸"}

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -82,7 +82,8 @@
 }
 
 .file-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
   padding: 0.35rem 0.5rem;
@@ -95,8 +96,10 @@
   background: rgba(148, 163, 184, 0.12);
 }
 
+.file-toggle,
 .file-spacer {
-  width: 24px;
+  width: 28px;
+  height: 28px;
 }
 
 .file-icon {
@@ -114,7 +117,7 @@
 }
 
 .file-name {
-  flex: 1;
+  min-width: 0;
   cursor: pointer;
 }
 
@@ -123,6 +126,7 @@
   gap: 0.4rem;
   margin-left: auto;
   align-items: center;
+  justify-self: end;
 }
 
 .editor-grid,


### PR DESCRIPTION
## Summary
- use a grid layout for file browser rows to align names and actions
- size the file toggle control and spacer consistently for folder/file entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e91765b88332a29c3a246f3dbe8e)