### PR TITLE
Add .kiro to command discovery locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ MADE loads commands from the following locations (first found are combined):
 
 - `$MADE_HOME/.made/commands/` — pre-installed commands bundled at the MADE home.
 - `$MADE_WORKSPACE_HOME/.made/commands/` — workspace-scoped commands.
-- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/` — user commands.
+- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/`, `~/.kiro/commands/` — user commands.
 - `$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md` — repository-specific commands inside hidden folders.
 
 ## API / Reference

--- a/packages/pybackend/command_service.py
+++ b/packages/pybackend/command_service.py
@@ -53,6 +53,7 @@ def list_commands(repo_name: str) -> List[Dict[str, Any]]:
         (Path.home() / ".made" / "commands", "user"),
         (Path.home() / ".claude" / "commands", "user"),
         (Path.home() / ".codex" / "commands", "user"),
+        (Path.home() / ".kiro" / "commands", "user"),
     ]
 
     for directory, source in command_roots:

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -40,6 +40,7 @@ def test_list_commands_collects_all_locations(temp_env):
     made_command = made_home / ".made" / "commands" / "made.md"
     user_command = user_home / ".made" / "commands" / "user.md"
     codex_command = user_home / ".codex" / "commands" / "codex.md"
+    kiro_command = user_home / ".kiro" / "commands" / "kiro.md"
 
     for path in [
         repo_path,
@@ -47,6 +48,7 @@ def test_list_commands_collects_all_locations(temp_env):
         made_home / ".made" / "commands",
         user_home / ".made" / "commands",
         user_home / ".codex" / "commands",
+        user_home / ".kiro" / "commands",
     ]:
         path.mkdir(parents=True, exist_ok=True)
 
@@ -55,16 +57,18 @@ def test_list_commands_collects_all_locations(temp_env):
     write_command_file(made_command, "Made command", "[arg]", "run $1")
     write_command_file(user_command, "User command", None, "say hi")
     write_command_file(codex_command, None, "[num]", "count $1")
+    write_command_file(kiro_command, None, None, "kiro content")
 
     commands = list_commands("sample-repo")
 
-    assert len(commands) == 5
+    assert len(commands) == 6
     descriptions = {command["description"] for command in commands}
     assert "Repo command" in descriptions
     assert "workspace" in descriptions
     assert "Made command" in descriptions
     assert "User command" in descriptions
     assert "codex" in descriptions
+    assert "kiro" in descriptions
 
     repo_entry = next(cmd for cmd in commands if cmd["name"] == "repo")
     assert repo_entry["argumentHint"] == "[name]"


### PR DESCRIPTION
### Motivation

- Support commands installed under Kiro by including `~/.kiro/commands` in the set of user command locations.
- Ensure the backend discovers Kiro-provided command markdown files in the same way it does for Claude and Codex.
- Keep documentation in sync with runtime behavior by listing the new location in the README.

### Description

- Updated `list_commands` in `packages/pybackend/command_service.py` to include `(Path.home() / ".kiro" / "commands", "user")` among `command_roots` so Kiro commands are discovered.
- Extended `packages/pybackend/tests/unit/test_command_service.py` to create a `~/.kiro/commands/kiro.md` test file and updated assertions to expect the extra command.
- Updated `README.md` to document `~/.kiro/commands/` in the Command Discovery Locations section.

### Testing

- Attempted to run `pytest packages/pybackend/tests/unit/test_command_service.py`, but the run failed because the local `pytest.ini` injects coverage options and the environment lacks the required coverage plugins.
- The unit test file was updated to reflect the new expected command count and assertions for the `kiro` command, but automated execution was blocked by the pytest configuration.
- Applied patches and validated the modified files are syntactically correct via simple file updates (no runtime errors observed from the edits themselves).
- No other automated tests (e.g., integration or system tests) were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613e768e14833292ed01b43e2ebe34)