### PR TITLE
Namespace frontend session storage by agent CLI

### DIFF
--- a/packages/frontend/src/hooks/useAgentCli.ts
+++ b/packages/frontend/src/hooks/useAgentCli.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { api } from "./useApi";
+
+const DEFAULT_AGENT_CLI = "opencode";
+
+export const useAgentCli = () => {
+  const [agentCli, setAgentCli] = useState(DEFAULT_AGENT_CLI);
+
+  useEffect(() => {
+    let active = true;
+
+    api
+      .getSettings()
+      .then((settings) => {
+        if (!active) return;
+        const cli =
+          settings && typeof settings.agentCli === "string"
+            ? settings.agentCli
+            : DEFAULT_AGENT_CLI;
+        setAgentCli(cli);
+      })
+      .catch((error) => {
+        if (!active) return;
+        console.error("Failed to load agent CLI settings", error);
+        setAgentCli(DEFAULT_AGENT_CLI);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return agentCli;
+};

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -12,6 +12,7 @@ import { TabView } from "../components/TabView";
 import { ChatWindow } from "../components/ChatWindow";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
@@ -26,13 +27,17 @@ export const ConstitutionPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
+  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `constitution-chat-${name}` : "constitution-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () => (name ? `constitution-session-${name}` : "constitution-session"),
-    [name],
+    () =>
+      name
+        ? `constitution-session-${name}-${agentCli}`
+        : `constitution-session-${agentCli}`,
+    [agentCli, name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -12,6 +12,7 @@ import { TabView } from "../components/TabView";
 import { ChatWindow } from "../components/ChatWindow";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
@@ -26,13 +27,17 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
+  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `knowledge-chat-${name}` : "knowledge-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () => (name ? `knowledge-session-${name}` : "knowledge-session"),
-    [name],
+    () =>
+      name
+        ? `knowledge-session-${name}-${agentCli}`
+        : `knowledge-session-${agentCli}`,
+    [agentCli, name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -15,6 +15,7 @@ import { ChatWindow } from "../components/ChatWindow";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { useAgentCli } from "../hooks/useAgentCli";
 import {
   api,
   CommandDefinition,
@@ -184,13 +185,17 @@ export const RepositoryPage: React.FC = () => {
   const [repository, setRepository] = useState<RepositorySummary | null>(null);
   const [fileTree, setFileTree] = useState<FileNode | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(["."]));
+  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `repository-chat-${name}` : "repository-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () => (name ? `repository-session-${name}` : "repository-session"),
-    [name],
+    () =>
+      name
+        ? `repository-session-${name}-${agentCli}`
+        : `repository-session-${agentCli}`,
+    [agentCli, name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);


### PR DESCRIPTION
### Motivation

- Prevent session ID collisions when switching between different agent CLI implementations by namespacing stored session keys with the active agent CLI.
- Provide a single place to load the active agent CLI setting and fall back to a sensible default.

### Description

- Add a new hook `useAgentCli` that loads `agentCli` from settings (via `api.getSettings`) and falls back to `opencode` if unavailable (`packages/frontend/src/hooks/useAgentCli.ts`).
- Update `RepositoryPage`, `KnowledgeArtefactPage`, and `ConstitutionPage` to include the agent CLI in the session storage key format, changing e.g. `repository-session-{name}` to `repository-session-{name}-{agentCli}` and the unnamed keys to include `-{agentCli}` (`packages/frontend/src/pages/RepositoryPage.tsx`, `packages/frontend/src/pages/KnowledgeArtefactPage.tsx`, `packages/frontend/src/pages/ConstitutionPage.tsx`).
- Import and use the new `useAgentCli` hook in the modified pages so session keys are computed from the active CLI value.

### Testing

- Ran frontend linting with `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a45bd2788332be7c6cf1f050f1af)