### PR TITLE
Use correct `opencode session list` command in `list_chat_sessions`

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -491,7 +491,7 @@ def list_chat_sessions(channel: str | None = None, limit: int = 10) -> list[dict
 
     try:
         result = subprocess.run(
-            ["opencode", "sessions"],
+            ["opencode", "session", "list"],
             capture_output=True,
             text=True,
             cwd=working_dir,


### PR DESCRIPTION
### Motivation
- The previous CLI invocation used the wrong `opencode` subcommand which produced unexpected output for the session listing parser. 
- Align the command with the expected tabular output so parsing of session rows works reliably.

### Description
- Update the `list_chat_sessions` implementation to call `subprocess.run` with `["opencode", "session", "list"]` instead of `["opencode", "sessions"]`.
- No other behavioral changes were made to error handling or return structure in `list_chat_sessions`.

### Testing
- Running `uv run pytest packages/pybackend/tests/unit/test_unit.py -k list_chat_sessions` with an incorrect path resulted in no tests being found. 
- Running `uv run pytest tests/unit/test_unit.py -k list_chat_sessions` executed two selected tests and both passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7f3efca88332994a175de3821085)