### PR TITLE
Update session pill hover styling

### DIFF
--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -411,13 +411,16 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, transform 0.2s ease,
+    background-color 0.2s ease;
+  will-change: transform;
 }
 
 .session-pill:hover,
 .session-pill:focus-visible {
   border-color: var(--accent);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-1px);
+  background-color: color-mix(in srgb, var(--surface) 90%, var(--accent));
   outline: none;
 }
 


### PR DESCRIPTION
### Motivation
- Improve hover responsiveness and performance for `.session-pill` by avoiding box-shadow transitions that can be janky during fast pointer movement.
- Use GPU-compositable properties (`transform`) and a subtle background tint to provide faster, smoother feedback.
- Hint the compositor with `will-change` to reduce jank on modern browsers.

### Description
- Modified `packages/frontend/src/styles/index.css` to remove `box-shadow` from the transition list and add `transform` and `background-color` transitions. 
- Added `will-change: transform` to `.session-pill` as a compositor hint. 
- Replaced the hover/active effect with `transform: translateY(-1px)` and a subtle `background-color` mix using `color-mix(...)` instead of `box-shadow`.

### Testing
- Started the frontend dev server with `npm run dev:frontend` and it launched successfully.  
- Started the backend with `uv run uvicorn app:app --host 0.0.0.0 --port 3000` and it launched successfully.  
- Ran Playwright scripts (Chromium/Firefox) to open the app and capture screenshots of the session picker modal, which produced artifacts.  
- End-to-end hover verification was blocked because the session list API returned 500 due to a missing `opencode` binary, so pills were not reliably populated for automated hover responsiveness checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e277f7ab48332868cd0eac4eacae5)