### PR TITLE
Fix agent message formatting and timestamps

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -102,6 +102,7 @@ def _parse_opencode_output(stdout: str) -> tuple[str | None, str | None]:
 
     display_parts: list[str] = []
     text_indices = [index for index, (kind, _) in enumerate(parts) if kind == "text"]
+    joiner = "\n\n"
 
     for index, (kind, content) in enumerate(parts):
         if kind == "text":
@@ -110,7 +111,7 @@ def _parse_opencode_output(stdout: str) -> tuple[str | None, str | None]:
         else:
             display_parts.append(content)
 
-    return session_id, "\n".join(display_parts)
+    return session_id, joiner.join(display_parts)
 
 
 def send_agent_message(channel: str, message: str):
@@ -150,9 +151,11 @@ def send_agent_message(channel: str, message: str):
     finally:
         _clear_channel_processing(channel)
 
+    sent_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
     return {
         "messageId": str(int(time.time() * 1000)),
-        "sent": datetime.now(UTC).isoformat() + "Z",
+        "sent": sent_at,
         "prompt": message,
         "response": response,
         "sessionId": _conversation_sessions.get(channel),

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -191,6 +191,9 @@ class TestAgentService:
         # Verify response structure
         assert "messageId" in result
         assert "sent" in result
+        assert result["sent"].endswith("Z")
+        # Ensure the timestamp can be parsed when converted to ISO format with offset
+        datetime.fromisoformat(result["sent"].replace("Z", "+00:00"))
         assert result["prompt"] == "Hello agent"
         assert result["response"] == "Agent response content"
 
@@ -250,7 +253,7 @@ class TestAgentService:
 
         result = send_agent_message("test-repo", "Hello agent")
 
-        assert result["response"] == "🧠 First line\n🎯 Second line"
+        assert result["response"] == "🧠 First line\n\n🎯 Second line"
         assert result["sessionId"] == "ses_123"
         assert _conversation_sessions["test-repo"] == "ses_123"
 
@@ -276,7 +279,9 @@ class TestAgentService:
 
         result = send_agent_message("test-repo", "Hello agent")
 
-        assert result["response"] == "🧠 Before tool\n🛠️ firecrawl_firecrawl_search\n🎯 After tool"
+        assert result["response"] == (
+            "🧠 Before tool\n\n🛠️ firecrawl_firecrawl_search\n\n🎯 After tool"
+        )
 
     def test_parse_opencode_output_single_text_is_final(self):
         """Ensure a single text response is treated as the final message."""


### PR DESCRIPTION
## Summary
- ensure agent responses use valid ISO timestamps for client display
- render agent message parts with paragraph breaks so tool and thinking steps appear on separate lines

## Testing
- uv run pytest tests/unit/test_unit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e8b1b2948332a3c3e1cc51148e9b)