### PR TITLE
Ensure export parsing preserves leading newline text and refactor agent CLI run API

### DIFF
--- a/packages/pybackend/agent_cli.py
+++ b/packages/pybackend/agent_cli.py
@@ -1,8 +1,34 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+import logging
 from pathlib import Path
+import re
 import subprocess
+import tempfile
+
+logger = logging.getLogger(__name__)
+SESSION_ROW_PATTERN = re.compile(r"^(ses_[^\s]+)\s{2,}(.*?)\s{2,}(.+)$")
+AGENT_ROW_PATTERN = re.compile(r"^(?P<name>\S+)\s+\((?P<kind>[^)]+)\)\s*$")
+LOG_PREVIEW_LIMIT = 500
+
+
+@dataclass(frozen=True)
+class RunHandle:
+    process: subprocess.Popen
+    command: list[str]
+
+
+@dataclass(frozen=True)
+class RunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    session_id: str | None
+    responses: list[dict[str, object]]
 
 
 class AgentCLI(ABC):
@@ -22,21 +48,30 @@ class AgentCLI(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def start_run(self, command: list[str], cwd: Path) -> subprocess.Popen:
+    def start_run(self, command: list[str], cwd: Path) -> RunHandle:
+        raise NotImplementedError
+
+    @abstractmethod
+    def wait_for_run(self, handle: RunHandle, message: str) -> RunResult:
         raise NotImplementedError
 
     @abstractmethod
     def export_session(
-        self, session_id: str, cwd: Path | None, stdout
-    ) -> subprocess.CompletedProcess:
+        self,
+        session_id: str,
+        cwd: Path | None,
+        start_timestamp: int | float | str | None = None,
+    ) -> list[dict[str, object]]:
         raise NotImplementedError
 
     @abstractmethod
-    def list_sessions(self, cwd: Path | None) -> subprocess.CompletedProcess:
+    def list_sessions(
+        self, cwd: Path | None, limit: int
+    ) -> list[dict[str, str]]:
         raise NotImplementedError
 
     @abstractmethod
-    def list_agents(self) -> subprocess.CompletedProcess:
+    def list_agents(self) -> list[dict[str, object]]:
         raise NotImplementedError
 
 
@@ -54,8 +89,8 @@ class OpenCodeAgentCLI(AgentCLI):
         command.extend(["--format", "json"])
         return command
 
