### PR TITLE
Document command discovery locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ $MADE_HOME/.made/
 └── settings.json  # Application settings
 ```
 
+### Command Discovery Locations
+
+MADE loads commands from the following locations (first found are combined):
+
+- `$MADE_HOME/.made/commands/` — pre-installed commands bundled at the MADE home.
+- `$MADE_WORKSPACE_HOME/.made/commands/` — workspace-scoped commands.
+- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/` — user commands.
+- `$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md` — repository-specific commands inside hidden folders.
+
 ## API / Reference
 
 The backend provides a RESTful API with endpoints for:


### PR DESCRIPTION
### Motivation

- Make it explicit where MADE looks for command files so users and operators can add or override commands.  
- Improve discoverability of pre-installed, workspace-scoped, user, and repository-specific command locations.  

### Description

- Added a new `Command Discovery Locations` section to `README.md` that documents the paths MADE scans for commands.  
- The section lists the locations including `'$MADE_HOME/.made/commands/'`, `'$MADE_WORKSPACE_HOME/.made/commands/'`, `'~/.made/commands/'`, `'~/.claude/commands/'`, `'~/.codex/commands/'`, and `'$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md'`.  

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69601bf4b5088332b391ec3ad5cb93e9)