### PR TITLE
Handle terminal websocket cancellation gracefully

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -410,6 +410,10 @@ async def repository_terminal(name: str, websocket: WebSocket):
                 client_addr,
                 exc.code,
             )
+        except asyncio.CancelledError:
+            logger.info(
+                "Terminal output task cancelled for '%s' from %s", name, client_addr
+            )
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Terminal output stopped for '%s': %s", name, exc)
         finally:
@@ -463,7 +467,7 @@ async def repository_terminal(name: str, websocket: WebSocket):
         logger.exception("Unexpected terminal error for '%s'", name)
     finally:
         reader_task.cancel()
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(asyncio.CancelledError, Exception):
             await reader_task
         with contextlib.suppress(Exception):
             os.close(master_fd)


### PR DESCRIPTION
## Summary
- add explicit handling for terminal output task cancellation so closing the browser websocket does not surface as an ASGI error
- suppress cancellation exceptions while awaiting the terminal reader task during shutdown for cleaner teardown

## Testing
- cd packages/pybackend && uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abbee3c108332bb167d9374e83a6e)