### PR TITLE
Prevent deduplication of tool messages in agent chat

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -328,10 +328,15 @@ export const RepositoryPage: React.FC = () => {
 
         setChat((previousChat) => {
           const existingKeys = new Set(
-            previousChat.map((message) => buildMessageDedupKey(message)),
+            previousChat
+              .filter((message) => message.messageType !== "tool")
+              .map((message) => buildMessageDedupKey(message)),
           );
           const mapped = mapHistoryToMessages(history.messages);
           const deduped = mapped.filter((message) => {
+            if (message.messageType === "tool") {
+              return true;
+            }
             const key = buildMessageDedupKey(message);
             if (existingKeys.has(key)) {
               return false;


### PR DESCRIPTION
## Summary
- keep tool chat messages from being filtered out by deduplication when syncing history
- avoid including tool messages in deduplication keys to ensure repeated tool outputs are displayed

## Testing
- npm --workspace packages/frontend run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953939754b483328872ec2abe74f3b9)