### PR TITLE
Improve chat message deduplication

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -20,7 +20,11 @@ import {
 } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
-import { mapAgentReplyToMessages, mapHistoryToMessages } from "../utils/chat";
+import {
+  buildMessageDedupKey,
+  mapAgentReplyToMessages,
+  mapHistoryToMessages,
+} from "../utils/chat";
 
 const stripCommandFrontmatter = (content: string) => {
   const delimiterPattern = /^\s*---(?:[\r\n]+[\s\S]*?[\r\n]+---|[\s\S]*?---)\s*/;
@@ -324,13 +328,11 @@ export const RepositoryPage: React.FC = () => {
 
         setChat((previousChat) => {
           const existingKeys = new Set(
-            previousChat.map(
-              (message) => `${message.role}-${message.timestamp}-${message.text}`,
-            ),
+            previousChat.map((message) => buildMessageDedupKey(message)),
           );
           const mapped = mapHistoryToMessages(history.messages);
           const deduped = mapped.filter((message) => {
-            const key = `${message.role}-${message.timestamp}-${message.text}`;
+            const key = buildMessageDedupKey(message);
             if (existingKeys.has(key)) {
               return false;
             }

--- a/packages/frontend/src/utils/chat.ts
+++ b/packages/frontend/src/utils/chat.ts
@@ -1,6 +1,34 @@
 import { AgentReply, ChatHistoryMessage } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 
+const QUOTE_PAIRS: Record<string, string> = {
+  "\"": "\"",
+  "'": "'",
+  "`": "`",
+  "“": "”",
+  "‘": "’",
+  "«": "»",
+};
+
+export const normalizeChatMessageText = (text: string | undefined | null) => {
+  let normalized = (text || "").trim();
+  const openingQuote = normalized[0];
+  const closingQuote = openingQuote ? QUOTE_PAIRS[openingQuote] : undefined;
+
+  if (closingQuote && normalized.endsWith(closingQuote)) {
+    normalized = normalized.slice(1, -closingQuote.length).trim();
+  }
+
+  return normalized;
+};
+
+export const buildMessageDedupKey = (message: ChatMessage) => {
+  const normalizedText = normalizeChatMessageText(message.text);
+  const normalizedType = message.messageType || "none";
+
+  return `${message.role}-${normalizedType}-${normalizedText}`;
+};
+
 const normalizeMessageType = (
   value: string | undefined,
 ): ChatMessage["messageType"] => {


### PR DESCRIPTION
## Summary
- add normalization for chat message text to strip surrounding quotes and produce role/type-aware dedup keys
- deduplicate chat history using content-based keys to avoid duplicates when timestamps differ slightly

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538ecea59c83328245da88d387e6c5)