### PR TITLE
Add repository prompt discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ MADE loads commands from the following locations (first found are combined):
 - `$MADE_HOME/.made/commands/`, `$MADE_HOME/.kiro/prompts/` — pre-installed commands bundled at the MADE home.
 - `$MADE_WORKSPACE_HOME/.made/commands/`, `$MADE_WORKSPACE_HOME/.kiro/prompts/` — workspace-scoped commands.
 - `~/.made/commands/`, `~/.claude/commands/`, `~/.codex/commands/`, `~/.kiro/commands/`, `~/.kiro/prompts/`, `~/.opencode/command/` — user commands.
-- `$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md` — repository-specific commands inside hidden folders.
+- `$MADE_WORKSPACE_HOME/<repo>/.*/commands/**/*.md`, `$MADE_WORKSPACE_HOME/<repo>/.*/prompts/**/*.md` — repository-specific commands inside hidden folders.
 
 ## API / Reference
 

--- a/packages/pybackend/command_service.py
+++ b/packages/pybackend/command_service.py
@@ -83,6 +83,9 @@ def _load_repo_commands(repo_name: str) -> List[Dict[str, Any]]:
         for path in repo_path.glob(".*/commands/**/*.md"):
             if path.is_file():
                 command_files.append((path, "repository"))
+        for path in repo_path.glob(".*/prompts/**/*.md"):
+            if path.is_file():
+                command_files.append((path, "repository"))
 
     commands = (_load_command_file(path, source) for path, source in sorted(command_files))
     return [command for command in commands if command]

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -36,6 +36,7 @@ def test_list_commands_collects_all_locations(temp_env):
     workspace, made_home, user_home = temp_env
     repo_path = workspace / "sample-repo"
     repo_command = repo_path / ".hidden" / "commands" / "repo.md"
+    repo_prompt = repo_path / ".hidden" / "prompts" / "repo-prompt.md"
     workspace_command = workspace / ".made" / "commands" / "workspace.md"
     made_command = made_home / ".made" / "commands" / "made.md"
     user_command = user_home / ".made" / "commands" / "user.md"
@@ -61,6 +62,7 @@ def test_list_commands_collects_all_locations(temp_env):
         path.mkdir(parents=True, exist_ok=True)
 
     write_command_file(repo_command, "Repo command", "[name]", "echo $1")
+    write_command_file(repo_prompt, None, None, "repo prompt")
     write_command_file(workspace_command, None, None, "workspace content")
     write_command_file(made_command, "Made command", "[arg]", "run $1")
     write_command_file(user_command, "User command", None, "say hi")
@@ -73,9 +75,10 @@ def test_list_commands_collects_all_locations(temp_env):
 
     commands = list_commands("sample-repo")
 
-    assert len(commands) == 10
+    assert len(commands) == 11
     descriptions = {command["description"] for command in commands}
     assert "Repo command" in descriptions
+    assert "repo-prompt" in descriptions
     assert "workspace" in descriptions
     assert "Made command" in descriptions
     assert "User command" in descriptions


### PR DESCRIPTION
### Motivation

- Allow repository-scoped prompt files stored in hidden folders to be discovered alongside repository commands.
- Bring repository behavior for `prompts/**/*.md` in line with other prompt/command discovery locations.
- Ensure prompts in repo hidden directories are surfaced by the backend command listing API.

### Description

- Extend `_load_repo_commands` in `command_service.py` to include `repo_path.glob(".*/prompts/**/*.md")` as repository sources.
- Update the unit test `test_list_commands_collects_all_locations` in `packages/pybackend/tests/unit/test_command_service.py` to create a `repo-prompt` file and expect it in the results.
- Document the new discovery path in `README.md` under "Command Discovery Locations".

### Testing

- Ran `pytest packages/pybackend/tests/unit/test_command_service.py`, which failed during collection due to a missing `frontmatter` dependency (ModuleNotFoundError).
- No other automated test failures were produced by the changes themselves because test execution was blocked by the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69640adf540c8332a0d2d54ea2f18ae5)