### PR TITLE
Dim session selector icon when chat is empty

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -290,7 +290,7 @@ export const ConstitutionPage: React.FC = () => {
                   <div className="panel-action-buttons">
                     <button
                       type="button"
-                      className="copy-button"
+                      className={`copy-button${chat.length ? "" : " is-muted"}`}
                       onClick={openSessionModal}
                       aria-label="Choose a session"
                       title="Choose a session"

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -308,7 +308,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
                   <div className="panel-action-buttons">
                     <button
                       type="button"
-                      className="copy-button"
+                      className={`copy-button${chat.length ? "" : " is-muted"}`}
                       onClick={openSessionModal}
                       aria-label="Choose a session"
                       title="Choose a session"

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -765,7 +765,7 @@ export const RepositoryPage: React.FC = () => {
             <div className="panel-action-buttons">
               <button
                 type="button"
-                className="copy-button"
+                className={`copy-button${chat.length ? "" : " is-muted"}`}
                 onClick={openSessionModal}
                 aria-label="Choose a session"
                 title="Choose a session"

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -166,6 +166,16 @@ textarea {
   border: none;
 }
 
+.copy-button.is-muted {
+  opacity: 0.35;
+}
+
+.copy-button.is-muted:hover,
+.copy-button.is-muted:focus-visible {
+  opacity: 0.35;
+  color: var(--muted);
+}
+
 .copy-button svg {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
### Motivation

- The session selector icon appeared visually prominent compared to the copy button when there are no agent messages, causing inconsistent UI affordance.
- Make inactive session controls visually consistent with the muted copy button so users can better infer availability.

### Description

- Added a muted modifier `.copy-button.is-muted` in `packages/frontend/src/styles/index.css` to set reduced opacity and keep the color muted on hover/focus.
- Applied the muted class to the `DatabaseIcon` session buttons in `packages/frontend/src/pages/ConstitutionPage.tsx`, `packages/frontend/src/pages/KnowledgeArtefactPage.tsx`, and `packages/frontend/src/pages/RepositoryPage.tsx` via `className={`copy-button${chat.length ? "" : " is-muted"}`}` so the icon is dimmed when `chat.length` is zero.
- Preserved the existing `:disabled` behavior for the copy button and only added a visual modifier for empty-session state.

### Testing

- Ran the frontend unit tests with `npm --workspace packages/frontend test` and all tests passed (3 test files, 11 tests).
- Started the frontend dev server with `npm run dev:frontend` and captured a Playwright screenshot to visually verify the change (note: backend was not running so proxy errors were logged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e294f92d483328c733a1fbd775e79)