### PR TITLE
Support structured agent messages with timestamps

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -68,11 +68,18 @@ async function request<T>(
   throw new Error("Maximum retry attempts exceeded");
 }
 
-type AgentReply = {
+export type AgentResponsePart = {
+  text: string;
+  timestamp?: string;
+};
+
+export type AgentReply = {
   messageId: string;
   sent: string;
   response: string;
   prompt?: string;
+  responses?: AgentResponsePart[];
+  sessionId?: string;
 };
 
 type AgentStatus = {

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -13,6 +13,7 @@ import { usePersistentChat } from "../hooks/usePersistentChat";
 import { api } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
+import { mapAgentReplyToMessages } from "../utils/chat";
 
 export const ConstitutionPage: React.FC = () => {
   const { name } = useParams();
@@ -104,12 +105,7 @@ export const ConstitutionPage: React.FC = () => {
       const reply = await api.sendConstitutionAgent(name, userMessage.text);
       setChat((prev) => [
         ...prev,
-        {
-          id: reply.messageId,
-          role: "agent",
-          text: reply.response,
-          timestamp: reply.sent,
-        },
+        ...mapAgentReplyToMessages(reply),
       ]);
       setActiveTab("agent");
       setAgentStatus(null);

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -13,6 +13,7 @@ import { usePersistentChat } from "../hooks/usePersistentChat";
 import { api } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
+import { mapAgentReplyToMessages } from "../utils/chat";
 
 export const KnowledgeArtefactPage: React.FC = () => {
   const { name } = useParams();
@@ -53,9 +54,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
         setContent(data.content ?? "");
       })
       .catch((error) => {
-      console.error("Failed to load artefact", error);
-      setStatus("Failed to load artefact");
-    });
+        console.error("Failed to load artefact", error);
+        setStatus("Failed to load artefact");
+      });
   }, [name, navigate]);
 
   const refreshAgentStatus = useCallback(async () => {
@@ -104,12 +105,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       const reply = await api.sendKnowledgeAgent(name, userMessage.text);
       setChat((prev) => [
         ...prev,
-        {
-          id: reply.messageId,
-          role: "agent",
-          text: reply.response,
-          timestamp: reply.sent,
-        },
+        ...mapAgentReplyToMessages(reply),
       ]);
       setActiveTab("agent");
       setAgentStatus(null);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
+import { mapAgentReplyToMessages } from "../utils/chat";
 
 const stripCommandFrontmatter = (content: string) => {
   const delimiterPattern = /^\s*---(?:[\r\n]+[\s\S]*?[\r\n]+---|[\s\S]*?---)\s*/;
@@ -312,12 +313,7 @@ export const RepositoryPage: React.FC = () => {
       const reply = await api.sendAgentMessage(name, message);
       setChat((prev) => [
         ...prev,
-        {
-          id: reply.messageId,
-          role: "agent",
-          text: reply.response,
-          timestamp: reply.sent,
-        },
+        ...mapAgentReplyToMessages(reply),
       ]);
       setChatError(null);
       setActiveTab("agent");

--- a/packages/frontend/src/utils/chat.ts
+++ b/packages/frontend/src/utils/chat.ts
@@ -1,0 +1,18 @@
+import { AgentReply } from "../hooks/useApi";
+import { ChatMessage } from "../types/chat";
+
+export const mapAgentReplyToMessages = (reply: AgentReply): ChatMessage[] => {
+  const parts =
+    reply.responses && reply.responses.length
+      ? reply.responses
+      : reply.response
+        ? [{ text: reply.response, timestamp: reply.sent }]
+        : [];
+
+  return parts.map((part, index) => ({
+    id: `${reply.messageId}-${index}`,
+    role: "agent",
+    text: part.text,
+    timestamp: part.timestamp || reply.sent,
+  }));
+};


### PR DESCRIPTION
## Summary
- parse opencode JSON output into per-part responses with preserved timestamps and expose them via the agent API
- update frontend chats to handle multi-part agent replies through a shared mapping helper
- expand unit tests to cover structured agent responses and timestamp formatting

## Testing
- python -m pytest packages/pybackend/tests/unit/test_unit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eaf663848332a48b8730a5457aaa)