### PR TITLE
Add .kiro/prompts to command discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ $MADE_HOME/.made/
 
 MADE loads commands from the following locations (first found are combined):
 
-- `$MADE_HOME/.made/commands/` — pre-installed commands bundled at the MADE home.
-- `$MADE_WORKSPACE_HOME/.made/commands/` — workspace-scoped commands.
-- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/`, `~/.kiro/commands/`, `~/.opencode/command/` — user commands.
+- `$MADE_HOME/.made/commands/`, `$MADE_HOME/.kiro/prompts/` — pre-installed commands bundled at the MADE home.
+- `$MADE_WORKSPACE_HOME/.made/commands/`, `$MADE_WORKSPACE_HOME/.kiro/prompts/` — workspace-scoped commands.
+- `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/`, `~/.kiro/commands/`, `~/.kiro/prompts/`, `~/.opencode/command/` — user commands.
 - `$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md` — repository-specific commands inside hidden folders.
 
 ## API / Reference

--- a/packages/pybackend/command_service.py
+++ b/packages/pybackend/command_service.py
@@ -50,10 +50,13 @@ def list_commands(repo_name: str) -> List[Dict[str, Any]]:
     command_roots: List[Tuple[Path, str]] = [
         (get_made_home() / ".made" / "commands", "made"),
         (get_workspace_home() / ".made" / "commands", "workspace"),
+        (get_made_home() / ".kiro" / "prompts", "made"),
+        (get_workspace_home() / ".kiro" / "prompts", "workspace"),
         (Path.home() / ".made" / "commands", "user"),
         (Path.home() / ".claude" / "commands", "user"),
         (Path.home() / ".codex" / "commands", "user"),
         (Path.home() / ".kiro" / "commands", "user"),
+        (Path.home() / ".kiro" / "prompts", "user"),
         (Path.home() / ".opencode" / "command", "user"),
     ]
 

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -41,16 +41,22 @@ def test_list_commands_collects_all_locations(temp_env):
     user_command = user_home / ".made" / "commands" / "user.md"
     codex_command = user_home / ".codex" / "commands" / "codex.md"
     kiro_command = user_home / ".kiro" / "commands" / "kiro.md"
+    made_kiro_prompt = made_home / ".kiro" / "prompts" / "made-prompt.md"
+    workspace_kiro_prompt = workspace / ".kiro" / "prompts" / "workspace-prompt.md"
+    user_kiro_prompt = user_home / ".kiro" / "prompts" / "user-prompt.md"
     opencode_command = user_home / ".opencode" / "command" / "opencode.md"
 
     for path in [
         repo_path,
         workspace / ".made" / "commands",
         made_home / ".made" / "commands",
+        made_home / ".kiro" / "prompts",
         user_home / ".made" / "commands",
         user_home / ".codex" / "commands",
         user_home / ".kiro" / "commands",
+        user_home / ".kiro" / "prompts",
         user_home / ".opencode" / "command",
+        workspace / ".kiro" / "prompts",
     ]:
         path.mkdir(parents=True, exist_ok=True)
 
@@ -60,11 +66,14 @@ def test_list_commands_collects_all_locations(temp_env):
     write_command_file(user_command, "User command", None, "say hi")
     write_command_file(codex_command, None, "[num]", "count $1")
     write_command_file(kiro_command, None, None, "kiro content")
+    write_command_file(made_kiro_prompt, None, None, "made prompt content")
+    write_command_file(workspace_kiro_prompt, None, None, "workspace prompt content")
+    write_command_file(user_kiro_prompt, None, None, "user prompt content")
     write_command_file(opencode_command, None, None, "opencode content")
 
     commands = list_commands("sample-repo")
 
-    assert len(commands) == 7
+    assert len(commands) == 10
     descriptions = {command["description"] for command in commands}
     assert "Repo command" in descriptions
     assert "workspace" in descriptions
@@ -72,6 +81,9 @@ def test_list_commands_collects_all_locations(temp_env):
     assert "User command" in descriptions
     assert "codex" in descriptions
     assert "kiro" in descriptions
+    assert "made-prompt" in descriptions
+    assert "workspace-prompt" in descriptions
+    assert "user-prompt" in descriptions
     assert "opencode" in descriptions
 
     repo_entry = next(cmd for cmd in commands if cmd["name"] == "repo")


### PR DESCRIPTION
### Motivation
- Ensure `.kiro/prompts` files are discovered alongside existing command locations so Kiro prompt files behave like other user-command sources.
- Match workspace- and MADE-level prompt directories to user-level locations for consistency across discovery roots.
- Make prompt locations discoverable by the backend API that powers the repository UI and agent integrations.

### Description
- Updated `list_commands` in `packages/pybackend/command_service.py` to include `get_made_home() / .kiro / prompts`, `get_workspace_home() / .kiro / prompts`, and `Path.home() / .kiro / prompts` as discovery roots.
- Expanded `packages/pybackend/tests/unit/test_command_service.py` to create sample `.kiro/prompts` files at MADE, workspace, and user locations and adjusted expectations to include them.
- Documented the new locations in the README under the "Command Discovery Locations" section by adding `.kiro/prompts` entries for MADE, workspace, and user scopes.

### Testing
- Ran the updated unit test file with `pytest packages/pybackend/tests/unit/test_command_service.py` to exercise the new discovery paths.
- The `pytest` invocation failed in this environment because `pytest.ini` injects unsupported coverage arguments, causing `pytest` to exit with an error.
- No additional automated tests (integration or system) were executed in this rollout due to the local pytest environment limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963cc453e548332821a39bab9574759)