### PR TITLE
Handle noisy chat export output

### DIFF
--- a/packages/pybackend/tests/unit/test_chat_history_service.py
+++ b/packages/pybackend/tests/unit/test_chat_history_service.py
@@ -164,6 +164,19 @@ class TestExportChatHistory:
             export_chat_history("ses_123")
 
     @patch("agent_service.subprocess.run")
+    def test_export_chat_history_trims_non_json_prefix_and_suffix(self, mock_run):
+        mock_result = Mock()
+        mock_result.returncode = 0
+        payload = json.dumps(self.SAMPLE_EXPORT)
+        mock_result.stdout = f"intro text\n{payload}\ntrailing stats"
+        mock_run.return_value = mock_result
+
+        result = export_chat_history("ses_123")
+
+        assert result["sessionId"] == "ses_123"
+        assert any(msg["content"] == "Hello" for msg in result["messages"])
+
+    @patch("agent_service.subprocess.run")
     @patch("agent_service._get_working_directory")
     def test_export_chat_history_uses_channel_working_directory(
         self, mock_get_working_directory, mock_run


### PR DESCRIPTION
## Summary
- trim opencode export stdout to the JSON envelope before parsing to tolerate noisy output
- centralize invalid export logging and add contextual info when trimming succeeds
- cover noisy export handling with a dedicated unit test

## Testing
- PYTHONPATH=. pytest -o addopts= tests/unit/test_chat_history_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69550cfd45b08332ae882ff61c2890c5)