### PR TITLE
Enable websocket proxying for terminal connections

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "/api": {
         target: "http://localhost:3000",
         changeOrigin: true,
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
## Summary
- enable websocket proxying on the Vite dev server so API WebSocket endpoints (like the terminal) are forwarded
- ensure local development can open repository terminal sessions without connection resets

## Testing
- npm --workspace packages/frontend test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695967fd6d148332b0a8478dbeb53696)