### PR TITLE
Add command preview to agent error logging

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -486,10 +486,12 @@ def send_agent_message(channel: str, message: str, session_id: str | None = None
                 if result.stderr.strip()
                 else "Command failed with no output"
             )
+            command_preview = " ".join(command)[:200]
             logger.error(
-                "Agent command failed (channel: %s, session: %s): %s",
+                "Agent command failed (channel: %s, session: %s, command: %s): %s",
                 channel,
                 _conversation_sessions.get(channel),
+                command_preview,
                 response,
             )
 


### PR DESCRIPTION
## Summary
- log the opencode command preview when agent subprocess failures occur
- keep existing error response messaging unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa33a30bc833292d21f09edfcee84)