### PR TITLE
Add timestamps to backend access logs

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -1,4 +1,6 @@
 import logging
+from copy import deepcopy
+from uvicorn.config import LOGGING_CONFIG
 
 from fastapi import Body, FastAPI, HTTPException, Query, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -489,10 +491,19 @@ def start():
     port = get_backend_port()
     logger.info("Starting MADE backend on %s:%s", host, port)
 
+    log_config = deepcopy(LOGGING_CONFIG)
+    log_config["formatters"]["default"]["fmt"] = (
+        "%(asctime)s %(levelprefix)s %(message)s"
+    )
+    log_config["formatters"]["access"]["fmt"] = (
+        '%(asctime)s %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+    )
+
     uvicorn.run(
         "app:app",
         host=host,
         port=port,
+        log_config=log_config,
     )
 
 


### PR DESCRIPTION
## Summary
- add uvicorn log configuration that includes timestamps for default and access logs
- apply the customized log configuration when starting the backend service

## Testing
- python -m compileall packages/pybackend/app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a2327d9883329922aef3429ae3d5)