### PR TITLE
Add agentCli default and dropdown selector in Settings

### DIFF
--- a/packages/frontend/src/pages/SettingsPage.tsx
+++ b/packages/frontend/src/pages/SettingsPage.tsx
@@ -6,6 +6,8 @@ import "../styles/page.css";
 
 type SettingsMap = Record<string, unknown>;
 
+const agentCliOptions = ["opencode", "kiro-cli"];
+
 export const SettingsPage: React.FC = () => {
   const [settings, setSettings] = useState<SettingsMap>({});
   const [activeTab, setActiveTab] = useState("settings");
@@ -57,13 +59,29 @@ export const SettingsPage: React.FC = () => {
                   {Object.entries(settings).map(([key, value]) => (
                     <div key={key} className="settings-row">
                       <label htmlFor={`setting-${key}`}>{key}</label>
-                      <input
-                        id={`setting-${key}`}
-                        value={String(value ?? "")}
-                        onChange={(event) =>
-                          handleChange(key, event.target.value)
-                        }
-                      />
+                      {key === "agentCli" ? (
+                        <select
+                          id={`setting-${key}`}
+                          value={String(value ?? "")}
+                          onChange={(event) =>
+                            handleChange(key, event.target.value)
+                          }
+                        >
+                          {agentCliOptions.map((option) => (
+                            <option key={option} value={option}>
+                              {option}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          id={`setting-${key}`}
+                          value={String(value ?? "")}
+                          onChange={(event) =>
+                            handleChange(key, event.target.value)
+                          }
+                        />
+                      )}
                     </div>
                   ))}
                   {Object.keys(settings).length === 0 && (

--- a/packages/pybackend/settings_service.py
+++ b/packages/pybackend/settings_service.py
@@ -15,9 +15,7 @@ def read_settings():
     settings_path = get_settings_path()
     if not settings_path.exists():
         defaults = {
-            "theme": "system",
-            "agentEndpoint": "https://a2a-protocol.org/mock",
-            "notifications": True,
+            "agentCli": "opencode",
         }
         settings_path.write_text(json.dumps(defaults, indent=2), encoding="utf-8")
         return defaults


### PR DESCRIPTION
### Motivation
- Simplify stored settings by removing unused defaults and prepare for selecting the Agent CLI implementation.
- Provide a UI for choosing the Agent CLI so users can pick between supported CLIs before further integration.

### Description
- Replace multiple backend default settings with a single `agentCli` default set to `"opencode"` in `packages/pybackend/settings_service.py`.
- Add an `agentCliOptions` array and render `agentCli` as a `<select>` dropdown on the settings page in `packages/frontend/src/pages/SettingsPage.tsx`.
- Preserve existing save/load behavior so the new setting is persisted via the existing API.

### Testing
- Ran `npm --workspace packages/frontend run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ea8b682883329b78a4a859c97d52)