### PR TITLE
Strip parenthetical comments from command frontmatter and argument hints

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -42,6 +42,7 @@ const stripCommandFrontmatter = (content: string) => {
 };
 
 const ARGUMENT_SPECIFIER_PATTERN = /\[([^\]]+)\]|<([^>]+)>/g;
+const PARENTHETICAL_COMMENT_PATTERN = /\s*\([^()]*\)\s*$/g;
 
 type HarnessRun = {
   pid: number;
@@ -55,9 +56,15 @@ type ArgumentHint = string | string[] | null | undefined;
 const normalizeArgumentHint = (argumentHint: ArgumentHint) => {
   if (!argumentHint) return "";
   if (Array.isArray(argumentHint)) {
-    return argumentHint.filter((value) => typeof value === "string").join(" ");
+    return argumentHint
+      .filter((value) => typeof value === "string")
+      .map((value) => value.replace(PARENTHETICAL_COMMENT_PATTERN, "").trim())
+      .filter(Boolean)
+      .join(" ");
   }
-  return typeof argumentHint === "string" ? argumentHint : "";
+  return typeof argumentHint === "string"
+    ? argumentHint.replace(PARENTHETICAL_COMMENT_PATTERN, "").trim()
+    : "";
 };
 
 const extractArgumentLabels = (argumentHint?: ArgumentHint) => {

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -118,3 +118,24 @@ def test_invalid_frontmatter_is_skipped(temp_env):
 
     assert len(commands) == 1
     assert commands[0]["name"] == "good"
+
+
+def test_parenthetical_comments_are_ignored_in_frontmatter(temp_env):
+    workspace, _, _ = temp_env
+    repo_path = workspace / "comment-repo"
+    command_path = repo_path / ".claude" / "commands" / "commented.md"
+    command_path.parent.mkdir(parents=True, exist_ok=True)
+    command_path.write_text(
+        "---\n"
+        "description: Commented command (internal note)\n"
+        "argument-hint: [feature/product idea] (blank = start with questions)\n"
+        "---\n"
+        "echo run\n",
+        encoding="utf-8",
+    )
+
+    commands = list_commands("comment-repo")
+
+    assert len(commands) == 1
+    assert commands[0]["description"] == "Commented command"
+    assert commands[0]["argumentHint"] == "[feature/product idea]"


### PR DESCRIPTION
### Motivation
- Some command frontmatter and `argument-hint` strings include explanatory comments in round parentheses which cause YAML parsing issues or display unwanted text.
- The frontmatter parser should ignore trailing parenthetical comments so metadata values are parsed cleanly.
- The repository UI should display normalized argument hints with those parenthetical notes removed for clarity.
- Preserve existing behavior for files without parenthetical comments.

### Description
- Added `_sanitize_frontmatter`, `_strip_parenthetical_comment`, and `_PAREN_COMMENT_PATTERN` to `packages/pybackend/command_service.py` to strip trailing parenthetical comments from frontmatter lines before calling `frontmatter.loads`.
- Updated `_load_command_file` to read raw file text and use the sanitizer instead of `frontmatter.load`.
- Added `PARENTHETICAL_COMMENT_PATTERN` and updated `normalizeArgumentHint` in `packages/frontend/src/pages/RepositoryPage.tsx` to remove trailing parenthetical comments from argument hint strings and arrays.
- Added unit test `test_parenthetical_comments_are_ignored_in_frontmatter` in `packages/pybackend/tests/unit/test_command_service.py` to cover the new behavior.

### Testing
- Added a unit test that asserts parenthetical comments are removed from `description` and `argument-hint` metadata when reading a command file.
- Ran `pytest packages/pybackend/tests/unit/test_command_service.py` which failed due to `pytest.ini` injecting `--cov` options while the `pytest-cov` plugin is not installed in the environment.
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963da1ec65083328e9ff4f51ccd4965)