### PR TITLE
Add optional folder name to repository cloning

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -108,10 +108,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ name }),
     }),
-  cloneRepository: (url: string) =>
+  cloneRepository: (url: string, name?: string) =>
     request<RepositorySummary>("/repositories/clone", {
       method: "POST",
-      body: JSON.stringify({ url }),
+      body: JSON.stringify({ url, name }),
     }),
   getRepository: (name: string) =>
     request<RepositorySummary>(`/repositories/${name}`),

--- a/packages/frontend/src/pages/RepositoriesPage.tsx
+++ b/packages/frontend/src/pages/RepositoriesPage.tsx
@@ -12,6 +12,7 @@ export const RepositoriesPage: React.FC = () => {
   const [cloneOpen, setCloneOpen] = useState(false);
   const [newRepoName, setNewRepoName] = useState("");
   const [cloneUrl, setCloneUrl] = useState("");
+  const [cloneName, setCloneName] = useState("");
   const [isCloning, setIsCloning] = useState(false);
   const [alert, setAlert] = useState<{
     type: "success" | "error";
@@ -53,6 +54,7 @@ export const RepositoriesPage: React.FC = () => {
 
   const handleClone = async () => {
     const trimmedUrl = cloneUrl.trim();
+    const trimmedName = cloneName.trim();
     if (!trimmedUrl) {
       setAlert({ type: "error", message: "Repository URL cannot be empty" });
       setCloneOpen(false);
@@ -60,10 +62,11 @@ export const RepositoriesPage: React.FC = () => {
     }
     setIsCloning(true);
     try {
-      await api.cloneRepository(trimmedUrl);
+      await api.cloneRepository(trimmedUrl, trimmedName || undefined);
       setAlert({ type: "success", message: "Repository cloned successfully" });
       setCloneOpen(false);
       setCloneUrl("");
+      setCloneName("");
       loadRepositories();
     } catch (e) {
       setCloneOpen(false);
@@ -175,6 +178,15 @@ export const RepositoriesPage: React.FC = () => {
             value={cloneUrl}
             onChange={(event) => setCloneUrl(event.target.value)}
             placeholder="https://github.com/owner/repo.git"
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="repository-name-clone">Folder Name (optional)</label>
+          <input
+            id="repository-name-clone"
+            value={cloneName}
+            onChange={(event) => setCloneName(event.target.value)}
+            placeholder="custom-folder-name"
           />
         </div>
         <div className="modal-actions">

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -91,13 +91,14 @@ def create_repo(payload: dict = Body(...)):
 @app.post("/api/repositories/clone", status_code=status.HTTP_201_CREATED)
 def clone_repo(payload: dict = Body(...)):
     repo_url = payload.get("url")
+    target_name = payload.get("name")
     if not repo_url:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Repository URL is required",
         )
     try:
-        return clone_repository(repo_url)
+        return clone_repository(repo_url, target_name)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 

--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -145,8 +145,12 @@ def create_repository(name: str) -> Dict[str, Union[str, bool, None]]:
     return get_repository_info(name)
 
 
-def clone_repository(repo_url: str) -> Dict[str, Union[str, bool, None]]:
-    repo_name = _extract_repo_name(repo_url)
+def clone_repository(
+    repo_url: str, target_name: str | None = None
+) -> Dict[str, Union[str, bool, None]]:
+    repo_name = target_name.strip() if target_name else None
+    if not repo_name:
+        repo_name = _extract_repo_name(repo_url)
     workspace = get_workspace_home()
     workspace.mkdir(parents=True, exist_ok=True)
     target_path = workspace / repo_name
@@ -156,7 +160,7 @@ def clone_repository(repo_url: str) -> Dict[str, Union[str, bool, None]]:
 
     try:
         subprocess.check_call(
-            ["git", "clone", repo_url],
+            ["git", "clone", repo_url, repo_name],
             cwd=str(workspace),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/packages/pybackend/tests/system/test_system.py
+++ b/packages/pybackend/tests/system/test_system.py
@@ -122,12 +122,14 @@ class TestServiceIntegration:
 
         response = client.post(
             "/api/repositories/clone",
-            json={"url": "https://example.com/repo.git"},
+            json={"url": "https://example.com/repo.git", "name": "custom"},
         )
 
         assert response.status_code == 201
         assert response.json()["name"] == "cloned"
-        mock_clone_repository.assert_called_once_with("https://example.com/repo.git")
+        mock_clone_repository.assert_called_once_with(
+            "https://example.com/repo.git", "custom"
+        )
 
 
 @patch('app.list_commands')

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -117,11 +117,11 @@ class TestRepositoryEndpoints:
 
         response = client.post(
             "/api/repositories/clone",
-            json={"url": "https://example.com/cloned.git"},
+            json={"url": "https://example.com/cloned.git", "name": "custom"},
         )
 
         assert response.status_code == 201
-        mock_clone.assert_called_once_with("https://example.com/cloned.git")
+        mock_clone.assert_called_once_with("https://example.com/cloned.git", "custom")
 
     def test_clone_repository_missing_url(self):
         """Test cloning without providing URL."""

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -49,12 +49,27 @@ def test_clone_repository_from_local_source(monkeypatch, tmp_path):
 
     monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
 
-    result = clone_repository(str(source_repo))
+    result = clone_repository(str(source_repo), "custom-name")
+
+    cloned_repo = workspace / "custom-name"
+    assert cloned_repo.exists()
+    assert result["name"] == "custom-name"
+    assert result["hasGit"] is True
+
+
+def test_clone_repository_ignores_empty_target(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source_repo = tmp_path / "source_repo"
+    _init_local_repo(source_repo)
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+
+    result = clone_repository(str(source_repo), " ")
 
     cloned_repo = workspace / "source_repo"
     assert cloned_repo.exists()
     assert result["name"] == "source_repo"
-    assert result["hasGit"] is True
 
 
 def test_clone_repository_existing_target(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- allow specifying a target folder name when cloning repositories on the backend
- expose the optional clone name through the API client and Clone Repository modal
- extend tests to cover custom clone names and fallback behavior

## Testing
- pytest -o addopts= -p no:cov tests/unit *(fails: missing dependencies such as fastapi and frontmatter as configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949013928c883328194744b45eface6)