### PR TITLE
Fix chat session delete button styling

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -293,11 +293,12 @@ textarea {
   padding: 0.1rem 0.3rem;
   border-radius: 0.5rem;
   line-height: 1;
+  font-style: normal;
 }
 
 .chat-session-id button:hover,
 .chat-session-id button:focus-visible {
-  background: var(--neutral);
+  background: transparent;
   color: var(--text);
   outline: none;
 }


### PR DESCRIPTION
## Summary
- ensure the chat session delete icon no longer renders italicized
- keep the session delete button background transparent, including hover and focus states

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538d2ba4c883329e7d9d7f9caf9700)