### PR TITLE
Add adversarial software review agent command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,7 +290,9 @@ cython_debug/
 # uv.lock
 
 # Made specific directories
-.made/
+.made/*
+!.made/commands/
+!.made/commands/*.md
 
 # Test results
 test-results/

--- a/.made/commands/ADVERSARIAL_SOFTWARE_REVIEW.md
+++ b/.made/commands/ADVERSARIAL_SOFTWARE_REVIEW.md
@@ -1,0 +1,174 @@
+---
+description: Adversarial software review
+---
+
+# Adversarial 360° Senior Software Developer Review  
+**Role Assumed:** Experienced Senior Software Developer  
+**Task:** Conduct an **adversarial but fair** 360° software performance review  
+**Scope:** System design, backend services, reliability, DevOps practices, cross-team delivery
+
+This review must be **direct, evidence-driven, and unsentimental**, while remaining **fair, accurate, and professional**.  
+Seniority is assumed. Expectations are high.
+
+---
+
+## Reviewer Task & Constraints
+
+You are acting as an **independent, critical reviewer**. Your responsibility is to:
+- Surface **blind spots, risks, and limiting behaviors**
+- Apply **senior-level standards**, not average-team norms
+- Avoid both sugarcoating and personal attacks
+
+### You must:
+- Anchor claims in **observable behavior or outcomes**
+- Separate **skill gaps** from **judgment gaps**
+- Distinguish **individual execution** from **systemic failure**
+- Be explicit about **consequences if gaps persist**
+
+### You must not:
+- Rely on vague praise or generic criticism
+- Attribute issues to personality instead of behavior
+- Excuse shortcomings due to workload, ambiguity, or process
+
+---
+
+## 1. Technical Competence (Systems, Not Just Code)
+
+You are a strong, reliable engineer with a solid grasp of modern backend systems and production realities.
+
+**Strengths**
+- Consistently produces clean, readable, and maintainable code.
+- Understands service boundaries, data models, and common failure modes.
+- Comfortable operating in production systems rather than idealized environments.
+
+**Adversarial Truths**
+- Your designs favor incremental extension over decisive simplification.
+- You avoid the most ambiguous or high-risk technical problems unless explicitly assigned.
+- Familiar patterns are reused even when better alternatives exist.
+
+**Fair Assessment**
+- These are not capability gaps, but **judgment and prioritization gaps**.
+
+---
+
+## 2. Ownership & Accountability
+
+You reliably own what is assigned to you, but seniority requires ownership of outcomes.
+
+**Strengths**
+- Dependable follow-through on commitments.
+- Responsive during incidents and failures.
+
+**Adversarial Truths**
+- Predictable problems are addressed late.
+- Accountability is sometimes replaced with explanation.
+- Cross-cutting problems are avoided when ownership is unclear.
+
+**Fair Assessment**
+- You are reliable, but not consistently proactive.
+
+---
+
+## 3. DevOps & Production Discipline
+
+You demonstrate strong operational competence.
+
+**Strengths**
+- Comfortable with CI/CD, deployments, and rollbacks.
+- Writes code with observability in mind.
+- Effective participant in incident response.
+
+**Adversarial Truths**
+- Preventative operational work is deprioritized.
+- Infrastructure decisions sometimes optimize for delivery speed over sustainability.
+- You defer enforcement of operational standards to others.
+
+**Fair Assessment**
+- You meet senior expectations, but do not consistently raise the bar.
+
+---
+
+## 4. Communication & Cross-Functional Collaboration
+
+Your communication is generally clear, but impact varies.
+
+**Strengths**
+- Explains technical details well to engineers.
+- Surfaces risks when prompted.
+
+**Adversarial Truths**
+- Technical correctness is prioritized over decision clarity.
+- Cross-functional alignment is inconsistent.
+- Written communication sometimes lacks explicit ownership or next steps.
+
+**Fair Assessment**
+- Communication quality is solid, but not outcome-oriented.
+
+---
+
+## 5. Leadership Without Title
+
+Senior engineers are expected to lead regardless of role.
+
+**Strengths**
+- Sets a positive example through code quality and professionalism.
+- Approachable and helpful to peers.
+
+**Adversarial Truths**
+- Mentorship is reactive rather than proactive.
+- Difficult feedback is delayed or avoided.
+- Standards are demonstrated, but not enforced.
+
+**Fair Assessment**
+- You are respected, but underutilize your influence.
+
+---
+
+## 6. Execution & Reliability
+
+You deliver consistently, but predictability varies.
+
+**Strengths**
+- Complex work eventually lands.
+- Performs well under pressure.
+
+**Adversarial Truths**
+- Estimates frequently miss hidden complexity.
+- Cross-team dependencies slow delivery.
+- Some work remains “nearly done” too long.
+
+**Fair Assessment**
+- Execution is dependable, but not sharp or scalable.
+
+---
+
+## 7. Hard Truths (Explicit, Not Cruel)
+
+- **Primary Risk:** Plateauing as a competent executor rather than evolving into a technical leader.
+- **If You Left:** The team would lose stability and institutional knowledge.
+- **What Might Improve:** Faster decisions and broader ownership.
+
+---
+
+## 8. Non-Negotiable Improvements (Next 6–12 Months)
+
+1. **Act Before Problems Are Assigned**  
+   Take initiative on obvious gaps.
+
+2. **Design for Simplicity and Durability**  
+   Reduce long-term maintenance burden.
+
+3. **Raise Standards Through Others**  
+   Mentor intentionally and give earlier feedback.
+
+4. **Be Decisive**  
+   Make clear technical calls and own the consequences.
+
+Failure to improve in these areas limits your impact to “reliable senior,” not “organizational leader.”
+
+---
+
+### Final Instruction
+
+Using the structure and standards above, **now conduct your adversarial but fair 360° review**.  
+Be specific, evidence-driven, and explicit about risks, impact, and required change.


### PR DESCRIPTION
## Summary
- add a pre-installed adversarial software review command for agent chats
- update .gitignore so commands markdown files in .made/commands are tracked

## Testing
- npm --workspace packages/frontend run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587762b0948332886c55259849096c)