### PR TITLE
Ensure disabled copy buttons stay transparent

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -154,6 +154,8 @@ textarea {
   opacity: 0.35;
   cursor: not-allowed;
   box-shadow: none;
+  background: transparent;
+  border: none;
 }
 
 .copy-button svg {


### PR DESCRIPTION
### Motivation
- The copy button showed a filled background when disabled, which is visually inconsistent with the rest of the UI.  
- Disabled controls should maintain a transparent background to avoid appearing active or highlighted.  

### Description
- Updated `packages/frontend/src/styles/index.css` to ensure ` .copy-button:disabled` sets `background: transparent` and `border: none`.  
- This change keeps the disabled copy button visually consistent with other transparent icon buttons.  

### Testing
- Ran `npm run lint` in `packages/frontend` and it completed successfully.  
- Captured a UI screenshot with a Playwright script navigating to the repository page to verify the disabled copy button appearance (screenshot produced; backend API proxy errors were observed because the backend was not running).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d198041cc8332bd4d82d288f3e3c5)