### PR TITLE
Style command source badges as small colored overlays

### DIFF
--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -186,17 +186,20 @@
 
 .command-button__badge {
   position: absolute;
-  top: 0.6rem;
-  right: 0.6rem;
-  padding: 0.15rem 0.45rem;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.1rem 0.4rem;
   border-radius: 999px;
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   font-weight: 600;
   letter-spacing: 0.08em;
+  line-height: 1.1;
   text-transform: uppercase;
-  background: rgba(15, 23, 42, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(14, 116, 144, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.5);
   color: rgba(255, 255, 255, 0.95);
+  z-index: 1;
+  box-shadow: 0 6px 16px rgba(8, 47, 73, 0.35);
 }
 
 .command-button__title {


### PR DESCRIPTION
### Motivation
- The source label for user commands was rendered as plain text instead of a small overlay badge, so make it a compact, colored badge positioned in the top-right of each command pill.

### Description
- Adjusted `.command-button__badge` placement and sizing for a tighter top-right overlay by changing `top`, `right`, `padding`, and `font-size` in `packages/frontend/src/styles/page.css`.
- Improved readability and visual prominence by adding `line-height`, a solid colored `background`, stronger `border` contrast, `z-index`, and a subtle `box-shadow`.
- The change only touches the frontend stylesheet and does not modify component markup or behavior.
- Added a preview screenshot to verify the badge overlay visually (captured via Playwright during verification).

### Testing
- Ran a Playwright script that navigated to the Commands panel and captured a screenshot, which completed successfully and produced `artifacts/commands-badge.png`.
- Ran frontend unit tests with `npm --workspace packages/frontend run test` (Vitest), which produced 13 passing tests and 1 failing test in `src/utils/chat.test.ts` for `mergeChatMessages` where a length expectation failed.
- No backend unit tests were run as part of this change.
- Dev servers were started (`uvicorn` and `vite`) to exercise the UI while capturing the visual verification, and they came up successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641f536d64833283d078eb8ed48559)