### PR TITLE
Sync chat history after reloads

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -88,6 +88,19 @@ type AgentStatus = {
   startedAt?: string | null;
 };
 
+export type ChatHistoryMessage = {
+  messageId?: string;
+  role: "user" | "assistant";
+  type: "text" | "tool" | "tool_use";
+  content: string;
+  timestamp?: string | null;
+};
+
+export type ChatHistoryResponse = {
+  sessionId: string;
+  messages: ChatHistoryMessage[];
+};
+
 export type CommandDefinition = {
   id: string;
   name: string;
@@ -156,6 +169,22 @@ export const api = {
     }),
   getRepositoryAgentStatus: (name: string) =>
     request<AgentStatus>(`/repositories/${name}/agent/status`),
+  getRepositoryAgentHistory: (
+    name: string,
+    sessionId: string,
+    startTimestamp?: number,
+    signal?: AbortSignal,
+  ) => {
+    const params = new URLSearchParams({ session_id: sessionId });
+    if (typeof startTimestamp === "number" && Number.isFinite(startTimestamp)) {
+      params.append("start", Math.floor(startTimestamp).toString());
+    }
+
+    return request<ChatHistoryResponse>(
+      `/repositories/${name}/agent/history?${params.toString()}`,
+      { signal },
+    );
+  },
   getRepositoryCommands: (name: string) =>
     request<{ commands: CommandDefinition[] }>(`/repositories/${name}/commands`),
   listKnowledge: () => request<{ artefacts: ArtefactSummary[] }>("/knowledge"),

--- a/packages/frontend/src/utils/chat.ts
+++ b/packages/frontend/src/utils/chat.ts
@@ -1,4 +1,4 @@
-import { AgentReply } from "../hooks/useApi";
+import { AgentReply, ChatHistoryMessage } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 
 const normalizeMessageType = (
@@ -25,4 +25,40 @@ export const mapAgentReplyToMessages = (reply: AgentReply): ChatMessage[] => {
     timestamp: part.timestamp || reply.sent,
     messageType: normalizeMessageType(part.type),
   }));
+};
+
+const normalizeTimestamp = (rawTimestamp: string | null | undefined) => {
+  if (rawTimestamp && !Number.isNaN(Date.parse(rawTimestamp))) {
+    return new Date(rawTimestamp).toISOString();
+  }
+  return new Date().toISOString();
+};
+
+const normalizeHistoryMessageType = (
+  rawType: ChatHistoryMessage["type"],
+): ChatMessage["messageType"] => {
+  if (rawType === "tool" || rawType === "tool_use") return "tool";
+  if (rawType === "text") return "final";
+  return undefined;
+};
+
+export const mapHistoryToMessages = (
+  messages: ChatHistoryMessage[],
+): ChatMessage[] => {
+  const occurrenceCounter: Record<string, number> = {};
+
+  return messages.map((message) => {
+    const role = message.role === "assistant" ? "agent" : "user";
+    const baseId = message.messageId || `${role}-${message.timestamp || "unknown"}`;
+    const count = occurrenceCounter[baseId] ?? 0;
+    occurrenceCounter[baseId] = count + 1;
+
+    return {
+      id: `${baseId}-${count}`,
+      role,
+      text: message.content || "",
+      timestamp: normalizeTimestamp(message.timestamp),
+      messageType: normalizeHistoryMessageType(message.type),
+    };
+  });
 };


### PR DESCRIPTION
## Summary
- add API support for repository agent chat history retrieval
- map backend history records into chat messages and normalize timestamps
- sync missing repository chat messages on reload using session IDs without blocking the UI

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695383e6fe688332aa5a20b426f241eb)