### PR TITLE
Introduce AgentCLI abstraction for opencode

### DIFF
--- a/packages/pybackend/agent_cli.py
+++ b/packages/pybackend/agent_cli.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+import subprocess
+
+
+class AgentCLI(ABC):
+    @property
+    @abstractmethod
+    def cli_name(self) -> str:
+        raise NotImplementedError
+
+    def missing_command_error(self) -> str:
+        return (
+            f"Error: '{self.cli_name}' command not found. "
+            "Please ensure it is installed and in PATH."
+        )
+
+    @abstractmethod
+    def build_run_command(self, session_id: str | None, agent: str | None) -> list[str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def start_run(self, command: list[str], cwd: Path) -> subprocess.Popen:
+        raise NotImplementedError
+
+    @abstractmethod
+    def export_session(
+        self, session_id: str, cwd: Path | None, stdout
+    ) -> subprocess.CompletedProcess:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_sessions(self, cwd: Path | None) -> subprocess.CompletedProcess:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_agents(self) -> subprocess.CompletedProcess:
+        raise NotImplementedError
+
+
+class OpenCodeAgentCLI(AgentCLI):
+    @property
+    def cli_name(self) -> str:
+        return "opencode"
+
+    def build_run_command(self, session_id: str | None, agent: str | None) -> list[str]:
+        command = ["opencode", "run"]
+        if session_id:
+            command.extend(["-s", session_id])
+        if agent:
+            command.extend(["--agent", agent])
+        command.extend(["--format", "json"])
+        return command
+
+    def start_run(self, command: list[str], cwd: Path) -> subprocess.Popen:
+        return subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+        )
+
+    def export_session(
+        self, session_id: str, cwd: Path | None, stdout
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["opencode", "export", session_id],
+            stdout=stdout,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+        )
+
+    def list_sessions(self, cwd: Path | None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["opencode", "session", "list"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+
+    def list_agents(self) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["opencode", "agent", "list"],
+            capture_output=True,
+            text=True,
+        )

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -4,7 +4,6 @@ These tests mock all external dependencies and focus on business logic.
 """
 
 import pytest
-import subprocess
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock, call, patch
@@ -160,8 +159,8 @@ class TestAgentService:
         assert result == const_dir
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_success(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_success(self, mock_start_run, mock_get_working_dir):
         """Test successful agent message sending."""
         from agent_service import send_agent_message
 
@@ -172,19 +171,15 @@ class TestAgentService:
         mock_process = Mock()
         mock_process.returncode = 0
         mock_process.communicate.return_value = ("Agent response content", "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         # Test successful message
         result = send_agent_message("test-repo", "Hello agent")
         
-        # Verify subprocess call
-        mock_subprocess_popen.assert_called_once_with(
+        # Verify CLI call
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         mock_process.communicate.assert_called_once_with(input="Hello agent")
         
@@ -199,8 +194,8 @@ class TestAgentService:
         assert result["responses"] == []
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_with_leading_hyphen(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_with_leading_hyphen(self, mock_start_run, mock_get_working_dir):
         """Messages beginning with '-' are passed via stdin, not parsed as flags."""
         from agent_service import send_agent_message
 
@@ -210,24 +205,20 @@ class TestAgentService:
         mock_process = Mock()
         mock_process.returncode = 0
         mock_process.communicate.return_value = ("Response", "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         result = send_agent_message("test-repo", "-inspect")
 
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         mock_process.communicate.assert_called_once_with(input="-inspect")
         assert result["prompt"] == "-inspect"
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_with_session_id(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_with_session_id(self, mock_start_run, mock_get_working_dir):
         """Test messages include provided session ID each time."""
         from agent_service import _conversation_sessions, send_agent_message
 
@@ -237,36 +228,28 @@ class TestAgentService:
         mock_process = Mock()
         mock_process.returncode = 0
         mock_process.communicate.return_value = ("Agent response content", "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         _conversation_sessions.clear()
 
         send_agent_message("test-repo", "Hello agent", "ses_123")
         send_agent_message("test-repo", "Follow up", "ses_123")
 
-        assert mock_subprocess_popen.call_args_list[0] == call(
+        assert mock_start_run.call_args_list[0] == call(
             ["opencode", "run", "-s", "ses_123", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
-        assert mock_subprocess_popen.call_args_list[1] == call(
+        assert mock_start_run.call_args_list[1] == call(
             ["opencode", "run", "-s", "ses_123", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         assert mock_process.communicate.call_args_list[0] == call(input="Hello agent")
         assert mock_process.communicate.call_args_list[1] == call(input="Follow up")
         assert _conversation_sessions["test-repo"] == "ses_123"
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_with_agent(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_with_agent(self, mock_start_run, mock_get_working_dir):
         """Test messages include provided agent."""
         from agent_service import send_agent_message
 
@@ -276,24 +259,20 @@ class TestAgentService:
         mock_process = Mock()
         mock_process.returncode = 0
         mock_process.communicate.return_value = ("Agent response content", "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         send_agent_message("test-repo", "Hello agent", agent="plan")
 
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--agent", "plan", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         mock_process.communicate.assert_called_once_with(input="Hello agent")
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
+    @patch('agent_service.AGENT_CLI.start_run')
     def test_send_agent_message_resets_channel_without_session_id(
-        self, mock_subprocess_popen, mock_get_working_dir
+        self, mock_start_run, mock_get_working_dir
     ):
         """When session ID is omitted, the channel starts a fresh session."""
         from agent_service import _conversation_sessions, send_agent_message
@@ -304,7 +283,7 @@ class TestAgentService:
         mock_process = Mock()
         mock_process.returncode = 0
         mock_process.communicate.return_value = ("Agent response content", "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         _conversation_sessions.clear()
         send_agent_message("test-repo", "Hello agent", "ses_123")
@@ -312,29 +291,21 @@ class TestAgentService:
 
         send_agent_message("test-repo", "Fresh start")
 
-        assert mock_subprocess_popen.call_args_list[0] == call(
+        assert mock_start_run.call_args_list[0] == call(
             ["opencode", "run", "-s", "ses_123", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
-        assert mock_subprocess_popen.call_args_list[1] == call(
+        assert mock_start_run.call_args_list[1] == call(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         assert mock_process.communicate.call_args_list[0] == call(input="Hello agent")
         assert mock_process.communicate.call_args_list[1] == call(input="Fresh start")
         assert "test-repo" not in _conversation_sessions
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_parses_json_output(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_parses_json_output(self, mock_start_run, mock_get_working_dir):
         """Ensure opencode JSON output is parsed for text and session ID."""
         from agent_service import _conversation_sessions, send_agent_message
 
@@ -349,7 +320,7 @@ class TestAgentService:
             '{"type":"text","timestamp":1766956199331,"sessionID":"ses_123","part":{"type":"text","text":"Second line"}}',
             '{"type":"step_finish","timestamp":1766956225161,"sessionID":"ses_123","part":{"type":"step-finish"}}',
         ]), "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         _conversation_sessions.clear()
 
@@ -362,19 +333,15 @@ class TestAgentService:
         ]
         assert result["sessionId"] == "ses_123"
         assert _conversation_sessions["test-repo"] == "ses_123"
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         mock_process.communicate.assert_called_once_with(input="Hello agent")
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_includes_tool_use(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_includes_tool_use(self, mock_start_run, mock_get_working_dir):
         """Ensure tool_use entries are included with type metadata."""
         from agent_service import send_agent_message
 
@@ -388,7 +355,7 @@ class TestAgentService:
             '{"type":"tool_use","timestamp":1766956199000,"sessionID":"ses_tool","part":{"tool":"firecrawl_firecrawl_search"}}',
             '{"type":"text","timestamp":1766956200000,"sessionID":"ses_tool","part":{"type":"text","text":"After tool"}}',
         ]), "")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         result = send_agent_message("test-repo", "Hello agent")
 
@@ -400,13 +367,9 @@ class TestAgentService:
             {"text": "firecrawl_firecrawl_search", "timestamp": "2025-12-28T21:09:59.000Z", "type": "tool"},
             {"text": "After tool", "timestamp": "2025-12-28T21:10:00.000Z", "type": "final"},
         ]
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         mock_process.communicate.assert_called_once_with(input="Hello agent")
 
@@ -424,8 +387,8 @@ class TestAgentService:
         assert parsed == [{"text": "Final answer", "timestamp": "2025-12-28T21:09:59.331Z", "type": "final"}]
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_command_failure(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_command_failure(self, mock_start_run, mock_get_working_dir):
         """Test agent message sending with command failure."""
         from agent_service import send_agent_message
         
@@ -436,26 +399,22 @@ class TestAgentService:
         mock_process = Mock()
         mock_process.returncode = 1
         mock_process.communicate.return_value = ("", "Command error")
-        mock_subprocess_popen.return_value = mock_process
+        mock_start_run.return_value = mock_process
 
         # Test failed command
         result = send_agent_message("test-repo", "Hello agent")
 
         # Verify error response
         assert result["response"] == "Error: Command error"
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
         mock_process.communicate.assert_called_once_with(input="Hello agent")
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_file_not_found(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_file_not_found(self, mock_start_run, mock_get_working_dir):
         """Test agent message sending when opencode is not found."""
         from agent_service import send_agent_message
         
@@ -463,25 +422,21 @@ class TestAgentService:
         mock_working_dir = Path("/test/workspace/repo")
         mock_get_working_dir.return_value = mock_working_dir
 
-        mock_subprocess_popen.side_effect = FileNotFoundError()
+        mock_start_run.side_effect = FileNotFoundError()
 
         # Test file not found
         result = send_agent_message("test-repo", "Hello agent")
         
         # Verify file not found response
         assert result["response"] == "Error: 'opencode' command not found. Please ensure it is installed and in PATH."
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.Popen')
-    def test_send_agent_message_generic_exception(self, mock_subprocess_popen, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.start_run')
+    def test_send_agent_message_generic_exception(self, mock_start_run, mock_get_working_dir):
         """Test agent message sending with generic exception."""
         from agent_service import send_agent_message
         
@@ -489,25 +444,21 @@ class TestAgentService:
         mock_working_dir = Path("/test/workspace/repo")
         mock_get_working_dir.return_value = mock_working_dir
 
-        mock_subprocess_popen.side_effect = Exception("Generic error")
+        mock_start_run.side_effect = Exception("Generic error")
 
         # Test generic exception
         result = send_agent_message("test-repo", "Hello agent")
         
         # Verify generic error response
         assert result["response"] == "Error: Generic error"
-        mock_subprocess_popen.assert_called_once_with(
+        mock_start_run.assert_called_once_with(
             ["opencode", "run", "--format", "json"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=mock_working_dir,
+            mock_working_dir,
         )
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.run')
-    def test_list_chat_sessions_parses_table(self, mock_subprocess_run, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.list_sessions')
+    def test_list_chat_sessions_parses_table(self, mock_list_sessions, mock_get_working_dir):
         """Parse the latest sessions from the opencode session table."""
         from agent_service import list_chat_sessions
 
@@ -537,7 +488,7 @@ ses_4c9b107a0ffeuRQ2c1mUgvcZto  Greeting and quick check-in                     
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = sample_output
-        mock_subprocess_run.return_value = mock_result
+        mock_list_sessions.return_value = mock_result
 
         sessions = list_chat_sessions("test-repo", limit=10)
 
@@ -548,8 +499,8 @@ ses_4c9b107a0ffeuRQ2c1mUgvcZto  Greeting and quick check-in                     
         assert sessions[-1]["id"] == "ses_4c7dd22b9ffe8RCrnIPoCt7Not"
 
     @patch('agent_service._get_working_directory')
-    @patch('agent_service.subprocess.run')
-    def test_list_chat_sessions_handles_errors(self, mock_subprocess_run, mock_get_working_dir):
+    @patch('agent_service.AGENT_CLI.list_sessions')
+    def test_list_chat_sessions_handles_errors(self, mock_list_sessions, mock_get_working_dir):
         """Raise errors when the opencode session list fails."""
         from agent_service import list_chat_sessions
 
@@ -560,7 +511,7 @@ ses_4c9b107a0ffeuRQ2c1mUgvcZto  Greeting and quick check-in                     
         mock_result.returncode = 1
         mock_result.stdout = ""
         mock_result.stderr = "boom"
-        mock_subprocess_run.return_value = mock_result
+        mock_list_sessions.return_value = mock_result
 
         with pytest.raises(RuntimeError):
             list_chat_sessions("test-repo", limit=5)


### PR DESCRIPTION
### Motivation
- Centralize all direct `opencode` subprocess interactions behind an abstraction to make it possible to switch CLIs without changing backend behavior.
- Provide a shared CLI identity (`cli_name`) and standardized missing-command message via `missing_command_error()` to keep logs and errors consistent.
- Preserve existing run/export/list behavior while enabling easier unit testing and mocking of subprocess interactions.

### Description
- Add `AgentCLI` abstract base class and `OpenCodeAgentCLI` implementation in `packages/pybackend/agent_cli.py` including `cli_name`, `missing_command_error`, `build_run_command`, `start_run`, `export_session`, `list_sessions`, and `list_agents`.
- Replace direct `subprocess.run`/`subprocess.Popen` usages in `packages/pybackend/agent_service.py` with an `AGENT_CLI` instance and calls to `AGENT_CLI.build_run_command`, `AGENT_CLI.start_run`, `AGENT_CLI.export_session`, `AGENT_CLI.list_sessions`, and `AGENT_CLI.list_agents`.
- Update logging and `FileNotFoundError` messages to use `AGENT_CLI.cli_name` and `AGENT_CLI.missing_command_error()` for consistent messaging.
- Update unit tests to mock `agent_service.AGENT_CLI.*` methods instead of patching `subprocess` functions.

### Testing
- Ran unit tests with `PYTHONPATH=/workspace/made/packages/pybackend pytest tests/unit/test_unit.py tests/unit/test_chat_history_service.py`.
- All unit tests passed: `40 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d885cc4c8332b936410d2155fbbb)