### PR TITLE
Shorten command source badges to 4-letter labels

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -96,11 +96,11 @@ const formatHarnessTimestamp = (value: string) => {
 const formatCommandSourceLabel = (source: string) => {
   switch (source) {
     case "user":
-      return "USER (HOME)";
+      return "USER";
     case "made":
-      return "MADE (MADE HOME)";
+      return "MADE";
     case "workspace":
-      return "WS (MADE Workspace)";
+      return "WS";
     case "repository":
       return "REPO";
     default:


### PR DESCRIPTION
### Motivation
- The UI displayed verbose command source badges like `USER (HOME)` and `MADE (MADE HOME)`, which exceed the requested four-letter format.
- The change aims to remove bracketed descriptors and limit badges to at most four characters for clarity and consistency.

### Description
- Simplified the command source label logic in `packages/frontend/src/pages/RepositoryPage.tsx` by updating `formatCommandSourceLabel` to return `USER`, `MADE`, `WS`, and `REPO` for the known sources. 
- This removes the extra parenthetical text previously appended to those badges. 
- No other UI or backend behavior was modified.

### Testing
- Started the frontend dev server with `npm run dev:frontend` and Vite reported readiness at `http://localhost:5173/`, which succeeded. 
- Ran a Playwright script that opened the app and captured `artifacts/repository-badges.png`, which produced the screenshot successfully. 
- The Vite dev server logged `ECONNREFUSED` proxy errors for `/api/repositories`, indicating the backend was not running and causing API requests to fail. 
- No automated unit or CI tests were executed for this small frontend-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964214f9f848332991f7c3ac15cc50a)