-    def start_run(self, command: list[str], cwd: Path) -> subprocess.Popen:
-        return subprocess.Popen(
+    def start_run(self, command: list[str], cwd: Path) -> RunHandle:
+        process = subprocess.Popen(
             command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -63,29 +98,484 @@ class OpenCodeAgentCLI(AgentCLI):
             text=True,
             cwd=cwd,
         )
+        return RunHandle(process=process, command=command)
 
-    def export_session(
-        self, session_id: str, cwd: Path | None, stdout
-    ) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            ["opencode", "export", session_id],
-            stdout=stdout,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=cwd,
+    def wait_for_run(self, handle: RunHandle, message: str) -> RunResult:
+        stdout, stderr = handle.process.communicate(input=message)
+        stdout_text = stdout or ""
+        stderr_text = stderr or ""
+
+        session_id = None
+        responses: list[dict[str, object]] = []
+        if handle.process.returncode == 0:
+            session_id, responses = _parse_opencode_output(stdout_text)
+
+        return RunResult(
+            returncode=handle.process.returncode or 0,
+            stdout=stdout_text,
+            stderr=stderr_text,
+            session_id=session_id,
+            responses=responses,
         )
 
-    def list_sessions(self, cwd: Path | None) -> subprocess.CompletedProcess:
-        return subprocess.run(
+    def export_session(
+        self,
+        session_id: str,
+        cwd: Path | None,
+        start_timestamp: int | float | str | None = None,
+    ) -> list[dict[str, object]]:
+        normalized_start = (
+            _to_milliseconds(start_timestamp) if start_timestamp is not None else None
+        )
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8", delete=True) as tmp:
+            result = subprocess.run(
+                ["opencode", "export", session_id],
+                stdout=tmp,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=cwd,
+            )
+
+            stderr_text = str(result.stderr or "")
+            if result.returncode != 0:
+                error_message = stderr_text.strip() or "Failed to export session history"
+                raise RuntimeError(error_message)
+
+            tmp.flush()
+            tmp_path = Path(tmp.name)
+
+            try:
+                export_payload = _decode_json_file(tmp_path, session_id)
+            except ValueError as exc:
+                tmp.seek(0)
+                preview = tmp.read(600)
+                _log_invalid_export_file(session_id, preview, stderr_text.strip())
+                raise exc
+
+        messages = export_payload.get("messages") or []
+        pruned_messages = _prune_export_payload({"messages": messages})["messages"]
+        return _filter_export_messages(pruned_messages, normalized_start)
+
+    def list_sessions(self, cwd: Path | None, limit: int) -> list[dict[str, str]]:
+        result = subprocess.run(
             ["opencode", "session", "list"],
             capture_output=True,
             text=True,
             cwd=cwd,
         )
+        stderr_text = str(result.stderr or "")
+        if result.returncode != 0:
+            error_message = stderr_text.strip() or "Failed to list sessions"
+            raise RuntimeError(error_message)
 
-    def list_agents(self) -> subprocess.CompletedProcess:
-        return subprocess.run(
+        return _parse_session_table(result.stdout or "", limit)
+
+    def list_agents(self) -> list[dict[str, object]]:
+        result = subprocess.run(
             ["opencode", "agent", "list"],
             capture_output=True,
             text=True,
         )
+        stderr_text = str(result.stderr or "")
+        if result.returncode != 0:
+            error_message = stderr_text.strip() or "Failed to list agents"
+            raise RuntimeError(error_message)
+
+        return _parse_agent_list(result.stdout or "")
+
+
+def _preview_output(raw_text: str, limit: int = LOG_PREVIEW_LIMIT) -> str:
+    stripped = (raw_text or "").strip()
+    if len(stripped) <= limit:
+        return stripped
+
+    return stripped[: limit - 3] + "..."
+
+
+def _to_milliseconds(raw_value: object) -> int | None:
+    try:
+        return int(float(raw_value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_timestamp(raw_timestamp: int | float | str | None) -> str:
+    try:
+        timestamp_value = (
+            float(raw_timestamp) / 1000 if raw_timestamp is not None else None
+        )
+    except (TypeError, ValueError):
+        timestamp_value = None
+
+    dt = (
+        datetime.fromtimestamp(timestamp_value, tz=UTC)
+        if timestamp_value is not None
+        else datetime.now(UTC)
+    )
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _format_timestamp_optional(raw_timestamp: int | float | str | None) -> str | None:
+    millis = _to_milliseconds(raw_timestamp)
+    if millis is None:
+        return None
+
+    dt = datetime.fromtimestamp(millis / 1000, tz=UTC)
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _extract_part_content(part: dict[str, object], part_type: str) -> str:
+    if part_type in {"text"}:
+        for key in ("text", "content", "value"):
+            if part.get(key) is not None:
+                return str(part.get(key) or "")
+        return ""
+
+    if part_type in {"tool_use", "tool"}:
+        for key in ("tool", "name", "id"):
+            if part.get(key):
+                return str(part[key])
+        return ""
+
+    return ""
+
+
+def _parse_session_table(output: str, limit: int) -> list[dict[str, str]]:
+    sessions: list[dict[str, str]] = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if (
+            not stripped
+            or stripped.startswith("Session ID")
+            or stripped.startswith("─")
+        ):
+            continue
+
+        match = SESSION_ROW_PATTERN.match(stripped)
+        if not match:
+            logger.debug("Skipping non-matching session row: %s", stripped)
+            continue
+
+        session_id, title, updated = match.groups()
+        sessions.append(
+            {"id": session_id.strip(), "title": title.strip(), "updated": updated.strip()}
+        )
+
+        if len(sessions) >= limit:
+            break
+
+    if not sessions:
+        logger.warning(
+            "No sessions parsed from opencode output (limit: %s, preview: %s)",
+            limit,
+            _preview_output(output),
+        )
+
+    return sessions
+
+
+def _parse_opencode_output(
+    stdout: str,
+) -> tuple[str | None, list[dict[str, object]]]:
+    session_id = None
+    parts: list[dict[str, object]] = []
+
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        payload_session_id = payload.get("sessionID")
+        if payload_session_id:
+            session_id = payload_session_id
+
+        payload_type = payload.get("type")
+        payload_timestamp = payload.get("timestamp")
+        part = payload.get("part") or {}
+
+        part_id = part.get("id")
+        call_id = part.get("callID") or part.get("callId")
+
+        if payload_type == "text":
+            text = _extract_part_content(part, "text")
+            if text:
+                parts.append(
+                    {
+                        "kind": "text",
+                        "content": text,
+                        "timestamp": payload_timestamp,
+                        "part_id": part_id,
+                        "call_id": call_id,
+                    }
+                )
+        elif payload_type in {"tool_use", "tool"}:
+            tool_name = _extract_part_content(part, payload_type)
+            if tool_name:
+                parts.append(
+                    {
+                        "kind": "tool",
+                        "content": tool_name,
+                        "timestamp": payload_timestamp,
+                        "part_id": part_id,
+                        "call_id": call_id,
+                    }
+                )
+
+    if not parts:
+        return session_id, []
+
+    responses: list[dict[str, str]] = []
+    text_indices = [
+        index for index, part in enumerate(parts) if part.get("kind") == "text"
+    ]
+
+    for index, part in enumerate(parts):
+        kind = part.get("kind")
+        content = str(part.get("content", ""))
+        raw_timestamp = part.get("timestamp")
+
+        if kind == "text":
+            message_type = (
+                "final" if text_indices and index == text_indices[-1] else "thinking"
+            )
+            text_content = content
+        else:
+            message_type = "tool"
+            text_content = content
+
+        response: dict[str, object] = {
+            "text": text_content,
+            "timestamp": _format_timestamp(raw_timestamp),
+            "type": message_type,
+        }
+
+        part_id = part.get("part_id")
+        call_id = part.get("call_id")
+        if part_id:
+            response["partId"] = part_id
+        if call_id:
+            response["callId"] = call_id
+
+        responses.append(response)
+
+    return session_id, responses
+
+
+def _resolve_message_timestamp(message_info: dict[str, object]) -> int | None:
+    time_info = message_info.get("time") or {}
+    if not isinstance(time_info, dict):
+        return None
+
+    for key in ("created", "start", "completed", "end", "updated"):
+        resolved = _to_milliseconds(time_info.get(key))
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _resolve_part_timestamp(
+    part: dict[str, object], fallback: int | None
+) -> int | None:
+    time_info = part.get("time") or {}
+    if isinstance(time_info, dict):
+        for key in ("end", "start"):
+            resolved = _to_milliseconds(time_info.get(key))
+            if resolved is not None:
+                return resolved
+
+    state = part.get("state")
+    if isinstance(state, dict):
+        state_time = state.get("time") or {}
+        if isinstance(state_time, dict):
+            for key in ("end", "start"):
+                resolved = _to_milliseconds(state_time.get(key))
+                if resolved is not None:
+                    return resolved
+
+    resolved = _to_milliseconds(part.get("timestamp"))
+    if resolved is not None:
+        return resolved
+
+    return fallback
+
+
+def _filter_export_messages(
+    messages: list[dict[str, object]], start_timestamp: int | None
+) -> list[dict[str, object]]:
+    history: list[dict[str, object]] = []
+
+    for message in messages:
+        message_info = message.get("info") or {}
+        role = message_info.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+
+        message_timestamp = _resolve_message_timestamp(message_info)
+
+        for part in message.get("parts") or []:
+            part_type = part.get("type")
+            if part_type not in {"text", "tool_use", "tool"}:
+                continue
+
+            part_timestamp = _resolve_part_timestamp(part, message_timestamp)
+            if start_timestamp is not None and part_timestamp is not None:
+                if part_timestamp < start_timestamp:
+                    continue
+
+            entry: dict[str, object] = {
+                "messageId": message_info.get("id"),
+                "role": role,
+                "type": part_type,
+                "content": _extract_part_content(part, part_type),
+                "timestamp": _format_timestamp_optional(part_timestamp),
+            }
+
+            content_value = str(entry.get("content") or "")
+            if not content_value.strip():
+                continue
+
+            part_id = part.get("id")
+            call_id = part.get("callID") or part.get("callId")
+            if part_id:
+                entry["partId"] = part_id
+            if call_id:
+                entry["callId"] = call_id
+
+            history.append(entry)
+
+    return history
+
+
+def _prune_export_payload(export_payload: dict[str, object]) -> dict[str, object]:
+    """Strip export payload down to only the fields required for history reconstruction."""
+
+    def _prune_time(time_obj: object) -> dict[str, object]:
+        if not isinstance(time_obj, dict):
+            return {}
+        pruned = {
+            key: time_obj[key]
+            for key in ("created", "start", "completed", "end", "updated")
+            if key in time_obj
+        }
+        return pruned
+
+    def _prune_part(part: object) -> dict[str, object]:
+        if not isinstance(part, dict):
+            return {}
+        pruned_part: dict[str, object] = {}
+        part_type = part.get("type")
+        if part_type:
+            pruned_part["type"] = part_type
+
+        for key in (
+            "text",
+            "content",
+            "value",
+            "tool",
+            "name",
+            "id",
+            "timestamp",
+            "callID",
+            "callId",
+        ):
+            if key in part:
+                pruned_part[key] = part[key]
+
+        time_info = _prune_time(part.get("time"))
+        if time_info:
+            pruned_part["time"] = time_info
+
+        state = part.get("state")
+        if isinstance(state, dict):
+            state_time = _prune_time(state.get("time"))
+            if state_time:
+                pruned_part["state"] = {"time": state_time}
+
+        return pruned_part
+
+    def _prune_message(message: object) -> dict[str, object]:
+        if not isinstance(message, dict):
+            return {"info": {}, "parts": []}
+
+        info = message.get("info") or {}
+        parts = message.get("parts") or []
+
+        pruned_info: dict[str, object] = {}
+        for key in ("id", "role"):
+            if key in info:
+                pruned_info[key] = info[key]
+
+        time_info = _prune_time(info.get("time"))
+        if time_info:
+            pruned_info["time"] = time_info
+
+        return {
+            "info": pruned_info,
+            "parts": [_prune_part(part) for part in parts if isinstance(part, dict)],
+        }
+
+    messages = export_payload.get("messages") or []
+    return {"messages": [_prune_message(message) for message in messages]}
+
+
+def _decode_json_file(json_file: Path, session_id: str) -> dict[str, object]:
+    """Parse clean JSON from a file."""
+    try:
+        with json_file.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "Invalid JSON export (session: %s): %s",
+            session_id,
+            exc,
+        )
+        raise ValueError("Invalid export data returned by opencode") from exc
+
+
+def _log_invalid_export_file(
+    session_id: str, stdout_preview: str, stderr_text: str
+) -> None:
+    logger.warning(
+        (
+            "Invalid export data while exporting chat history "
+            "(session: %s). "
+            "stdout sample: %r stderr first: %r stderr last: %r"
+        ),
+        session_id,
+        stdout_preview,
+        stderr_text[:300],
+        stderr_text[-300:],
+    )
+
+
+def _parse_agent_list(output: str) -> list[dict[str, object]]:
+    agents: list[dict[str, object]] = []
+    current_agent: dict[str, object] | None = None
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        match = AGENT_ROW_PATTERN.match(stripped)
+        if match:
+            current_agent = {
+                "name": match.group("name"),
+                "type": match.group("kind"),
+                "details": [],
+            }
+            agents.append(current_agent)
+            continue
+
+        if current_agent is not None:
+            details = current_agent.get("details")
+            if isinstance(details, list):
+                details.append(stripped)
+
+    if not agents:
+        logger.warning("No agents parsed from opencode output")
+    return agents

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -1,9 +1,6 @@
-import json
 import logging
-import re
 import subprocess
 import time
-import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
@@ -18,9 +15,6 @@ _processing_channels: dict[str, datetime] = {}
 _processing_processes: dict[str, subprocess.Popen] = {}
 _cancelled_channels: set[str] = set()
 _conversation_sessions: dict[str, str] = {}
-SESSION_ROW_PATTERN = re.compile(r"^(ses_[^\s]+)\s{2,}(.*?)\s{2,}(.+)$")
-AGENT_ROW_PATTERN = re.compile(r"^(?P<name>\S+)\s+\((?P<kind>[^)]+)\)\s*$")
-LOG_PREVIEW_LIMIT = 500
 AGENT_CLI = OpenCodeAgentCLI()
 
 
@@ -89,14 +83,6 @@ def get_channel_status(channel: str) -> dict[str, object]:
     }
 
 
-def _preview_output(raw_text: str, limit: int = LOG_PREVIEW_LIMIT) -> str:
-    stripped = (raw_text or "").strip()
-    if len(stripped) <= limit:
-        return stripped
-
-    return stripped[: limit - 3] + "..."
-
-
 def _get_working_directory(channel: str) -> Path:
     """Determine the working directory based on the channel context."""
     # For repository chats, run opencode in the repository directory
@@ -117,353 +103,6 @@ def _get_working_directory(channel: str) -> Path:
     return ensure_directory(made_dir / "constitutions")
 
 
-def _to_milliseconds(raw_value: object) -> int | None:
-    try:
-        return int(float(raw_value))
-    except (TypeError, ValueError):
-        return None
-
-
-def _format_timestamp(raw_timestamp: int | float | str | None) -> str:
-    try:
-        timestamp_value = (
-            float(raw_timestamp) / 1000 if raw_timestamp is not None else None
-        )
-    except (TypeError, ValueError):
-        timestamp_value = None
-
-    dt = (
-        datetime.fromtimestamp(timestamp_value, tz=UTC)
-        if timestamp_value is not None
-        else datetime.now(UTC)
-    )
-    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
-
-
-def _format_timestamp_optional(raw_timestamp: int | float | str | None) -> str | None:
-    millis = _to_milliseconds(raw_timestamp)
-    if millis is None:
-        return None
-
-    dt = datetime.fromtimestamp(millis / 1000, tz=UTC)
-    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
-
-
-def _extract_part_content(part: dict[str, object], part_type: str) -> str:
-    if part_type in {"text"}:
-        return str(part.get("text") or "")
-
-    if part_type in {"tool_use", "tool"}:
-        for key in ("tool", "name", "id"):
-            if part.get(key):
-                return str(part[key])
-        return ""
-
-    return ""
-
-
-def _parse_session_table(output: str, limit: int) -> list[dict[str, str]]:
-    sessions: list[dict[str, str]] = []
-    for line in output.splitlines():
-        stripped = line.strip()
-        if (
-            not stripped
-            or stripped.startswith("Session ID")
-            or stripped.startswith("─")
-        ):
-            continue
-
-        match = SESSION_ROW_PATTERN.match(stripped)
-        if not match:
-            logger.debug("Skipping non-matching session row: %s", stripped)
-            continue
-
-        session_id, title, updated = match.groups()
-        sessions.append(
-            {"id": session_id.strip(), "title": title.strip(), "updated": updated.strip()}
-        )
-
-        if len(sessions) >= limit:
-            break
-
-    if not sessions:
-        logger.warning(
-            "No sessions parsed from opencode output (limit: %s, preview: %s)",
-            limit,
-            _preview_output(output),
-        )
-
-    return sessions
-
-
-def _parse_opencode_output(
-    stdout: str,
-) -> tuple[str | None, list[dict[str, object]]]:
-    session_id = None
-    parts: list[dict[str, object]] = []
-
-    for line in stdout.splitlines():
-        if not line.strip():
-            continue
-
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        payload_session_id = payload.get("sessionID")
-        if payload_session_id:
-            session_id = payload_session_id
-
-        payload_type = payload.get("type")
-        payload_timestamp = payload.get("timestamp")
-        part = payload.get("part") or {}
-
-        part_id = part.get("id")
-        call_id = part.get("callID") or part.get("callId")
-
-        if payload_type == "text":
-            text = _extract_part_content(part, "text")
-            if text:
-                parts.append(
-                    {
-                        "kind": "text",
-                        "content": text,
-                        "timestamp": payload_timestamp,
-                        "part_id": part_id,
-                        "call_id": call_id,
-                    }
-                )
-        elif payload_type in {"tool_use", "tool"}:
-            tool_name = _extract_part_content(part, payload_type)
-            if tool_name:
-                parts.append(
-                    {
-                        "kind": "tool",
-                        "content": tool_name,
-                        "timestamp": payload_timestamp,
-                        "part_id": part_id,
-                        "call_id": call_id,
-                    }
-                )
-
-    if not parts:
-        return session_id, []
-
-    responses: list[dict[str, str]] = []
-    text_indices = [
-        index for index, part in enumerate(parts) if part.get("kind") == "text"
-    ]
-
-    for index, part in enumerate(parts):
-        kind = part.get("kind")
-        content = str(part.get("content", ""))
-        raw_timestamp = part.get("timestamp")
-
-        if kind == "text":
-            message_type = (
-                "final" if text_indices and index == text_indices[-1] else "thinking"
-            )
-            text_content = content
-        else:
-            message_type = "tool"
-            text_content = content
-
-        response: dict[str, object] = {
-            "text": text_content,
-            "timestamp": _format_timestamp(raw_timestamp),
-            "type": message_type,
-        }
-
-        part_id = part.get("part_id")
-        call_id = part.get("call_id")
-        if part_id:
-            response["partId"] = part_id
-        if call_id:
-            response["callId"] = call_id
-
-        responses.append(response)
-
-    return session_id, responses
-
-
-def _resolve_message_timestamp(message_info: dict[str, object]) -> int | None:
-    time_info = message_info.get("time") or {}
-    if not isinstance(time_info, dict):
-        return None
-
-    for key in ("created", "start", "completed", "end", "updated"):
-        resolved = _to_milliseconds(time_info.get(key))
-        if resolved is not None:
-            return resolved
-    return None
-
-
-def _resolve_part_timestamp(
-    part: dict[str, object], fallback: int | None
-) -> int | None:
-    time_info = part.get("time") or {}
-    if isinstance(time_info, dict):
-        for key in ("end", "start"):
-            resolved = _to_milliseconds(time_info.get(key))
-            if resolved is not None:
-                return resolved
-
-    state = part.get("state")
-    if isinstance(state, dict):
-        state_time = state.get("time") or {}
-        if isinstance(state_time, dict):
-            for key in ("end", "start"):
-                resolved = _to_milliseconds(state_time.get(key))
-                if resolved is not None:
-                    return resolved
-
-    resolved = _to_milliseconds(part.get("timestamp"))
-    if resolved is not None:
-        return resolved
-
-    return fallback
-
-
-def _filter_export_messages(
-    messages: list[dict[str, object]], start_timestamp: int | None
-) -> list[dict[str, object]]:
-    history: list[dict[str, object]] = []
-
-    for message in messages:
-        message_info = message.get("info") or {}
-        role = message_info.get("role")
-        if role not in {"user", "assistant"}:
-            continue
-
-        message_timestamp = _resolve_message_timestamp(message_info)
-
-        for part in message.get("parts") or []:
-            part_type = part.get("type")
-            if part_type not in {"text", "tool_use", "tool"}:
-                continue
-
-            part_timestamp = _resolve_part_timestamp(part, message_timestamp)
-            if start_timestamp is not None and part_timestamp is not None:
-                if part_timestamp < start_timestamp:
-                    continue
-
-            entry: dict[str, object] = {
-                "messageId": message_info.get("id"),
-                "role": role,
-                "type": part_type,
-                "content": _extract_part_content(part, part_type),
-                "timestamp": _format_timestamp_optional(part_timestamp),
-            }
-
-            part_id = part.get("id")
-            call_id = part.get("callID") or part.get("callId")
-            if part_id:
-                entry["partId"] = part_id
-            if call_id:
-                entry["callId"] = call_id
-
-            history.append(entry)
-
-    return history
-
-
-def _prune_export_payload(export_payload: dict[str, object]) -> dict[str, object]:
-    """Strip export payload down to only the fields required for history reconstruction."""
-
-    def _prune_time(time_obj: object) -> dict[str, object]:
-        if not isinstance(time_obj, dict):
-            return {}
-        pruned = {
-            key: time_obj[key]
-            for key in ("created", "start", "completed", "end", "updated")
-            if key in time_obj
-        }
-        return pruned
-
-    def _prune_part(part: object) -> dict[str, object]:
-        if not isinstance(part, dict):
-            return {}
-        pruned_part: dict[str, object] = {}
-        part_type = part.get("type")
-        if part_type:
-            pruned_part["type"] = part_type
-
-        for key in ("text", "tool", "name", "id", "timestamp", "callID", "callId"):
-            if key in part:
-                pruned_part[key] = part[key]
-
-        time_info = _prune_time(part.get("time"))
-        if time_info:
-            pruned_part["time"] = time_info
-
-        state = part.get("state")
-        if isinstance(state, dict):
-            state_time = _prune_time(state.get("time"))
-            if state_time:
-                pruned_part["state"] = {"time": state_time}
-
-        return pruned_part
-
-    def _prune_message(message: object) -> dict[str, object]:
-        if not isinstance(message, dict):
-            return {"info": {}, "parts": []}
-
-        info = message.get("info") or {}
-        parts = message.get("parts") or []
-
-        pruned_info: dict[str, object] = {}
-        for key in ("id", "role"):
-            if key in info:
-                pruned_info[key] = info[key]
-
-        time_info = _prune_time(info.get("time"))
-        if time_info:
-            pruned_info["time"] = time_info
-
-        return {
-            "info": pruned_info,
-            "parts": [_prune_part(part) for part in parts if isinstance(part, dict)],
-        }
-
-    messages = export_payload.get("messages") or []
-    return {"messages": [_prune_message(message) for message in messages]}
-
-
-def _decode_json_file(
-    json_file: Path, channel: str | None, session_id: str
-) -> dict[str, object]:
-    """Parse clean JSON from a file."""
-    try:
-        with json_file.open("r", encoding="utf-8") as handle:
-            return json.load(handle)
-    except json.JSONDecodeError as exc:
-        logger.error(
-            "Invalid JSON export (channel: %s, session: %s): %s",
-            channel or "<unspecified>",
-            session_id,
-            exc,
-        )
-        raise ValueError("Invalid export data returned by opencode") from exc
-
-
-def _log_invalid_export_file(
-    channel: str | None, session_id: str, stdout_preview: str, stderr_text: str
-) -> None:
-    logger.warning(
-        (
-            "Invalid export data while exporting chat history "
-            "(channel: %s, session: %s). "
-            "stdout sample: %r stderr first: %r stderr last: %r"
-        ),
-        channel or "<unspecified>",
-        session_id,
-        stdout_preview,
-        stderr_text[:300],
-        stderr_text[-300:],
-    )
-
-
 def export_chat_history(
     session_id: str | None,
     start_timestamp: int | float | str | None = None,
@@ -471,67 +110,36 @@ def export_chat_history(
 ) -> dict[str, object]:
     if not session_id:
         raise ValueError("Session ID is required")
-
-    normalized_start = (
-        _to_milliseconds(start_timestamp) if start_timestamp is not None else None
-    )
     working_dir = _get_working_directory(channel) if channel else None
 
     logger.info(
         "Exporting chat history (channel: %s, session: %s, start: %s)",
         channel or "<unspecified>",
         session_id,
-        normalized_start,
+        start_timestamp,
     )
 
-    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8", delete=True) as tmp:
-        try:
-            result = AGENT_CLI.export_session(session_id, working_dir, stdout=tmp)
-        except FileNotFoundError:
-            logger.error(
-                "Unable to export history: '%s' command not found", AGENT_CLI.cli_name
-            )
-            raise FileNotFoundError(AGENT_CLI.missing_command_error())
-
-        stderr_text = str(result.stderr or "")
-
-        if result.returncode != 0:
-            error_message = stderr_text.strip() or "Failed to export session history"
-            logger.error(
-                "Exporting chat history failed (channel: %s, session: %s): %s",
-                channel or "<unspecified>",
-                session_id,
-                error_message,
-            )
-            raise RuntimeError(error_message)
-
-        tmp.flush()
-        tmp_path = Path(tmp.name)
-        stdout_size = tmp_path.stat().st_size
-
-        logger.debug(
-            "Captured opencode export output (channel: %s, session: %s, stdout_bytes: %s, stderr_bytes: %s)",
+    try:
+        messages = AGENT_CLI.export_session(
+            session_id, working_dir, start_timestamp=start_timestamp
+        )
+    except FileNotFoundError:
+        logger.error(
+            "Unable to export history: '%s' command not found", AGENT_CLI.cli_name
+        )
+        raise FileNotFoundError(AGENT_CLI.missing_command_error())
+    except RuntimeError as exc:
+        logger.error(
+            "Exporting chat history failed (channel: %s, session: %s): %s",
             channel or "<unspecified>",
             session_id,
-            stdout_size,
-            len(stderr_text),
+            exc,
         )
+        raise
 
-        try:
-            export_payload = _decode_json_file(tmp_path, channel, session_id)
-        except ValueError as exc:
-            tmp.seek(0)
-            preview = tmp.read(600)
-            _log_invalid_export_file(
-                channel, session_id, preview, stderr_text.strip()
-            )
-            raise exc
-
-    messages = export_payload.get("messages") or []
-    pruned_messages = _prune_export_payload({"messages": messages})["messages"]
     return {
         "sessionId": session_id,
-        "messages": _filter_export_messages(pruned_messages, normalized_start),
+        "messages": messages,
     }
 
 
@@ -544,94 +152,47 @@ def list_chat_sessions(channel: str | None = None, limit: int = 10) -> list[dict
     )
 
     try:
-        result = AGENT_CLI.list_sessions(working_dir)
+        sessions = AGENT_CLI.list_sessions(working_dir, limit=limit)
     except FileNotFoundError:
         logger.error(
             "Unable to list sessions: '%s' command not found", AGENT_CLI.cli_name
         )
         raise FileNotFoundError(AGENT_CLI.missing_command_error())
-
-    stderr_text = str(result.stderr or "")
-
-    if result.returncode != 0:
-        error_message = stderr_text.strip() or "Failed to list sessions"
+    except RuntimeError as exc:
         logger.error(
-            "Listing chat sessions failed (channel: %s, cwd: %s, code: %s, stderr: %s)",
+            "Listing chat sessions failed (channel: %s, cwd: %s): %s",
             channel or "<unspecified>",
             working_dir,
-            result.returncode,
-            _preview_output(stderr_text),
+            exc,
         )
-        raise RuntimeError(error_message)
+        raise
 
     logger.debug(
-        "Listing chat sessions succeeded (channel: %s, cwd: %s, stdout_bytes: %s, stderr_preview: %s)",
+        "Listing chat sessions succeeded (channel: %s, cwd: %s, count: %s)",
         channel or "<unspecified>",
         working_dir,
-        len(result.stdout or ""),
-        _preview_output(stderr_text),
+        len(sessions),
     )
 
-    return _parse_session_table(result.stdout or "", limit)
-
-
-def _parse_agent_list(output: str) -> list[dict[str, object]]:
-    agents: list[dict[str, object]] = []
-    current_agent: dict[str, object] | None = None
-
-    for line in output.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-
-        match = AGENT_ROW_PATTERN.match(stripped)
-        if match:
-            current_agent = {
-                "name": match.group("name"),
-                "type": match.group("kind"),
-                "details": [],
-            }
-            agents.append(current_agent)
-            continue
-
-        if current_agent is not None:
-            details = current_agent.get("details")
-            if isinstance(details, list):
-                details.append(stripped)
-
-    if not agents:
-        logger.warning("No agents parsed from opencode output")
-    return agents
+    return sessions
 
 
 def list_agents() -> list[dict[str, object]]:
     logger.info("Listing available %s agents", AGENT_CLI.cli_name)
     try:
-        result = AGENT_CLI.list_agents()
+        agents = AGENT_CLI.list_agents()
     except FileNotFoundError:
         logger.error(
             "Unable to list agents: '%s' command not found", AGENT_CLI.cli_name
         )
         raise FileNotFoundError(AGENT_CLI.missing_command_error())
+    except RuntimeError as exc:
+        logger.error("Listing agents failed: %s", exc)
+        raise
 
-    stderr_text = str(result.stderr or "")
+    logger.debug("Listing agents succeeded (count: %s)", len(agents))
 
-    if result.returncode != 0:
-        error_message = stderr_text.strip() or "Failed to list agents"
-        logger.error(
-            "Listing agents failed (code: %s, stderr: %s)",
-            result.returncode,
-            _preview_output(stderr_text),
-        )
-        raise RuntimeError(error_message)
-
-    logger.debug(
-        "Listing agents succeeded (stdout_bytes: %s, stderr_preview: %s)",
-        len(result.stdout or ""),
-        _preview_output(stderr_text),
-    )
-
-    return _parse_agent_list(result.stdout or "")
+    return agents
 
 
 def send_agent_message(
@@ -660,22 +221,21 @@ def send_agent_message(
     )
 
     try:
-        # Run the agent command with the message in the appropriate directory
-        process = AGENT_CLI.start_run(command, working_dir)
-        _set_channel_process(channel, process)
-        stdout, stderr = process.communicate(input=message)
+        handle = AGENT_CLI.start_run(command, working_dir)
+        _set_channel_process(channel, handle.process)
+        run_result = AGENT_CLI.wait_for_run(handle, message)
+        parsed_responses = run_result.responses
 
         if _was_channel_cancelled(channel):
             parsed_responses = []
             response = "Agent request cancelled."
-        elif process.returncode == 0:
-            session_id, parsed_responses = _parse_opencode_output(stdout or "")
-            if session_id:
-                _conversation_sessions[channel] = session_id
+        elif run_result.returncode == 0:
+            if run_result.session_id:
+                _conversation_sessions[channel] = run_result.session_id
             response = (
                 "\n\n".join(part["text"] for part in parsed_responses)
                 if parsed_responses
-                else (stdout or "").strip()
+                else run_result.stdout.strip()
             )
             logger.info(
                 "Agent message processed (channel: %s, session: %s)",
@@ -685,8 +245,8 @@ def send_agent_message(
         else:
             parsed_responses = []
             response = (
-                f"Error: {(stderr or '').strip()}"
-                if (stderr or "").strip()
+                f"Error: {run_result.stderr.strip()}"
+                if run_result.stderr.strip()
                 else "Command failed with no output"
             )
             command_preview = " ".join(command)[:200]
@@ -702,9 +262,9 @@ def send_agent_message(
         parsed_responses = []
         response = AGENT_CLI.missing_command_error()
         logger.error("Agent command not found for channel %s", channel)
-    except Exception as e:
+    except Exception as exc:
         parsed_responses = []
-        response = f"Error: {str(e)}"
+        response = f"Error: {str(exc)}"
         logger.exception("Unexpected error sending agent message on channel %s", channel)
     finally:
         _clear_channel_processing(channel)

--- a/packages/pybackend/tests/unit/test_chat_history_service.py
+++ b/packages/pybackend/tests/unit/test_chat_history_service.py
@@ -1,17 +1,21 @@
 import json
+import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
-from agent_service import (
+from agent_cli import (
+    _decode_json_file,
+    _filter_export_messages,
     _format_timestamp,
     _format_timestamp_optional,
+    _prune_export_payload,
     _resolve_part_timestamp,
     _resolve_message_timestamp,
     _to_milliseconds,
-    export_chat_history,
 )
+from agent_service import export_chat_history
 
 
 class TestTimestampHelpers:
@@ -92,23 +96,11 @@ class TestExportChatHistory:
         ]
     }
 
-    @patch("agent_service.AGENT_CLI.export_session")
-    def test_export_chat_history_success(self, mock_export):
-        def _fake_export(session_id, cwd, stdout=None):
-            if stdout is not None:
-                stdout.write(json.dumps(self.SAMPLE_EXPORT))
-                stdout.flush()
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stderr = ""
-            return mock_result
+    def test_filter_export_messages(self):
+        pruned = _prune_export_payload(self.SAMPLE_EXPORT)
+        messages = _filter_export_messages(pruned["messages"], None)
 
-        mock_export.side_effect = _fake_export
-
-        result = export_chat_history("ses_123")
-
-        assert result["sessionId"] == "ses_123"
-        assert result["messages"] == [
+        assert messages == [
             {
                 "messageId": "msg_1",
                 "role": "user",
@@ -144,22 +136,94 @@ class TestExportChatHistory:
             },
         ]
 
+    def test_filter_export_messages_with_start_filter(self):
+        pruned = _prune_export_payload(self.SAMPLE_EXPORT)
+        messages = _filter_export_messages(pruned["messages"], 2000)
+        assert [msg["content"] for msg in messages] == ["Hi", "search", "todowrite"]
+
+    def test_filter_export_messages_uses_content_field(self):
+        payload = {
+            "messages": [
+                {
+                    "info": {"id": "msg_1", "role": "assistant"},
+                    "parts": [{"type": "text", "content": "Hello there"}],
+                }
+            ]
+        }
+        pruned = _prune_export_payload(payload)
+        messages = _filter_export_messages(pruned["messages"], None)
+
+        assert messages == [
+            {
+                "messageId": "msg_1",
+                "role": "assistant",
+                "type": "text",
+                "content": "Hello there",
+                "timestamp": None,
+            }
+        ]
+
+    def test_filter_export_messages_keeps_leading_newline(self):
+        payload = {
+            "messages": [
+                {
+                    "info": {"id": "msg_1", "role": "user"},
+                    "parts": [
+                        {
+                            "type": "text",
+                            "text": "\nJust a quick question: Is this preserved?",
+                        }
+                    ],
+                }
+            ]
+        }
+        pruned = _prune_export_payload(payload)
+        messages = _filter_export_messages(pruned["messages"], None)
+
+        assert messages == [
+            {
+                "messageId": "msg_1",
+                "role": "user",
+                "type": "text",
+                "content": "\nJust a quick question: Is this preserved?",
+                "timestamp": None,
+            }
+        ]
+
+    def test_filter_export_messages_ignores_empty_content(self):
+        payload = {
+            "messages": [
+                {
+                    "info": {"id": "msg_1", "role": "assistant"},
+                    "parts": [
+                        {"type": "text", "text": ""},
+                        {"type": "text", "text": "  "},
+                        {"type": "text", "text": "Hi there"},
+                        {"type": "tool_use", "tool": ""},
+                    ],
+                }
+            ]
+        }
+        pruned = _prune_export_payload(payload)
+        messages = _filter_export_messages(pruned["messages"], None)
+
+        assert messages == [
+            {
+                "messageId": "msg_1",
+                "role": "assistant",
+                "type": "text",
+                "content": "Hi there",
+                "timestamp": None,
+            }
+        ]
+
     @patch("agent_service.AGENT_CLI.export_session")
-    def test_export_chat_history_with_start_filter(self, mock_export):
-        def _fake_export(session_id, cwd, stdout=None):
-            if stdout is not None:
-                stdout.write(json.dumps(self.SAMPLE_EXPORT))
-                stdout.flush()
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stderr = ""
-            return mock_result
+    def test_export_chat_history_success(self, mock_export):
+        mock_export.return_value = [{"messageId": "msg_1", "role": "user"}]
+        result = export_chat_history("ses_123")
 
-        mock_export.side_effect = _fake_export
-
-        result = export_chat_history("ses_123", start_timestamp=2000)
-
-        assert [msg["content"] for msg in result["messages"]] == ["Hi", "search", "todowrite"]
+        assert result["sessionId"] == "ses_123"
+        assert result["messages"] == [{"messageId": "msg_1", "role": "user"}]
 
     def test_export_chat_history_missing_session(self):
         with pytest.raises(ValueError):
@@ -174,68 +238,36 @@ class TestExportChatHistory:
 
     @patch("agent_service.AGENT_CLI.export_session")
     def test_export_chat_history_failure(self, mock_export):
-        mock_result = Mock()
-        mock_result.returncode = 1
-        mock_result.stderr = "Failed"
-        mock_export.return_value = mock_result
+        mock_export.side_effect = RuntimeError("Failed")
 
         with pytest.raises(RuntimeError):
             export_chat_history("ses_123")
 
-    @patch("agent_service.AGENT_CLI.export_session")
-    def test_export_chat_history_bad_json(self, mock_export):
-        def _fake_export(session_id, cwd, stdout=None):
-            if stdout is not None:
-                stdout.write("not json")
-                stdout.flush()
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stderr = ""
-            return mock_result
+    def test_export_chat_history_bad_json(self):
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp:
+            tmp.write("not json")
+            tmp.flush()
+            with pytest.raises(ValueError):
+                _decode_json_file(Path(tmp.name), "ses_123")
 
-        mock_export.side_effect = _fake_export
-
-        with pytest.raises(ValueError):
-            export_chat_history("ses_123")
-
-    @patch("agent_service.AGENT_CLI.export_session")
-    def test_export_chat_history_rejects_non_json_prefix_or_suffix(self, mock_export):
+    def test_export_chat_history_rejects_non_json_prefix_or_suffix(self):
         payload = json.dumps(self.SAMPLE_EXPORT)
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp:
+            tmp.write(f"intro text\n{payload}\ntrailing stats")
+            tmp.flush()
+            with pytest.raises(ValueError):
+                _decode_json_file(Path(tmp.name), "ses_123")
 
-        def _fake_export(session_id, cwd, stdout=None):
-            if stdout is not None:
-                stdout.write(f"intro text\n{payload}\ntrailing stats")
-                stdout.flush()
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stderr = ""
-            return mock_result
-
-        mock_export.side_effect = _fake_export
-
-        with pytest.raises(ValueError):
-            export_chat_history("ses_123")
-
-    @patch("agent_service.AGENT_CLI.export_session")
-    def test_export_chat_history_rejects_multiple_json_blocks(self, mock_export):
+    def test_export_chat_history_rejects_multiple_json_blocks(self):
         first_payload = json.dumps(self.SAMPLE_EXPORT)
         second_payload = json.dumps({"messages": []})
-
-        def _fake_export(session_id, cwd, stdout=None):
-            if stdout is not None:
-                stdout.write(
-                    f"INFO log before\n{first_payload}\nnoise-between\n{second_payload}"
-                )
-                stdout.flush()
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stderr = ""
-            return mock_result
-
-        mock_export.side_effect = _fake_export
-
-        with pytest.raises(ValueError):
-            export_chat_history("ses_123")
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as tmp:
+            tmp.write(
+                f"INFO log before\n{first_payload}\nnoise-between\n{second_payload}"
+            )
+            tmp.flush()
+            with pytest.raises(ValueError):
+                _decode_json_file(Path(tmp.name), "ses_123")
 
     @patch("agent_service.AGENT_CLI.export_session")
     @patch("agent_service._get_working_directory")
@@ -243,22 +275,13 @@ class TestExportChatHistory:
         self, mock_get_working_directory, mock_export
     ):
         mock_get_working_directory.return_value = Path("/tmp/workspace/sample")
-        def _fake_export(session_id, cwd, stdout=None):
-            if stdout is not None:
-                stdout.write(json.dumps(self.SAMPLE_EXPORT))
-                stdout.flush()
-            mock_result = Mock()
-            mock_result.returncode = 0
-            mock_result.stderr = ""
-            return mock_result
-
-        mock_export.side_effect = _fake_export
+        mock_export.return_value = []
 
         export_chat_history("ses_123", channel="sample")
 
         mock_get_working_directory.assert_called_once_with("sample")
-        mock_export.assert_called_once()
-        args, kwargs = mock_export.call_args
-        assert args[0] == "ses_123"
-        assert args[1] == Path("/tmp/workspace/sample")
-        assert "stdout" in kwargs
+        mock_export.assert_called_once_with(
+            "ses_123",
+            mock_get_working_directory.return_value,
+            start_timestamp=None,
+        )


### PR DESCRIPTION
### Motivation
- Fix missing or blank exported messages when parts use `content`/`value` (not just `text`) so frontend receives actual message text.
- Preserve leading newlines and other non-empty whitespace in exported `text` to match previous behavior and user-visible history.
- Simplify and encapsulate run/parse logic in the CLI layer to make `send_agent_message` and `export_chat_history` flows clearer and easier to test.

### Description
- Add `RunHandle` and `RunResult` dataclasses and change `AgentCLI`/`OpenCodeAgentCLI` to expose `start_run`, `wait_for_run`, and `export_session` that return structured results instead of raw `CompletedProcess` objects.
- Implement robust export/session parsing and helpers in `agent_cli.py`, including `_parse_opencode_output`, `_extract_part_content` (checks `text`, `content`, `value`), `_prune_export_payload`, `_filter_export_messages`, and timestamp helpers.
- Update `agent_service.py` to call the new CLI API (`start_run`/`wait_for_run`/`export_session`), simplify error handling, and return parsed messages from `export_chat_history`.
- Update and add unit tests to reflect the new APIs and parsing behavior, including `test_filter_export_messages_keeps_leading_newline` to ensure leading newlines are preserved.

### Testing
- Ran the full unit test suite with `cd packages/pybackend && uv run pytest` and all tests passed.
- Test run summary: `145 passed, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965dc06d9a08332b223678e293c8e97)