### PR TITLE
Add cancel action for running agent requests

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -176,6 +176,8 @@ export const api = {
     }),
   getRepositoryAgentStatus: (name: string) =>
     request<AgentStatus>(`/repositories/${name}/agent/status`),
+  cancelRepositoryAgent: (name: string) =>
+    request(`/repositories/${name}/agent/cancel`, { method: "POST" }),
   getRepositoryAgentHistory: (
     name: string,
     sessionId: string,
@@ -260,6 +262,8 @@ export const api = {
     }),
   getKnowledgeAgentStatus: (name: string) =>
     request<AgentStatus>(`/knowledge/${name}/agent/status`),
+  cancelKnowledgeAgent: (name: string) =>
+    request(`/knowledge/${name}/agent/cancel`, { method: "POST" }),
   listConstitutions: () =>
     request<{ constitutions: ArtefactSummary[] }>("/constitutions"),
   getConstitution: (name: string) =>
@@ -276,6 +280,8 @@ export const api = {
     }),
   getConstitutionAgentStatus: (name: string) =>
     request<AgentStatus>(`/constitutions/${name}/agent/status`),
+  cancelConstitutionAgent: (name: string) =>
+    request(`/constitutions/${name}/agent/cancel`, { method: "POST" }),
   getSettings: () => request<Record<string, unknown>>("/settings"),
   saveSettings: (settings: Record<string, unknown>) =>
     request("/settings", {

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -178,6 +178,18 @@ export const ConstitutionPage: React.FC = () => {
     }
   };
 
+  const handleCancel = async () => {
+    if (!name) return;
+    try {
+      await api.cancelConstitutionAgent(name);
+    } catch (error) {
+      console.error("Failed to cancel agent request", error);
+      setAgentStatus("Unable to cancel the agent request.");
+    } finally {
+      await refreshAgentStatus();
+    }
+  };
+
   const handleCancelClearSession = () => {
     setClearSessionModalOpen(false);
   };
@@ -340,13 +352,19 @@ export const ConstitutionPage: React.FC = () => {
                   placeholder="Ask the agent to update governance rules..."
                 />
                 <div className="button-bar">
-                  <button
-                    className="primary"
-                    onClick={handleSend}
-                    disabled={chatLoading || !prompt.trim()}
-                  >
-                    {chatLoading ? "Sending..." : "Send"}
-                  </button>
+                  {chatLoading ? (
+                    <button className="danger" onClick={handleCancel}>
+                      Cancel
+                    </button>
+                  ) : (
+                    <button
+                      className="primary"
+                      onClick={handleSend}
+                      disabled={!prompt.trim()}
+                    >
+                      Send
+                    </button>
+                  )}
                 </div>
               </Panel>
             ),

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -178,6 +178,18 @@ export const KnowledgeArtefactPage: React.FC = () => {
     }
   };
 
+  const handleCancel = async () => {
+    if (!name) return;
+    try {
+      await api.cancelKnowledgeAgent(name);
+    } catch (error) {
+      console.error("Failed to cancel agent request", error);
+      setAgentStatus("Unable to cancel the agent request.");
+    } finally {
+      await refreshAgentStatus();
+    }
+  };
+
   const handleCancelClearSession = () => {
     setClearSessionModalOpen(false);
   };
@@ -358,13 +370,19 @@ export const KnowledgeArtefactPage: React.FC = () => {
                   placeholder="Ask the agent about this artefact..."
                 />
                 <div className="button-bar">
-                  <button
-                    className="primary"
-                    onClick={handleSend}
-                    disabled={chatLoading || !prompt.trim()}
-                  >
-                    {chatLoading ? "Sending..." : "Send"}
-                  </button>
+                  {chatLoading ? (
+                    <button className="danger" onClick={handleCancel}>
+                      Cancel
+                    </button>
+                  ) : (
+                    <button
+                      className="primary"
+                      onClick={handleSend}
+                      disabled={!prompt.trim()}
+                    >
+                      Send
+                    </button>
+                  )}
                 </div>
               </Panel>
             ),

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -473,6 +473,18 @@ export const RepositoryPage: React.FC = () => {
     }
   };
 
+  const handleCancelAgent = async () => {
+    if (!name) return;
+    try {
+      await api.cancelRepositoryAgent(name);
+    } catch (error) {
+      console.error("Failed to cancel agent request", error);
+      setChatError("Unable to cancel the agent request.");
+    } finally {
+      await refreshAgentStatus();
+    }
+  };
+
   const handleCancelClearSession = () => {
     setClearSessionModalOpen(false);
   };
@@ -815,13 +827,19 @@ export const RepositoryPage: React.FC = () => {
             placeholder="Describe the change or ask the agent..."
           />
           <div className="button-bar">
-            <button
-              className="primary"
-              onClick={() => handleSendMessage()}
-              disabled={chatLoading || !pendingPrompt.trim()}
-            >
-              {chatLoading ? "Sending..." : "Send"}
-            </button>
+            {chatLoading ? (
+              <button className="danger" onClick={handleCancelAgent}>
+                Cancel
+              </button>
+            ) : (
+              <button
+                className="primary"
+                onClick={() => handleSendMessage()}
+                disabled={!pendingPrompt.trim()}
+              >
+                Send
+              </button>
+            )}
           </div>
         </Panel>
       ),

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from agent_service import (
     ChannelBusyError,
+    cancel_agent_message,
     export_chat_history,
     get_channel_status,
     list_chat_sessions,
@@ -337,6 +338,16 @@ def repository_agent_status(name: str):
     return get_channel_status(name)
 
 
+@app.post("/api/repositories/{name}/agent/cancel")
+def repository_agent_cancel(name: str):
+    if not cancel_agent_message(name):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active agent process to cancel",
+        )
+    return {"success": True}
+
+
 @app.get("/api/repositories/{name}/commands")
 def repository_commands(name: str):
     try:
