### PR TITLE
Handle opencode sessions with explicit session IDs

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -162,10 +162,10 @@ export const api = {
       method: "DELETE",
       body: JSON.stringify({ path: filePath }),
     }),
-  sendAgentMessage: (name: string, message: string) =>
+  sendAgentMessage: (name: string, message: string, sessionId?: string) =>
     request<AgentReply>(`/repositories/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, sessionId }),
     }),
   getRepositoryAgentStatus: (name: string) =>
     request<AgentStatus>(`/repositories/${name}/agent/status`),
@@ -194,10 +194,10 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
-  sendKnowledgeAgent: (name: string, message: string) =>
+  sendKnowledgeAgent: (name: string, message: string, sessionId?: string) =>
     request<AgentReply>(`/knowledge/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, sessionId }),
     }),
   getKnowledgeAgentStatus: (name: string) =>
     request<AgentStatus>(`/knowledge/${name}/agent/status`),
@@ -210,10 +210,10 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
-  sendConstitutionAgent: (name: string, message: string) =>
+  sendConstitutionAgent: (name: string, message: string, sessionId?: string) =>
     request<AgentReply>(`/constitutions/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, sessionId }),
     }),
   getConstitutionAgentStatus: (name: string) =>
     request<AgentStatus>(`/constitutions/${name}/agent/status`),

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -108,7 +108,7 @@ export const ConstitutionPage: React.FC = () => {
     setPrompt("");
     setChatLoading(true);
     try {
-      const reply = await api.sendConstitutionAgent(name, userMessage.text);
+      const reply = await api.sendConstitutionAgent(name, userMessage.text, sessionId || undefined);
       setChat((prev) => [
         ...prev,
         ...mapAgentReplyToMessages(reply),

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -108,7 +108,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     setPrompt("");
     setChatLoading(true);
     try {
-      const reply = await api.sendKnowledgeAgent(name, userMessage.text);
+      const reply = await api.sendKnowledgeAgent(name, userMessage.text, sessionId || undefined);
       setChat((prev) => [
         ...prev,
         ...mapAgentReplyToMessages(reply),

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -368,7 +368,7 @@ export const RepositoryPage: React.FC = () => {
     setPendingPrompt("");
     setChatLoading(true);
     try {
-      const reply = await api.sendAgentMessage(name, message);
+      const reply = await api.sendAgentMessage(name, message, sessionId || undefined);
       setChat((prev) => [
         ...prev,
         ...mapAgentReplyToMessages(reply),

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -198,12 +198,13 @@ def delete_repository_file_endpoint(name: str, payload: dict = Body(...)):
 @app.post("/api/repositories/{name}/agent")
 def repository_agent(name: str, payload: dict = Body(...)):
     message = payload.get("message")
+    session_id = payload.get("sessionId")
     if not message:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
     try:
-        return send_agent_message(name, message)
+        return send_agent_message(name, message, session_id)
     except ChannelBusyError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 
@@ -255,12 +256,13 @@ def knowledge_write(name: str, payload: dict = Body(...)):
 @app.post("/api/knowledge/{name}/agent")
 def knowledge_agent(name: str, payload: dict = Body(...)):
     message = payload.get("message")
+    session_id = payload.get("sessionId")
     if not message:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
     try:
-        return send_agent_message(f"knowledge:{name}", message)
+        return send_agent_message(f"knowledge:{name}", message, session_id)
     except ChannelBusyError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 
@@ -302,12 +304,13 @@ def constitution_write(name: str, payload: dict = Body(...)):
 @app.post("/api/constitutions/{name}/agent")
 def constitution_agent(name: str, payload: dict = Body(...)):
     message = payload.get("message")
+    session_id = payload.get("sessionId")
     if not message:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
     try:
-        return send_agent_message(f"constitution:{name}", message)
+        return send_agent_message(f"constitution:{name}", message, session_id)
     except ChannelBusyError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -329,7 +329,18 @@ class TestRepositoryEndpoints:
         response = client.post("/api/repositories/test-repo/agent", json=payload)
         
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("test-repo", "Test message")
+        mock_agent.assert_called_once_with("test-repo", "Test message", None)
+
+    @patch('app.send_agent_message')
+    def test_repository_agent_with_session_id(self, mock_agent):
+        """Test repository agent forwards provided session ID."""
+        mock_agent.return_value = {"response": "Agent response"}
+        payload = {"message": "Test message", "sessionId": "ses_456"}
+
+        response = client.post("/api/repositories/test-repo/agent", json=payload)
+
+        assert response.status_code == 200
+        mock_agent.assert_called_once_with("test-repo", "Test message", "ses_456")
 
 
 class TestKnowledgeEndpoints:
@@ -387,7 +398,18 @@ class TestKnowledgeEndpoints:
         response = client.post("/api/knowledge/test-guide/agent", json=payload)
         
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("knowledge:test-guide", "Test message")
+        mock_agent.assert_called_once_with("knowledge:test-guide", "Test message", None)
+
+    @patch('app.send_agent_message')
+    def test_knowledge_agent_with_session_id(self, mock_agent):
+        """Test knowledge agent forwards provided session ID."""
+        mock_agent.return_value = {"response": "Agent response"}
+        payload = {"message": "Test message", "sessionId": "ses_k"}
+
+        response = client.post("/api/knowledge/test-guide/agent", json=payload)
+
+        assert response.status_code == 200
+        mock_agent.assert_called_once_with("knowledge:test-guide", "Test message", "ses_k")
 
 
 class TestConstitutionEndpoints:
@@ -436,7 +458,18 @@ class TestConstitutionEndpoints:
         response = client.post("/api/constitutions/test-const/agent", json=payload)
         
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("constitution:test-const", "Test message")
+        mock_agent.assert_called_once_with("constitution:test-const", "Test message", None)
+
+    @patch('app.send_agent_message')
+    def test_constitution_agent_with_session_id(self, mock_agent):
+        """Test constitution agent forwards provided session ID."""
+        mock_agent.return_value = {"response": "Agent response"}
+        payload = {"message": "Test message", "sessionId": "ses_c"}
+
+        response = client.post("/api/constitutions/test-const/agent", json=payload)
+
+        assert response.status_code == 200
+        mock_agent.assert_called_once_with("constitution:test-const", "Test message", "ses_c")
 
 
 class TestSettingsEndpoints:


### PR DESCRIPTION
## Summary
- pass stored session IDs from the frontend when sending agent chat messages
- update the backend to continue opencode sessions via -s instead of the deprecated -c flag
- extend backend unit tests to cover session forwarding for repository, knowledge, and constitution chats

## Testing
- cd packages/pybackend && uv run python -m pytest tests/unit/test_unit.py tests/unit/test_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538aabc8c083329ca7edffc7a756e1)