### PR TITLE
Add source badges to user command cards

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -93,6 +93,21 @@ const formatHarnessTimestamp = (value: string) => {
   return new Date(parsed).toLocaleString();
 };
 
+const formatCommandSourceLabel = (source: string) => {
+  switch (source) {
+    case "user":
+      return "USER (HOME)";
+    case "made":
+      return "MADE (MADE HOME)";
+    case "workspace":
+      return "WS (MADE Workspace)";
+    case "repository":
+      return "REPO";
+    default:
+      return source.toUpperCase();
+  }
+};
+
 const COMMAND_ACTIONS = [
   {
     id: "init-openspec",
@@ -1304,6 +1319,9 @@ export const RepositoryPage: React.FC = () => {
                           title={`${command.source} • ${command.name}`}
                           onClick={() => handleCommandSelection(command)}
                         >
+                          <span className="command-button__badge">
+                            {formatCommandSourceLabel(command.source)}
+                          </span>
                           <span className="command-button__title">
                             {command.name}
                           </span>

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -175,12 +175,28 @@
 }
 
 .command-button {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 0.35rem;
   text-align: left;
   width: 100%;
+}
+
+.command-button__badge {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.95);
 }
 
 .command-button__title {


### PR DESCRIPTION
### Motivation
- Make it easier to see where user commands come from by showing a compact source tag on each command card.
- Differentiate commands from `user`, `made`, `workspace`, and `repository` locations at-a-glance.
- Improve discoverability and reduce confusion when multiple command sources are configured.

### Description
- Add a `formatCommandSourceLabel` helper to map `source` keys to human-friendly labels (e.g. `USER (HOME)`, `MADE (MADE HOME)`, `WS (MADE Workspace)`, `REPO`).
- Render a badge in the command tiles by inserting `<span className="command-button__badge">{formatCommandSourceLabel(command.source)}</span>` in `RepositoryPage.tsx`.
- Add CSS for `.command-button__badge` and make `.command-button` `position: relative` to position the badge in the top-right corner in `packages/frontend/src/styles/page.css`.
- Modified files: `packages/frontend/src/pages/RepositoryPage.tsx` and `packages/frontend/src/styles/page.css`.

### Testing
- Started the backend and frontend and verified the API responded to `GET /api/repositories` using a `curl` check (service reachable).
- Captured a Playwright screenshot of the Commands tab showing badges (`artifacts/commands-badges.png`) to visually confirm placement and styling.
- Ran frontend unit tests with `npm --workspace packages/frontend run test`; test run executed 14 tests with `13 passed` and `1 failed` (failing: `src/utils/chat.test.ts > mergeChatMessages > uses message IDs for user history entries when available`).
- No additional automated backend test failures were introduced by these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641b776db48332a72873a39449440d)