### PR TITLE
Include agent details in listings and support selecting agent for messages

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -22,6 +22,7 @@ from agent_service import (
     cancel_agent_message,
     export_chat_history,
     get_channel_status,
+    list_agents,
     list_chat_sessions,
     send_agent_message,
 )
@@ -145,6 +146,18 @@ def dashboard():
         return get_dashboard_summary()
     except Exception as exc:  # pragma: no cover - passthrough errors
         logger.exception("Failed to fetch dashboard summary")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.get("/api/agents")
+def list_available_agents():
+    try:
+        logger.info("Listing available agents")
+        return {"agents": list_agents()}
+    except Exception as exc:
+        logger.exception("Failed to list available agents")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         )
@@ -320,17 +333,19 @@ def delete_repository_file_endpoint(name: str, payload: dict = Body(...)):
 def repository_agent(name: str, payload: dict = Body(...)):
     message = payload.get("message")
     session_id = payload.get("sessionId")
+    agent = payload.get("agent")
     if not message:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
     try:
         logger.info(
-            "Forwarding agent message for repository '%s' (session: %s)",
+            "Forwarding agent message for repository '%s' (session: %s, agent: %s)",
             name,
             session_id or "new",
+            agent or "default",
         )
-        return send_agent_message(name, message, session_id)
+        return send_agent_message(name, message, session_id, agent)
     except ChannelBusyError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 
@@ -570,17 +585,19 @@ def knowledge_write(name: str, payload: dict = Body(...)):
 def knowledge_agent(name: str, payload: dict = Body(...)):
     message = payload.get("message")
     session_id = payload.get("sessionId")
+    agent = payload.get("agent")
     if not message:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
     try:
         logger.info(
-            "Forwarding agent message for knowledge '%s' (session: %s)",
+            "Forwarding agent message for knowledge '%s' (session: %s, agent: %s)",
             name,
             session_id or "new",
+            agent or "default",
         )
-        return send_agent_message(f"knowledge:{name}", message, session_id)
+        return send_agent_message(f"knowledge:{name}", message, session_id, agent)
     except ChannelBusyError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 
@@ -695,17 +712,19 @@ def constitution_write(name: str, payload: dict = Body(...)):
 def constitution_agent(name: str, payload: dict = Body(...)):
     message = payload.get("message")
     session_id = payload.get("sessionId")
+    agent = payload.get("agent")
     if not message:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Message is required"
         )
     try:
         logger.info(
-            "Forwarding agent message for constitution '%s' (session: %s)",
+            "Forwarding agent message for constitution '%s' (session: %s, agent: %s)",
             name,
             session_id or "new",
+            agent or "default",
         )
-        return send_agent_message(f"constitution:{name}", message, session_id)
+        return send_agent_message(f"constitution:{name}", message, session_id, agent)
     except ChannelBusyError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -57,6 +57,31 @@ class TestDashboardEndpoint:
         assert "Dashboard error" in response.json()["detail"]
 
 
+class TestAgentsEndpoint:
+    """Test the agents endpoint."""
+
+    @patch('app.list_agents')
+    def test_list_agents_success(self, mock_list):
+        mock_list.return_value = [
+            {"name": "build", "type": "primary", "details": ["allow: read"]},
+            {"name": "plan", "type": "primary", "details": []},
+        ]
+
+        response = client.get("/api/agents")
+
+        assert response.status_code == 200
+        assert response.json() == {"agents": mock_list.return_value}
+
+    @patch('app.list_agents')
+    def test_list_agents_error(self, mock_list):
+        mock_list.side_effect = Exception("Agent error")
+
+        response = client.get("/api/agents")
+
+        assert response.status_code == 500
+        assert "Agent error" in response.json()["detail"]
+
+
 class TestChatHistoryEndpoint:
     @patch('app.export_chat_history')
     def test_repository_history_success(self, mock_export):
@@ -531,9 +556,9 @@ class TestRepositoryEndpoints:
         payload = {"message": "Test message"}
         
         response = client.post("/api/repositories/test-repo/agent", json=payload)
-        
+
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("test-repo", "Test message", None)
+        mock_agent.assert_called_once_with("test-repo", "Test message", None, None)
 
     @patch('app.send_agent_message')
     def test_repository_agent_with_session_id(self, mock_agent):
@@ -544,7 +569,7 @@ class TestRepositoryEndpoints:
         response = client.post("/api/repositories/test-repo/agent", json=payload)
 
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("test-repo", "Test message", "ses_456")
+        mock_agent.assert_called_once_with("test-repo", "Test message", "ses_456", None)
 
 
 class TestKnowledgeEndpoints:
@@ -600,9 +625,14 @@ class TestKnowledgeEndpoints:
         payload = {"message": "Test message"}
         
         response = client.post("/api/knowledge/test-guide/agent", json=payload)
-        
+
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("knowledge:test-guide", "Test message", None)
+        mock_agent.assert_called_once_with(
+            "knowledge:test-guide",
+            "Test message",
+            None,
+            None,
+        )
 
     @patch('app.send_agent_message')
     def test_knowledge_agent_with_session_id(self, mock_agent):
@@ -613,7 +643,12 @@ class TestKnowledgeEndpoints:
         response = client.post("/api/knowledge/test-guide/agent", json=payload)
 
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("knowledge:test-guide", "Test message", "ses_k")
+        mock_agent.assert_called_once_with(
+            "knowledge:test-guide",
+            "Test message",
+            "ses_k",
+            None,
+        )
 
 
 class TestConstitutionEndpoints:
@@ -660,9 +695,14 @@ class TestConstitutionEndpoints:
         payload = {"message": "Test message"}
         
         response = client.post("/api/constitutions/test-const/agent", json=payload)
-        
+
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("constitution:test-const", "Test message", None)
+        mock_agent.assert_called_once_with(
+            "constitution:test-const",
+            "Test message",
+            None,
+            None,
+        )
 
     @patch('app.send_agent_message')
     def test_constitution_agent_with_session_id(self, mock_agent):
@@ -673,7 +713,12 @@ class TestConstitutionEndpoints:
         response = client.post("/api/constitutions/test-const/agent", json=payload)
 
         assert response.status_code == 200
-        mock_agent.assert_called_once_with("constitution:test-const", "Test message", "ses_c")
+        mock_agent.assert_called_once_with(
+            "constitution:test-const",
+            "Test message",
+            "ses_c",
+            None,
+        )
 
 
 class TestSettingsEndpoints:


### PR DESCRIPTION
### Motivation
- Provide richer agent discovery by capturing per-agent detail lines from `opencode agent list` so UIs can show permissions/details.
- Allow callers to pick which OpenCode agent runs a conversation by wiring an `agent` parameter through the agent command path.

### Description
- Capture detail lines when parsing `opencode agent list` in `_parse_agent_list` and return `details` alongside `name` and `type` in each agent entry.
- Add `--agent` support to the opencode invocation by extending `_build_opencode_command` and accepting an `agent` parameter in `send_agent_message`.
- Expose agent discovery via a new `GET /api/agents` endpoint that returns `{"agents": [...]}` and propagate the `agent` payload through repository/knowledge/constitution agent endpoints to `send_agent_message`.
- Update and add unit tests to cover agent detail parsing and agent parameter forwarding in API and service calls.

### Testing
- Ran `uv run pytest tests/unit/test_unit.py tests/unit/test_api.py` in the package environment. 
- Test result: all tests passed (`92 passed, 1 warning`).
- Specific new/updated tests include `_parse_agent_list` detail parsing and `send_agent_message` invocation with `agent` present.
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b2c2bf308332b0d4eb067c5e93a2)