### PR TITLE
Add clear session control for agent conversations

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -242,7 +242,14 @@ export const ConstitutionPage: React.FC = () => {
                   )}
                   {sessionId && (
                     <div className="chat-session-id" aria-label="Session ID">
-                      Session ID: {sessionId}
+                      <span>Session ID: {sessionId}</span>
+                      <button
+                        type="button"
+                        title="Clear session"
+                        onClick={() => setSessionId(null)}
+                      >
+                        🗑️
+                      </button>
                     </div>
                   )}
                 </div>

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -260,7 +260,14 @@ export const KnowledgeArtefactPage: React.FC = () => {
                   )}
                   {sessionId && (
                     <div className="chat-session-id" aria-label="Session ID">
-                      Session ID: {sessionId}
+                      <span>Session ID: {sessionId}</span>
+                      <button
+                        type="button"
+                        title="Clear session"
+                        onClick={() => setSessionId(null)}
+                      >
+                        🗑️
+                      </button>
                     </div>
                   )}
                 </div>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -680,7 +680,14 @@ export const RepositoryPage: React.FC = () => {
             )}
             {sessionId && (
               <div className="chat-session-id" aria-label="Session ID">
-                Session ID: {sessionId}
+                <span>Session ID: {sessionId}</span>
+                <button
+                  type="button"
+                  title="Clear session"
+                  onClick={() => setSessionId(null)}
+                >
+                  🗑️
+                </button>
               </div>
             )}
           </div>

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -275,11 +275,31 @@ textarea {
 }
 
 .chat-session-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   align-self: flex-end;
-  text-align: right;
   font-style: italic;
   font-size: 0.85rem;
   color: var(--muted);
+  text-align: right;
+}
+
+.chat-session-id button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.5rem;
+  line-height: 1;
+}
+
+.chat-session-id button:hover,
+.chat-session-id button:focus-visible {
+  background: var(--neutral);
+  color: var(--text);
+  outline: none;
 }
 
 .editor-input {


### PR DESCRIPTION
## Summary
- add a clear session button with a 🗑️ icon next to agent chat session IDs across agent pages
- style the session ID display to accommodate the new control

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538c0b4888833290c622489ba4221f)