### PR TITLE
Pipe agent prompts to opencode stdin to avoid leading-hyphen flag parsing

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -44,12 +44,12 @@ def get_channel_status(channel: str) -> dict[str, object]:
     }
 
 
-def _build_opencode_command(message: str, session_id: str | None) -> list[str]:
+def _build_opencode_command(session_id: str | None) -> list[str]:
     """Build the opencode command based on conversation state."""
     command = ["opencode", "run"]
     if session_id:
         command.extend(["-s", session_id])
-    command.extend(["--format", "json", message])
+    command.extend(["--format", "json"])
     return command
 
 
@@ -450,7 +450,7 @@ def send_agent_message(channel: str, message: str, session_id: str | None = None
     else:
         _conversation_sessions.pop(channel, None)
 
-    command = _build_opencode_command(message, active_session)
+    command = _build_opencode_command(active_session)
 
     logger.info(
         "Sending agent message (channel: %s, session: %s)", channel, active_session
@@ -462,6 +462,7 @@ def send_agent_message(channel: str, message: str, session_id: str | None = None
             command,
             capture_output=True,
             text=True,
+            input=message,
             cwd=working_dir,  # Run in the correct directory
         )
 


### PR DESCRIPTION
### Motivation

- Prevent user prompts that begin with `-` from being interpreted as CLI flags by `opencode`.
- Standardize how prompts are passed to the `opencode run` process so arguments and session handling remain separate.
- Make the invocation safer and more robust for arbitrary user input.

### Description

- Change `_build_opencode_command` to accept only `session_id` and always include `--format json` while leaving the prompt out of the argument list.
- Update `send_agent_message` to call `subprocess.run` with the built command and pass the user `message` via the `input` argument so it is piped to `opencode` stdin.
- Update unit tests in `packages/pybackend/tests/unit/test_unit.py` to assert the new invocation shape, add a test for messages beginning with `-`, and add `input` assertions to existing tests.

### Testing

- Ran unit tests with `cd packages/pybackend && uv run pytest tests/unit/test_unit.py` and all tests passed (`20 passed`).
- The updated tests assert `subprocess.run` calls include `input` and that a leading-hyphen prompt is preserved and sent via stdin.
- No automated failures were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1bc9168883329dc22decb1e8032b)