### PR TITLE
Display filestem as command title with description on second line

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -949,18 +949,24 @@ export const RepositoryPage: React.FC = () => {
                   </div>
                 ) : (
                   <div className="commands-grid">
-                    {availableCommands.map((command) => (
-                      <button
-                        key={command.id}
-                        className="primary command-button"
-                        title={`${command.source} • ${command.name}`}
-                        onClick={() => handleCommandSelection(command)}
-                      >
-                        <span className="command-button__title">
-                          {command.description || command.name}
-                        </span>
-                      </button>
-                    ))}
+                    {availableCommands.map((command) => {
+                      const description = command.description || command.name;
+                      return (
+                        <button
+                          key={command.id}
+                          className="primary command-button"
+                          title={`${command.source} • ${command.name}`}
+                          onClick={() => handleCommandSelection(command)}
+                        >
+                          <span className="command-button__title">
+                            {command.name}
+                          </span>
+                          <span className="command-button__description">
+                            {description}
+                          </span>
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </>

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -186,3 +186,7 @@
 .command-button__title {
   font-weight: 600;
 }
+
+.command-button__description {
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
### Motivation
- Surface the command filestem as the primary label so users can identify commands by filename at a glance.
- Move the command description to a secondary, smaller line to avoid repeating the same text twice.
- Remove descriptive brackets and keep the UI concise while preserving existing behavior.

### Description
- Update `packages/frontend/src/pages/RepositoryPage.tsx` to render `command.name` in `.command-button__title` and the description fallback in `.command-button__description` via `const description = command.description || command.name`.
- Preserve the `title` attribute and existing click handler `handleCommandSelection` so selection and tooltips remain unchanged.
- Add a CSS rule for `.command-button__description` in `packages/frontend/src/styles/page.css` to reduce the font size for the secondary line.

### Testing
- Started the frontend dev server with `npm --workspace packages/frontend run dev` and Vite reported ready (succeeded).
- Launched the backend `made-backend` and it started successfully (succeeded).
- Executed a Playwright script that navigated to `/repositories/demo-repo`, opened the Commands tab, and captured a screenshot at `artifacts/user-commands-format.png` (succeeded).
- No automated unit tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fff6b4ce883329f06eaf3b85fca41)