### PR TITLE
Handle tool use output parsing

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -85,13 +85,17 @@ def _parse_opencode_output(stdout: str) -> tuple[str | None, str | None]:
 
         session_id = session_id or payload.get("sessionID")
 
-        if payload.get("type") != "text":
-            continue
-
+        payload_type = payload.get("type")
         part = payload.get("part") or {}
-        text = part.get("text")
-        if text:
-            text_parts.append(text)
+
+        if payload_type == "text":
+            text = part.get("text")
+            if text:
+                text_parts.append(text)
+        elif payload_type == "tool_use":
+            tool_name = part.get("tool")
+            if tool_name:
+                text_parts.append(f"🛠️ {tool_name}")
 
     if not text_parts:
         return session_id, None


### PR DESCRIPTION
## Summary
- include tool_use events when parsing opencode output, emitting the tool emoji and name
- add unit coverage to verify tool_use responses are returned to callers

## Testing
- uv run pytest tests/unit/test_unit.py::TestAgentService::test_send_agent_message_includes_tool_use

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e553dc808332b693898ce88a0105)