### PR TITLE
Sort file browser entries by name (folders first)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -670,13 +670,29 @@ export const RepositoryPage: React.FC = () => {
     }
   };
 
+  const sortNodes = (nodes?: FileNode[]) => {
+    if (!nodes) return [];
+    return [...nodes].sort((a, b) => {
+      if (a.type !== b.type) {
+        return a.type === "folder" ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    });
+  };
+
   const renderNode = (node: FileNode, depth = 0): React.ReactNode => {
     if (node.path === ".") {
-      return node.children?.map((child) => renderNode(child, depth));
+      return sortNodes(node.children).map((child) =>
+        renderNode(child, depth),
+      );
     }
     const indent = { marginLeft: depth * 16 };
     const isFolder = node.type === "folder";
     const isExpanded = expanded.has(node.path);
+    const sortedChildren = sortNodes(node.children);
 
     const handleFolderToggle = () => toggleFolder(node.path);
     const handleToggleKeyDown = (event: React.KeyboardEvent) => {
@@ -761,7 +777,7 @@ export const RepositoryPage: React.FC = () => {
         </div>
         {isFolder &&
           isExpanded &&
-          node.children?.map((child) => renderNode(child, depth + 1))}
+          sortedChildren.map((child) => renderNode(child, depth + 1))}
       </div>
     );
   };


### PR DESCRIPTION
### Motivation
- Ensure the file browser lists entries in a predictable order: folders grouped first and then files, with entries sorted alphabetically by name. 
- Improve usability when navigating repositories with many files and nested folders. 

### Description
- Added a `sortNodes` helper to `packages/frontend/src/pages/RepositoryPage.tsx` that returns nodes with folders first and then items ordered via `a.name.localeCompare(...)`.
- Apply `sortNodes` when rendering the root node and when rendering a folder's children so both top-level and nested listings are ordered.
- No UI or API contract changes were made; the change only affects client-side rendering order.

### Testing
- Ran unit tests with `npm --workspace packages/frontend run test` (Vitest), which produced 13 passing tests and 1 failing test: `src/utils/chat.test.ts > mergeChatMessages > uses message IDs for user history entries when available`.
- Launched the frontend dev server with `npm --workspace packages/frontend run dev -- --host 0.0.0.0 --port 4173` and executed an automated Playwright script to capture a screenshot of the File Browser tab, which completed and produced `artifacts/file-browser.png`.
- The failing Vitest spec is unrelated to the file-browser sorting change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a1184454833282d9150a4a8dfc56)