### PR TITLE
Add branch badges to repositories and expose branch in backend API

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -320,6 +320,7 @@ export type RepositorySummary = {
   path: string;
   hasGit: boolean;
   lastCommit: string | null;
+  branch: string | null;
   technology: string;
   license: string;
 };

--- a/packages/frontend/src/pages/RepositoriesPage.tsx
+++ b/packages/frontend/src/pages/RepositoriesPage.tsx
@@ -135,6 +135,9 @@ export const RepositoriesPage: React.FC = () => {
                         </span>
                         <span className="badge">{repo.technology}</span>
                         <span className="badge">{repo.license}</span>
+                        {repo.hasGit && repo.branch && (
+                          <span className="badge">Branch: {repo.branch}</span>
+                        )}
                       </div>
                       <div className="meta-secondary">
                         Last commit:{" "}

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1371,6 +1371,9 @@ export const RepositoryPage: React.FC = () => {
           >
             {repository.hasGit ? "Git" : "No Git"}
           </span>
+          {repository.hasGit && repository.branch && (
+            <span className="badge">Branch: {repository.branch}</span>
+          )}
         </div>
       )}
       <TabView

--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -76,6 +76,23 @@ def get_last_commit_date(repo_path: Path) -> str | None:
         return None
 
 
+def get_branch_name(repo_path: Path) -> str | None:
+    try:
+        output = subprocess.check_output(
+            ["git", "-C", str(repo_path), "rev-parse", "--abbrev-ref", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    if not output:
+        return None
+    if output == "HEAD":
+        return "Detached"
+    return output
+
+
 def get_license(repo_path: Path) -> str:
     for candidate in ["LICENSE", "LICENSE.md", "LICENSE.txt"]:
         license_path = repo_path / candidate
@@ -116,6 +133,7 @@ def get_repository_info(repo_name: str) -> Dict[str, Union[str, bool, None]]:
         "path": str(repo_path),
         "hasGit": is_git,
         "lastCommit": get_last_commit_date(repo_path) if is_git else None,
+        "branch": get_branch_name(repo_path) if is_git else None,
         "technology": detect_technology(repo_path),
         "license": get_license(repo_path),
     }


### PR DESCRIPTION
### Motivation
- Surface the current Git branch for repositories in the frontend UI alongside technology/license/git badges so users can see which branch is active. 
- Provide the branch information from the backend API so the frontend can reliably display the branch for Git repositories. 

### Description
- Added `get_branch_name` to `packages/pybackend/repository_service.py` which runs `git rev-parse --abbrev-ref HEAD` and returns a branch name or `Detached` for detached HEADs. 
- Included a `branch` field in the repository metadata returned by `get_repository_info` so repository listings and detail endpoints include branch info. 
- Extended the frontend `RepositorySummary` type in `packages/frontend/src/hooks/useApi.ts` to include `branch: string | null`. 
- Rendered branch badges in the UI in `packages/frontend/src/pages/RepositoriesPage.tsx` and `packages/frontend/src/pages/RepositoryPage.tsx` when `hasGit` is true and `branch` is present. 

### Testing
- Ran frontend unit tests with `npm --workspace packages/frontend run test`, which produced 1 failing test (Vitest): the `chat utils` test `mergeChatMessages` case "uses message IDs for user history entries when available" failed. 
- Ran backend tests with `cd packages/pybackend && uv run pytest`, and all backend tests passed (`178 passed, 6 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ea2b23388332ad1a4d43d9503500)