### PR TITLE
Ensure copy buttons stay transparent

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -143,8 +143,10 @@ textarea {
   opacity: 0.6;
   transition: color 0.2s ease, opacity 0.2s ease;
   background: transparent;
+  background-color: transparent !important;
   border: none;
   padding: 0;
+  box-shadow: none;
 }
 
 .copy-button:hover,
@@ -152,6 +154,8 @@ textarea {
   opacity: 1;
   color: var(--text);
   outline: none;
+  background-color: transparent;
+  box-shadow: none;
 }
 
 .copy-button:disabled {


### PR DESCRIPTION
### Motivation
- Session history and copy action buttons were receiving non-transparent backgrounds again, so styles need to be enforced to keep them transparent.
- Prevent unintended fills or shadows on the small icon buttons in normal, hover and focus states to keep the UI unobtrusive.
- Make the CSS robust against specificity changes so the buttons remain transparent across themes and parent components.

### Description
- Updated `packages/frontend/src/styles/index.css` to add `background-color: transparent !important` and `box-shadow: none` for the `.copy-button` selector.
- Applied `background-color: transparent` and `box-shadow: none` for `.copy-button:hover` and `.copy-button:focus-visible` to keep interactive states transparent.
- Preserved the existing disabled styling while ensuring no unwanted background or shadow appears in any state.

### Testing
- Ran `npm run lint` which executed the frontend ESLint checks and completed successfully.
- Launched the frontend dev server and captured a visual verification screenshot via Playwright to confirm the action buttons remain transparent.
- Backend was not running during the visual check which produced `ECONNREFUSED` proxy logs, but the styling verification succeeded despite those errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d27b15cd48332863e23415e63e1e9)