### PR TITLE
Handle non-string argument hints in repository commands

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -88,7 +88,7 @@ export type CommandDefinition = {
   source: string;
   content: string;
   metadata?: Record<string, unknown>;
-  argumentHint?: string;
+  argumentHint?: string | string[] | null;
 };
 
 export const api = {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -29,21 +29,34 @@ const stripCommandFrontmatter = (content: string) => {
 
 const ARGUMENT_SPECIFIER_PATTERN = /\[([^\]]+)\]|<([^>]+)>/g;
 
-const extractArgumentLabels = (argumentHint?: string | null) =>
-  argumentHint
-    ? Array.from(argumentHint.matchAll(ARGUMENT_SPECIFIER_PATTERN))
+type ArgumentHint = string | string[] | null | undefined;
+
+const normalizeArgumentHint = (argumentHint: ArgumentHint) => {
+  if (!argumentHint) return "";
+  if (Array.isArray(argumentHint)) {
+    return argumentHint.filter((value) => typeof value === "string").join(" ");
+  }
+  return typeof argumentHint === "string" ? argumentHint : "";
+};
+
+const extractArgumentLabels = (argumentHint?: ArgumentHint) => {
+  const normalizedHint = normalizeArgumentHint(argumentHint);
+  return normalizedHint
+    ? Array.from(normalizedHint.matchAll(ARGUMENT_SPECIFIER_PATTERN))
         .map((match) => (match[1] || match[2] || "").trim())
         .filter(Boolean)
     : [];
+};
 
-const formatArgumentHint = (argumentHint?: string | null) => {
-  if (!argumentHint) return "";
-  const labels = extractArgumentLabels(argumentHint);
+const formatArgumentHint = (argumentHint?: ArgumentHint) => {
+  const normalizedHint = normalizeArgumentHint(argumentHint);
+  if (!normalizedHint) return "";
+  const labels = extractArgumentLabels(normalizedHint);
   if (labels.length) {
     return labels.join(" ");
   }
 
-  return argumentHint.trim();
+  return normalizedHint.trim();
 };
 
 const COMMAND_ACTIONS = [


### PR DESCRIPTION
## Summary
- normalize command argument hints so non-string values no longer break repository pages
- allow repository command argument hints to be provided as arrays or null when building hints

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952de4a34e48332a74cccfc58d43586)