### PR TITLE
Add copy controls for agent chat messages

### DIFF
--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { marked } from "marked";
+import { ChatMessage } from "../types/chat";
+
+interface ChatWindowProps {
+  chat: ChatMessage[];
+  chatWindowRef?: React.RefObject<HTMLDivElement>;
+  loading: boolean;
+  emptyMessage: string;
+  sessionId?: string | null;
+  onClearSession?: () => void;
+}
+
+const formatTimestamp = (message: ChatMessage) => {
+  const prefix =
+    message.role === "agent"
+      ? message.messageType === "thinking"
+        ? "🧠 "
+        : message.messageType === "tool"
+          ? "🛠️ "
+          : message.messageType === "final"
+            ? "🎯 "
+            : ""
+      : "";
+
+  return `${prefix}${new Date(message.timestamp).toLocaleString()}`;
+};
+
+const copyText = (text: string) => {
+  if (!navigator.clipboard) return;
+
+  navigator.clipboard.writeText(text).catch((error) => {
+    console.error("Failed to copy message", error);
+  });
+};
+
+const CopyIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+export const ChatWindow: React.FC<ChatWindowProps> = ({
+  chat,
+  chatWindowRef,
+  loading,
+  emptyMessage,
+  sessionId,
+  onClearSession,
+}) => (
+  <div className="chat-window" ref={chatWindowRef}>
+    {chat.map((message) => (
+      <div
+        key={message.id}
+        className={`chat-message ${message.role} ${message.messageType || ""}`}
+      >
+        <div className="chat-meta">{formatTimestamp(message)}</div>
+        <button
+          type="button"
+          className="copy-button chat-copy-button"
+          aria-label="Copy message"
+          title="Copy message"
+          onClick={() => copyText(message.text || "")}
+        >
+          <CopyIcon />
+        </button>
+        <div
+          className="markdown"
+          dangerouslySetInnerHTML={{
+            __html: marked(message.text || ""),
+          }}
+        />
+      </div>
+    ))}
+    {loading && (
+      <div className="loading-indicator">
+        <div className="loading-spinner"></div>
+        <span>Agent is thinking...</span>
+      </div>
+    )}
+    {chat.length === 0 && !loading && <div className="empty">{emptyMessage}</div>}
+    {sessionId && (
+      <div className="chat-session-id" aria-label="Session ID">
+        <span>Session ID: {sessionId}</span>
+        <button
+          type="button"
+          title="Clear session"
+          onClick={onClearSession}
+        >
+          🗑️
+        </button>
+      </div>
+    )}
+  </div>
+);

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
+import { ChatWindow } from "../components/ChatWindow";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { api } from "../hooks/useApi";
@@ -226,57 +227,14 @@ export const ConstitutionPage: React.FC = () => {
             label: "Agent",
             content: (
               <Panel title="Agent Conversation">
-                <div className="chat-window" ref={chatWindowRef}>
-                  {chat.map((message) => (
-                    <div
-                      key={message.id}
-                      className={`chat-message ${message.role} ${message.messageType || ""}`}
-                    >
-                      <div className="chat-meta">
-                        {`${
-                          message.role === "agent"
-                            ? message.messageType === "thinking"
-                              ? "🧠 "
-                              : message.messageType === "tool"
-                                ? "🛠️ "
-                                : message.messageType === "final"
-                                  ? "🎯 "
-                                  : ""
-                            : ""
-                        }${new Date(message.timestamp).toLocaleString()}`}
-                      </div>
-                      <div
-                        className="markdown"
-                        dangerouslySetInnerHTML={{
-                          __html: marked(message.text || ""),
-                        }}
-                      />
-                    </div>
-                  ))}
-                  {chatLoading && (
-                    <div className="loading-indicator">
-                      <div className="loading-spinner"></div>
-                      <span>Agent is thinking...</span>
-                    </div>
-                  )}
-                  {chat.length === 0 && !chatLoading && (
-                    <div className="empty">
-                      Start a conversation to discuss this constitution.
-                    </div>
-                  )}
-                  {sessionId && (
-                    <div className="chat-session-id" aria-label="Session ID">
-                      <span>Session ID: {sessionId}</span>
-                      <button
-                        type="button"
-                        title="Clear session"
-                        onClick={() => setClearSessionModalOpen(true)}
-                      >
-                        🗑️
-                      </button>
-                    </div>
-                  )}
-                </div>
+                <ChatWindow
+                  chat={chat}
+                  chatWindowRef={chatWindowRef}
+                  loading={chatLoading}
+                  emptyMessage="Start a conversation to discuss this constitution."
+                  sessionId={sessionId}
+                  onClearSession={() => setClearSessionModalOpen(true)}
+                />
                 {agentStatus && <div className="alert">{agentStatus}</div>}
                 <textarea
                   value={prompt}

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
+import { ChatWindow } from "../components/ChatWindow";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { api } from "../hooks/useApi";
@@ -244,57 +245,14 @@ export const KnowledgeArtefactPage: React.FC = () => {
             label: "Agent",
             content: (
               <Panel title="Agent Conversation">
-                <div className="chat-window" ref={chatWindowRef}>
-                  {chat.map((message) => (
-                    <div
-                      key={message.id}
-                      className={`chat-message ${message.role} ${message.messageType || ""}`}
-                    >
-                      <div className="chat-meta">
-                        {`${
-                          message.role === "agent"
-                            ? message.messageType === "thinking"
-                              ? "🧠 "
-                              : message.messageType === "tool"
-                                ? "🛠️ "
-                                : message.messageType === "final"
-                                  ? "🎯 "
-                                  : ""
-                            : ""
-                        }${new Date(message.timestamp).toLocaleString()}`}
-                      </div>
-                      <div
-                        className="markdown"
-                        dangerouslySetInnerHTML={{
-                          __html: marked(message.text || ""),
-                        }}
-                      />
-                    </div>
-                  ))}
-                  {chatLoading && (
-                    <div className="loading-indicator">
-                      <div className="loading-spinner"></div>
-                      <span>Agent is thinking...</span>
-                    </div>
-                  )}
-                  {chat.length === 0 && !chatLoading && (
-                    <div className="empty">
-                      Start a conversation to collaborate with agents.
-                    </div>
-                  )}
-                  {sessionId && (
-                    <div className="chat-session-id" aria-label="Session ID">
-                      <span>Session ID: {sessionId}</span>
-                      <button
-                        type="button"
-                        title="Clear session"
-                        onClick={() => setClearSessionModalOpen(true)}
-                      >
-                        🗑️
-                      </button>
-                    </div>
-                  )}
-                </div>
+                <ChatWindow
+                  chat={chat}
+                  chatWindowRef={chatWindowRef}
+                  loading={chatLoading}
+                  emptyMessage="Start a conversation to collaborate with agents."
+                  sessionId={sessionId}
+                  onClearSession={() => setClearSessionModalOpen(true)}
+                />
                 {agentStatus && <div className="alert">{agentStatus}</div>}
                 <textarea
                   value={prompt}

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -11,6 +11,7 @@ import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { Modal } from "../components/Modal";
 import { TerminalTab } from "../components/TerminalTab";
+import { ChatWindow } from "../components/ChatWindow";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import {
@@ -176,6 +177,18 @@ export const RepositoryPage: React.FC = () => {
     values: [],
   });
   const chatWindowRef = useRef<HTMLDivElement>(null);
+  const copyAllMessages = useCallback(() => {
+    if (!navigator.clipboard || !chat.length) return;
+
+    const content = chat
+      .map((message) => message.text || "")
+      .join("\n\n")
+      .trim();
+
+    navigator.clipboard.writeText(content).catch((error) => {
+      console.error("Failed to copy chat history", error);
+    });
+  }, [chat]);
 
   const scrollToBottom = () => {
     if (chatWindowRef.current) {
@@ -664,56 +677,44 @@ export const RepositoryPage: React.FC = () => {
       id: "agent",
       label: "Agent",
       content: (
-        <Panel title="Agent Collaboration">
-          <div className="chat-window" ref={chatWindowRef}>
-            {chat.map((message) => (
-              <div
-                key={message.id}
-                className={`chat-message ${message.role} ${message.messageType || ""}`}
+        <Panel
+          title="Agent Collaboration"
+          actions={
+            <button
+              type="button"
+              className="copy-button"
+              onClick={copyAllMessages}
+              aria-label="Copy chat messages"
+              title="Copy chat messages"
+              disabled={!chat.length}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                focusable="false"
               >
-                <div className="chat-meta">
-                  {`${
-                    message.role === "agent"
-                      ? message.messageType === "thinking"
-                        ? "🧠 "
-                        : message.messageType === "tool"
-                          ? "🛠️ "
-                          : message.messageType === "final"
-                            ? "🎯 "
-                            : ""
-                      : ""
-                  }${new Date(message.timestamp).toLocaleString()}`}
-                </div>
-                <div
-                  className="markdown"
-                  dangerouslySetInnerHTML={{
-                    __html: marked(message.text || ""),
-                  }}
-                />
-              </div>
-            ))}
-            {chatLoading && (
-              <div className="loading-indicator">
-                <div className="loading-spinner"></div>
-                <span>Agent is thinking...</span>
-              </div>
-            )}
-            {chat.length === 0 && !chatLoading && (
-              <div className="empty">No conversation yet.</div>
-            )}
-            {sessionId && (
-              <div className="chat-session-id" aria-label="Session ID">
-                <span>Session ID: {sessionId}</span>
-                <button
-                  type="button"
-                  title="Clear session"
-                  onClick={() => setClearSessionModalOpen(true)}
-                >
-                  🗑️
-                </button>
-              </div>
-            )}
-          </div>
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+            </button>
+          }
+        >
+          <ChatWindow
+            chat={chat}
+            chatWindowRef={chatWindowRef}
+            loading={chatLoading}
+            emptyMessage="No conversation yet."
+            sessionId={sessionId}
+            onClearSession={() => setClearSessionModalOpen(true)}
+          />
           {chatError && <div className="alert">{chatError}</div>}
           <textarea
             value={pendingPrompt}

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -129,6 +129,38 @@ textarea {
   color: var(--text);
 }
 
+.copy-button {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0.6;
+  transition: color 0.2s ease, opacity 0.2s ease;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.copy-button:hover,
+.copy-button:focus-visible {
+  opacity: 1;
+  color: var(--text);
+  outline: none;
+}
+
+.copy-button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.copy-button svg {
+  width: 18px;
+  height: 18px;
+}
+
 .primary {
   padding: 0.75rem 1.25rem;
   border-radius: 0.9rem;
@@ -242,6 +274,8 @@ textarea {
   padding: 0.75rem 1rem;
   border-radius: 0.9rem;
   box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
+  position: relative;
+  padding-right: 2.5rem;
 }
 
 .chat-message pre,
@@ -272,6 +306,16 @@ textarea {
   font-size: 0.75rem;
   color: var(--muted);
   margin-bottom: 0.5rem;
+}
+
+.chat-copy-button {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+}
+
+.chat-message:hover .chat-copy-button {
+  opacity: 0.9;
 }
 
 .chat-session-id {


### PR DESCRIPTION
## Summary
- add a reusable ChatWindow component with per-message copy buttons using unframed outlined copy glyphs
- add a copy-all control to the Agent Collaboration panel
- refresh chat styling and reuse the component across agent views

## Testing
- npm --workspace packages/frontend run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aeca405248332ad1206c44e8cff5a)