@@ -540,6 +551,16 @@ def knowledge_agent_status(name: str):
     return get_channel_status(f"knowledge:{name}")
 
 
+@app.post("/api/knowledge/{name}/agent/cancel")
+def knowledge_agent_cancel(name: str):
+    if not cancel_agent_message(f"knowledge:{name}"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active agent process to cancel",
+        )
+    return {"success": True}
+
+
 @app.get("/api/knowledge/{name}/agent/history")
 def knowledge_agent_history(
     name: str,
@@ -653,6 +674,16 @@ def constitution_agent(name: str, payload: dict = Body(...)):
 @app.get("/api/constitutions/{name}/agent/status")
 def constitution_agent_status(name: str):
     return get_channel_status(f"constitution:{name}")
+
+
+@app.post("/api/constitutions/{name}/agent/cancel")
+def constitution_agent_cancel(name: str):
+    if not cancel_agent_message(f"constitution:{name}"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active agent process to cancel",
+        )
+    return {"success": True}
 
 
 @app.get("/api/constitutions/{name}/agent/history")

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -185,6 +185,27 @@ class TestKnowledgeAgentSessions:
         assert response.status_code == 500
 
 
+class TestKnowledgeAgentCancel:
+    @patch('app.cancel_agent_message')
+    def test_knowledge_agent_cancel_success(self, mock_cancel):
+        mock_cancel.return_value = True
+
+        response = client.post("/api/knowledge/sample/agent/cancel")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+        mock_cancel.assert_called_once_with("knowledge:sample")
+
+    @patch('app.cancel_agent_message')
+    def test_knowledge_agent_cancel_not_found(self, mock_cancel):
+        mock_cancel.return_value = False
+
+        response = client.post("/api/knowledge/sample/agent/cancel")
+
+        assert response.status_code == 404
+        assert "No active agent process" in response.json()["detail"]
+
+
 class TestConstitutionAgentHistory:
     @patch('app.export_chat_history')
     def test_constitution_history_success(self, mock_export):
@@ -219,6 +240,27 @@ class TestConstitutionAgentHistory:
         )
 
         assert response.status_code == 500
+
+
+class TestConstitutionAgentCancel:
+    @patch('app.cancel_agent_message')
+    def test_constitution_agent_cancel_success(self, mock_cancel):
+        mock_cancel.return_value = True
+
+        response = client.post("/api/constitutions/sample/agent/cancel")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+        mock_cancel.assert_called_once_with("constitution:sample")
+
+    @patch('app.cancel_agent_message')
+    def test_constitution_agent_cancel_not_found(self, mock_cancel):
+        mock_cancel.return_value = False
+
+        response = client.post("/api/constitutions/sample/agent/cancel")
+
+        assert response.status_code == 404
+        assert "No active agent process" in response.json()["detail"]
 
 
 class TestConstitutionAgentSessions:
@@ -347,6 +389,25 @@ class TestRepositoryEndpoints:
 
         assert response.status_code == 200
         assert response.json() == payload
+
+    @patch('app.cancel_agent_message')
+    def test_repository_agent_cancel_success(self, mock_cancel):
+        mock_cancel.return_value = True
+
+        response = client.post("/api/repositories/sample/agent/cancel")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+        mock_cancel.assert_called_once_with("sample")
+
+    @patch('app.cancel_agent_message')
+    def test_repository_agent_cancel_not_found(self, mock_cancel):
+        mock_cancel.return_value = False
+
+        response = client.post("/api/repositories/sample/agent/cancel")
+
+        assert response.status_code == 404
+        assert "No active agent process" in response.json()["detail"]
 
     @patch('app.get_repository_info')
     def test_get_repository_info_success(self, mock_get_info):


### PR DESCRIPTION
### Motivation
- Allow users to cancel a running `opencode`/agent operation from the UI instead of leaving "Sending..." active.
- Ensure the backend can terminate the underlying subprocess for repository, knowledge, and constitution agent channels.
- Make the UI show a red `Cancel` button while an agent request is active and only restore the `Send` button when the agent is not processing.
- Keep agent state consistent across restarts and surface useful error/status messages when cancellation occurs.

### Description
- Track running `opencode` subprocesses per channel in `agent_service.py` and add `cancel_agent_message(channel)` to terminate and clear tracked processes.
- Switch agent execution from `subprocess.run` to `subprocess.Popen` + `communicate` to enable cancellation and capture `stdout`/`stderr` safely.
- Expose cancel endpoints in the API at `POST /api/{repositories,knowledge,constitutions}/{name}/agent/cancel` implemented in `app.py` and wired to `cancel_agent_message`.
- Wire new cancel APIs into the frontend by adding `cancelRepositoryAgent`, `cancelKnowledgeAgent`, and `cancelConstitutionAgent` to `useApi.ts` and replacing the `chatLoading ? "Sending..." : "Send"` UI with a red `Cancel` button that calls the appropriate cancel API in the repository, knowledge, and constitution pages.
- Update unit tests to mock `subprocess.Popen` instead of `subprocess.run` and add tests covering the new cancel endpoints and Popen-based behavior.

### Testing
- Ran backend unit tests: `cd packages/pybackend && uv run pytest tests/unit/test_unit.py tests/unit/test_api.py` which passed (`88 passed`).
- Executed a Playwright script to exercise the frontend agent flow and capture a screenshot verifying the `Cancel` button appears; the script completed and produced a screenshot artifact.
- Started the backend and frontend locally (`uv run made-backend` and `npm --workspace packages/frontend run dev`) to validate the integrated flow and API connectivity; health and repository endpoints responded as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e71f9d5808332a17cee98385a62f1)