### PR TITLE
Add .opencode/command user command discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ MADE loads commands from the following locations (first found are combined):
 
 - `$MADE_HOME/.made/commands/` — pre-installed commands bundled at the MADE home.
 - `$MADE_WORKSPACE_HOME/.made/commands/` — workspace-scoped commands.
-- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/`, `~/.kiro/commands/` — user commands.
+- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/`, `~/.kiro/commands/`, `~/.opencode/command/` — user commands.
 - `$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md` — repository-specific commands inside hidden folders.
 
 ## API / Reference

--- a/packages/pybackend/command_service.py
+++ b/packages/pybackend/command_service.py
@@ -54,6 +54,7 @@ def list_commands(repo_name: str) -> List[Dict[str, Any]]:
         (Path.home() / ".claude" / "commands", "user"),
         (Path.home() / ".codex" / "commands", "user"),
         (Path.home() / ".kiro" / "commands", "user"),
+        (Path.home() / ".opencode" / "command", "user"),
     ]
 
     for directory, source in command_roots:

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -41,6 +41,7 @@ def test_list_commands_collects_all_locations(temp_env):
     user_command = user_home / ".made" / "commands" / "user.md"
     codex_command = user_home / ".codex" / "commands" / "codex.md"
     kiro_command = user_home / ".kiro" / "commands" / "kiro.md"
+    opencode_command = user_home / ".opencode" / "command" / "opencode.md"
 
     for path in [
         repo_path,
@@ -49,6 +50,7 @@ def test_list_commands_collects_all_locations(temp_env):
         user_home / ".made" / "commands",
         user_home / ".codex" / "commands",
         user_home / ".kiro" / "commands",
+        user_home / ".opencode" / "command",
     ]:
         path.mkdir(parents=True, exist_ok=True)
 
@@ -58,10 +60,11 @@ def test_list_commands_collects_all_locations(temp_env):
     write_command_file(user_command, "User command", None, "say hi")
     write_command_file(codex_command, None, "[num]", "count $1")
     write_command_file(kiro_command, None, None, "kiro content")
+    write_command_file(opencode_command, None, None, "opencode content")
 
     commands = list_commands("sample-repo")
 
-    assert len(commands) == 6
+    assert len(commands) == 7
     descriptions = {command["description"] for command in commands}
     assert "Repo command" in descriptions
     assert "workspace" in descriptions
@@ -69,10 +72,12 @@ def test_list_commands_collects_all_locations(temp_env):
     assert "User command" in descriptions
     assert "codex" in descriptions
     assert "kiro" in descriptions
+    assert "opencode" in descriptions
 
     repo_entry = next(cmd for cmd in commands if cmd["name"] == "repo")
     assert repo_entry["argumentHint"] == "[name]"
     assert repo_entry["content"] == "echo $1"
+
 
 def test_description_defaults_to_stem(temp_env):
     workspace, made_home, user_home = temp_env


### PR DESCRIPTION
### Motivation

- Add support for another user command location so commands placed under `.opencode/command/` are discovered like existing agent folders such as `.claude` and `.codex`.
- Keep documentation consistent with the backend behavior by listing the new path in the README `Command Discovery Locations` section.
- Ensure behavior is covered by unit tests so the new discovery path is validated by the test suite.

### Description

- Add `(Path.home() / ".opencode" / "command", "user")` to the `command_roots` in `list_commands` inside `packages/pybackend/command_service.py`.
- Document the new user command location in `README.md` under `Command Discovery Locations` as `~/.opencode/command/`.
- Extend `packages/pybackend/tests/unit/test_command_service.py` to create an `opencode` command file and assert the commands list grows to include the `opencode` entry and increases the expected count from 6 to 7.

### Testing

- Ran the unit test file with `cd packages/pybackend && pytest tests/unit/test_command_service.py` which failed to run due to `pytest.ini` adding coverage flags (`--cov`) while the `pytest-cov` plugin is not available in this environment.
- No further automated test runs were completed because the above `pytest` invocation aborted with the plugin/coverage configuration error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963493c7e208332a9fb10fe34291c03)