### PR TITLE
Prioritise normalized user text for message deduplication with 300-char cap

### DIFF
--- a/packages/frontend/src/utils/chat.test.ts
+++ b/packages/frontend/src/utils/chat.test.ts
@@ -24,6 +24,30 @@ describe("chat utils", () => {
       expect(buildMessageDedupKey(message)).toBe("agent:stable-key");
     });
 
+    it("prioritises normalized text for user messages", () => {
+      const message: ChatMessage = {
+        id: "msg-1",
+        messageKey: "server-key",
+        role: "user",
+        text: "  Hello there!  ",
+        timestamp: baseTimestamp,
+      };
+
+      expect(buildMessageDedupKey(message)).toBe("user:Hello there!");
+    });
+
+    it("limits user message dedup keys to 300 characters", () => {
+      const longText = "a".repeat(350);
+      const message: ChatMessage = {
+        id: "msg-1",
+        role: "user",
+        text: longText,
+        timestamp: baseTimestamp,
+      };
+
+      expect(buildMessageDedupKey(message)).toBe(`user:${"a".repeat(300)}`);
+    });
+
     it("falls back to normalised text when no key is provided", () => {
       const message: ChatMessage = {
         id: "msg-2",

--- a/packages/frontend/src/utils/chat.ts
+++ b/packages/frontend/src/utils/chat.ts
@@ -24,7 +24,11 @@ export const normalizeChatMessageText = (text: string | undefined | null) => {
 
 export const buildMessageDedupKey = (message: ChatMessage) => {
   const normalizedText = normalizeChatMessageText(message.text);
-  const baseKey = message.messageKey || normalizedText || message.id;
+  const userTextKey = normalizedText.slice(0, 300);
+  const baseKey =
+    message.role === "user"
+      ? userTextKey || message.messageKey || message.id
+      : message.messageKey || normalizedText || message.id;
 
   if (!baseKey) return undefined;
 


### PR DESCRIPTION
### Motivation
- Improve deduplication for user messages by preferring the actual normalized user text when available.
- Avoid overly long dedup keys by capping user text keys to a reasonable length.
- Preserve existing behavior for non-user roles that continue to prefer `messageKey` when present.

### Description
- Change `buildMessageDedupKey` in `packages/frontend/src/utils/chat.ts` to compute `userTextKey` as `normalizeChatMessageText(message.text).slice(0, 300)` and prefer it when `message.role === "user"`.
- Keep the previous fallback order (`messageKey || normalizedText || id`) for non-user roles.
- Add unit tests in `packages/frontend/src/utils/chat.test.ts` to assert that user messages prioritise normalized text and that the dedup key is limited to 300 characters.

### Testing
- Added Vitest unit tests covering user-text priority and the 300-character cap in `chat.test.ts`.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960033497288332833546ad7167beed)