### PR TITLE
Hide command argument hints

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -739,30 +739,18 @@ export const RepositoryPage: React.FC = () => {
                   </div>
                 ) : (
                   <div className="commands-grid">
-                    {availableCommands.map((command) => {
-                      const displayArgumentHint = formatArgumentHint(
-                        command.argumentHint,
-                      );
-                      return (
-                        <button
-                          key={command.id}
-                          className="primary command-button"
-                          title={`${command.source} • ${command.name}${
-                            displayArgumentHint ? ` • ${displayArgumentHint}` : ""
-                          }`}
-                          onClick={() => handleCommandSelection(command)}
-                        >
-                          <span className="command-button__title">
-                            {command.description || command.name}
-                          </span>
-                          {displayArgumentHint && (
-                            <span className="command-hint">
-                              {displayArgumentHint}
-                            </span>
-                          )}
-                        </button>
-                      );
-                    })}
+                    {availableCommands.map((command) => (
+                      <button
+                        key={command.id}
+                        className="primary command-button"
+                        title={`${command.source} • ${command.name}`}
+                        onClick={() => handleCommandSelection(command)}
+                      >
+                        <span className="command-button__title">
+                          {command.description || command.name}
+                        </span>
+                      </button>
+                    ))}
                   </div>
                 )}
               </>

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -187,8 +187,3 @@
 .command-button__title {
   font-weight: 600;
 }
-
-.command-hint {
-  font-size: 0.85rem;
-  color: #2d6cdf;
-}


### PR DESCRIPTION
## Summary
- remove argument hint text from user command buttons
- clean up unused command hint styling

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e0de2ef88332bc4fb6d6566078ce)