### PR TITLE
Store latest opencode session id

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -97,7 +97,9 @@ def _parse_opencode_output(stdout: str) -> tuple[str | None, list[dict[str, str]
         except json.JSONDecodeError:
             continue
 
-        session_id = session_id or payload.get("sessionID")
+        payload_session_id = payload.get("sessionID")
+        if payload_session_id:
+            session_id = payload_session_id
 
         payload_type = payload.get("type")
         payload_timestamp = payload.get("timestamp")


### PR DESCRIPTION
## Summary
- ensure opencode session parsing retains the latest sessionID received from opencode output

## Testing
- PYTHONPATH=packages/pybackend pytest packages/pybackend/tests/unit/test_unit.py -q --override-ini addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ff9c2b7c8332b4a24ed1ae791c9f)