### PR TITLE
Use argument hint for repository command inputs

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -763,7 +763,9 @@ export const RepositoryPage: React.FC = () => {
                 onChange={(event) =>
                   handleCommandValueChange(index, event.target.value)
                 }
-                placeholder={`Value for ${label}`}
+                placeholder={
+                  commandModal.command?.argumentHint || `Value for ${label}`
+                }
               />
             </div>
           ))


### PR DESCRIPTION
## Summary
- use command metadata argument hints as input placeholders in the repository command modal
- preserve existing fallback placeholder text when no hint is provided

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694870d0a30883329dd619db0991e1ee)