### PR TITLE
Disable enter key sending in chat inputs

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -232,14 +232,6 @@ export const ConstitutionPage: React.FC = () => {
                 <textarea
                   value={prompt}
                   onChange={(event) => setPrompt(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" && !event.shiftKey) {
-                      event.preventDefault();
-                      if (!chatLoading && prompt.trim()) {
-                        handleSend();
-                      }
-                    }
-                  }}
                   placeholder="Ask the agent to update governance rules..."
                 />
                 <div className="button-bar">

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -250,14 +250,6 @@ export const KnowledgeArtefactPage: React.FC = () => {
                 <textarea
                   value={prompt}
                   onChange={(event) => setPrompt(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" && !event.shiftKey) {
-                      event.preventDefault();
-                      if (!chatLoading && prompt.trim()) {
-                        handleSend();
-                      }
-                    }
-                  }}
                   placeholder="Ask the agent about this artefact..."
                 />
                 <div className="button-bar">

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -552,14 +552,6 @@ export const RepositoryPage: React.FC = () => {
           <textarea
             value={pendingPrompt}
             onChange={(event) => setPendingPrompt(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                if (!chatLoading && pendingPrompt.trim()) {
-                  handleSendMessage();
-                }
-              }
-            }}
             placeholder="Describe the change or ask the agent..."
           />
           <div className="button-bar">


### PR DESCRIPTION
## Summary
- allow chat textareas to use Enter for line breaks instead of sending
- require the Send button to submit messages across chat pages

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949343c5de0833286e2055aa2e9f765)