### PR TITLE
Handle invalid command frontmatter when listing commands

### DIFF
--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -103,3 +103,18 @@ def test_description_defaults_to_stem(temp_env):
     assert len(commands) == 1
     assert commands[0]["description"] == "no-meta"
     assert commands[0]["content"] == "Plain content"
+
+
+def test_invalid_frontmatter_is_skipped(temp_env):
+    workspace, made_home, user_home = temp_env
+    repo_path = workspace / "bad-repo"
+    good_command = repo_path / ".claude" / "commands" / "good.md"
+    bad_command = repo_path / ".claude" / "commands" / "bad.md"
+    good_command.parent.mkdir(parents=True, exist_ok=True)
+    write_command_file(good_command, "Good command", None, "echo ok")
+    bad_command.write_text('---\ndescription: "broken\n---\nfail\n', encoding="utf-8")
+
+    commands = list_commands("bad-repo")
+
+    assert len(commands) == 1
+    assert commands[0]["name"] == "good"


### PR DESCRIPTION
### Motivation
- Listing repository commands failed with a YAML parse error when a single command file contained malformed frontmatter, causing the whole listing to 500. 
- The intent is to make command discovery robust: ignore/skipping invalid command files instead of failing the entire operation. 

### Description
- Add `logging` and `yaml` imports and make `_load_command_file` tolerant to malformed frontmatter by catching `yaml.YAMLError` and `ValueError` and returning `None` for bad files. 
- Use `Optional[Dict]` return type for `_load_command_file` and filter out `None` results when collecting commands from directories and repositories. 
- Preserve existing metadata/behavior for valid files and retain `id`, `name`, `description`, `content`, `metadata`, and `argumentHint` fields. 
- Add unit test `test_invalid_frontmatter_is_skipped` in `packages/pybackend/tests/unit/test_command_service.py` to cover the new behavior. 

### Testing
- Added unit test `test_invalid_frontmatter_is_skipped` that creates one valid and one invalid frontmatter file and asserts only the valid file is returned. 
- Ran `pytest packages/pybackend/tests/unit/test_command_service.py`, but the run failed immediately due to pytest reading `pytest.ini` and passing `--cov` options that are not supported in the current environment (unrecognized `--cov` arguments). 
- Existing unit tests in the file are unchanged and expected to pass under a properly provisioned test environment with `pytest-cov` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d705434083328e69935c5fc2c597)