### PR TITLE
Improve chat history deduplication robustness

### DIFF
--- a/packages/frontend/src/utils/chat.test.ts
+++ b/packages/frontend/src/utils/chat.test.ts
@@ -21,7 +21,7 @@ describe("chat utils", () => {
         timestamp: baseTimestamp,
       };
 
-      expect(buildMessageDedupKey(message)).toBe("stable-key");
+      expect(buildMessageDedupKey(message)).toBe("agent:stable-key");
     });
 
     it("falls back to normalised text when no key is provided", () => {
@@ -32,7 +32,7 @@ describe("chat utils", () => {
         timestamp: baseTimestamp,
       };
 
-      expect(buildMessageDedupKey(message)).toBe("Wrapped content");
+      expect(buildMessageDedupKey(message)).toBe("agent:Wrapped content");
     });
   });
 


### PR DESCRIPTION
## Summary
- Scope chat deduplication keys by role and remove length-based truncation to reduce collisions
- Avoid auto-generating timestamps when history entries are invalid and track all messages in the dedup map, including tools
- Tighten merge replacement to only trust valid timestamps and update expectations in chat utility tests

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695684abbbec8332af40550beffa720e)