### PR TITLE
Adjust thinking and tool chat styling

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -11,6 +11,8 @@
   --success: #14b86a;
   --warning: #f59e0b;
   --danger: #ef4444;
+  --neutral: rgba(148, 163, 184, 0.16);
+  --neutral-strong: rgba(148, 163, 184, 0.32);
   --shadow: 0 20px 45px rgba(15, 22, 40, 0.12);
   font-family:
     "Inter",
@@ -35,6 +37,8 @@
   --success: #34d399;
   --warning: #facc15;
   --danger: #f87171;
+  --neutral: rgba(148, 163, 184, 0.14);
+  --neutral-strong: rgba(148, 163, 184, 0.26);
   --shadow: 0 25px 50px rgba(8, 11, 19, 0.45);
 }
 
@@ -259,9 +263,9 @@ textarea {
 
 .chat-message.agent.thinking,
 .chat-message.agent.tool {
-  background: rgba(250, 204, 21, 0.15);
-  box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.35);
-  color: var(--warning);
+  background: var(--neutral);
+  box-shadow: inset 0 0 0 1px var(--neutral-strong);
+  color: var(--text);
 }
 
 .chat-meta {


### PR DESCRIPTION
## Summary
- add neutral theme tokens for chat message styling
- restyle agent thinking/tool messages to use neutral grey tones instead of green/yellow

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f81325488332825d4545f6886cfd)