### PR TITLE
Add timestamps to copied chat history labels

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -16,7 +16,12 @@ import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
-import { mapAgentReplyToMessages, mapHistoryToMessages } from "../utils/chat";
+import {
+  formatChatMessageLabel,
+  formatChatMessageTimestamp,
+  mapAgentReplyToMessages,
+  mapHistoryToMessages,
+} from "../utils/chat";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
@@ -66,7 +71,13 @@ export const ConstitutionPage: React.FC = () => {
     if (!navigator.clipboard || !chat.length) return;
 
     const content = chat
-      .map((message) => message.text || "")
+      .map((message) => {
+        const label = formatChatMessageLabel(message);
+        const timestamp = formatChatMessageTimestamp(message);
+        const messageText = message.text || "";
+        const header = `${label} ${timestamp}`.trim();
+        return messageText ? `${header} ${messageText}` : header;
+      })
       .join("\n\n")
       .trim();
 

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -16,7 +16,12 @@ import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
-import { mapAgentReplyToMessages, mapHistoryToMessages } from "../utils/chat";
+import {
+  formatChatMessageLabel,
+  formatChatMessageTimestamp,
+  mapAgentReplyToMessages,
+  mapHistoryToMessages,
+} from "../utils/chat";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
@@ -66,7 +71,13 @@ export const KnowledgeArtefactPage: React.FC = () => {
     if (!navigator.clipboard || !chat.length) return;
 
     const content = chat
-      .map((message) => message.text || "")
+      .map((message) => {
+        const label = formatChatMessageLabel(message);
+        const timestamp = formatChatMessageTimestamp(message);
+        const messageText = message.text || "";
+        const header = `${label} ${timestamp}`.trim();
+        return messageText ? `${header} ${messageText}` : header;
+      })
       .join("\n\n")
       .trim();
 

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -27,6 +27,8 @@ import {
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
 import {
+  formatChatMessageLabel,
+  formatChatMessageTimestamp,
   mapAgentReplyToMessages,
   mapHistoryToMessages,
   mergeChatMessages,
@@ -280,18 +282,13 @@ export const RepositoryPage: React.FC = () => {
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;
 
-    const formatMessageLabel = (message: ChatMessage) => {
-      if (message.messageType === "tool") return "[tool]";
-      if (message.messageType === "thinking") return "[agent:thinking]";
-      if (message.messageType === "final") return "[agent:final]";
-      return `[${message.role}]`;
-    };
-
     const content = chat
       .map((message) => {
-        const label = formatMessageLabel(message);
+        const label = formatChatMessageLabel(message);
+        const timestamp = formatChatMessageTimestamp(message);
         const messageText = message.text || "";
-        return messageText ? `${label} ${messageText}` : label;
+        const header = `${label} ${timestamp}`.trim();
+        return messageText ? `${header} ${messageText}` : header;
       })
       .join("\n\n")
       .trim();

--- a/packages/frontend/src/utils/chat.ts
+++ b/packages/frontend/src/utils/chat.ts
@@ -22,6 +22,19 @@ export const normalizeChatMessageText = (text: string | undefined | null) => {
   return normalized;
 };
 
+export const formatChatMessageLabel = (message: ChatMessage) => {
+  if (message.messageType === "tool") return "[tool]";
+  if (message.messageType === "thinking") return "[agent:thinking]";
+  if (message.messageType === "final") return "[agent:final]";
+  return `[${message.role}]`;
+};
+
+export const formatChatMessageTimestamp = (message: ChatMessage) => {
+  const parsed = Date.parse(message.timestamp);
+  if (!Number.isFinite(parsed)) return "Unknown time";
+  return new Date(parsed).toLocaleString();
+};
+
 export const buildMessageDedupKey = (message: ChatMessage) => {
   const normalizedText = normalizeChatMessageText(message.text);
   const userTextKey = normalizedText.slice(0, 300);


### PR DESCRIPTION
### Motivation

- Improve the "whole chat history" copy feature by including per-message timestamps alongside role labels so exported histories are more informative.

### Description

- Add shared helpers `formatChatMessageLabel` and `formatChatMessageTimestamp` in `packages/frontend/src/utils/chat.ts` to produce consistent role/type labels and human-readable timestamps.
- Update the full-chat copy behavior in `RepositoryPage`, `KnowledgeArtefactPage`, and `ConstitutionPage` to prepend a header of the form `<label> <timestamp>` to each message when copying the whole conversation.
- Replace the inline label formatter in `RepositoryPage` with the new shared helper and update imports across the three pages.

### Testing

- Ran linting with `npm --workspace packages/frontend run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c8cf76688332b1ac9b87502e6f2d)