### PR TITLE
Deduplicate command files by path

### DIFF
--- a/packages/pybackend/command_service.py
+++ b/packages/pybackend/command_service.py
@@ -110,4 +110,23 @@ def list_commands(repo_name: str) -> List[Dict[str, Any]]:
         commands.extend(_load_commands_from_dir(directory, source))
 
     commands.extend(_load_repo_commands(repo_name))
-    return commands
+    return _dedupe_commands_by_path(commands)
+
+
+def _dedupe_commands_by_path(commands: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen: set[str] = set()
+    deduped: List[Dict[str, Any]] = []
+    for command in commands:
+        path_value = command.get("path")
+        if not path_value:
+            deduped.append(command)
+            continue
+        try:
+            path_key = str(Path(path_value).resolve())
+        except OSError:
+            path_key = str(Path(path_value))
+        if path_key in seen:
+            continue
+        seen.add(path_key)
+        deduped.append(command)
+    return deduped

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -142,3 +142,19 @@ def test_parenthetical_comments_are_ignored_in_frontmatter(temp_env):
     assert len(commands) == 1
     assert commands[0]["description"] == "Commented command"
     assert commands[0]["argumentHint"] == ["feature/product idea"]
+
+
+def test_list_commands_dedupes_identical_command_paths(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("MADE_HOME", str(workspace))
+    monkeypatch.setenv("MADE_WORKSPACE_HOME", str(workspace))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "user_home")
+
+    command_path = workspace / ".made" / "commands" / "shared.md"
+    write_command_file(command_path, "Shared command", None, "echo shared")
+
+    commands = list_commands("repo")
+
+    assert len(commands) == 1
+    assert commands[0]["description"] == "Shared command"


### PR DESCRIPTION
### Motivation
- Prevent the same command file from being reported multiple times when command roots overlap (for example when `MADE_HOME` and workspace share the same path). 
- Ensure `list_commands` returns a single canonical entry per real file by normalizing paths.

### Description
- Added `_dedupe_commands_by_path` which resolves command file paths and removes duplicates based on the resolved full path. 
- Updated `list_commands` to return the deduplicated results via `_dedupe_commands_by_path`. 
- Added unit test `test_list_commands_dedupes_identical_command_paths` to cover the deduplication behavior. 
- Modified files: `packages/pybackend/command_service.py` and `packages/pybackend/tests/unit/test_command_service.py`.

### Testing
- Ran `pytest tests/unit/test_command_service.py`, which failed during collection with `ModuleNotFoundError: No module named 'frontmatter'`. 
- The new unit test was added but could not be executed successfully due to the missing test dependency, so no further automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641c2be330833291da042e20182cd5)