### PR TITLE
Implement lazy loading for repository tree

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -154,8 +154,10 @@ export const api = {
     }),
   getRepository: (name: string) =>
     request<RepositorySummary>(`/repositories/${name}`),
-  getRepositoryFiles: (name: string) =>
-    request<FileNode>(`/repositories/${name}/files`),
+  getRepositoryFiles: (name: string, path = ".") =>
+    request<FileNode>(
+      `/repositories/${name}/files?path=${encodeURIComponent(path)}`,
+    ),
   readRepositoryFile: (name: string, filePath: string) =>
     request<{ content: string }>(
       `/repositories/${name}/file?path=${encodeURIComponent(filePath)}`,

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -228,10 +228,10 @@ def repository_info(name: str):
 
 
 @app.get("/api/repositories/{name}/files")
-def repository_files(name: str):
+def repository_files(name: str, path: str = Query(".")):
     try:
-        logger.info("Listing files for repository '%s'", name)
-        return list_repository_files(name)
+        logger.info("Listing files for repository '%s' at '%s'", name, path)
+        return list_repository_files(name, path)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
 

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -463,13 +463,21 @@ class TestRepositoryEndpoints:
     @patch('app.list_repository_files')
     def test_list_repository_files_success(self, mock_list_files):
         """Test successful repository files listing."""
-        mock_files = ["file1.py", "file2.md", "dir/file3.txt"]
+        mock_files = {
+            "name": "test-repo",
+            "path": ".",
+            "type": "folder",
+            "children": [
+                {"name": "file1.py", "path": "file1.py", "type": "file", "size": 123},
+            ],
+        }
         mock_list_files.return_value = mock_files
         
         response = client.get("/api/repositories/test-repo/files")
         
         assert response.status_code == 200
         assert response.json() == mock_files
+        mock_list_files.assert_called_once_with("test-repo", ".")
 
     @patch('app.read_repository_file')
     def test_read_repository_file_success(self, mock_read):


### PR DESCRIPTION
### Motivation
- Prevent expensive full-repository traversal on initial load by adding shallow directory listing and enabling lazy loading of folder contents.

### Description
- Add `build_directory_node` and change `list_repository_files` to accept a `path` parameter and return a shallow listing for the requested directory in `packages/pybackend/repository_service.py`.
- Update the backend endpoint to accept `path` via `Query` and forward it to `list_repository_files` in `packages/pybackend/app.py`.
- Update frontend API to allow calling `getRepositoryFiles(name, path)` and encode the `path` query parameter in `packages/frontend/src/hooks/useApi.ts`.
- Implement lazy loading in the file browser by fetching root initially and loading folder children on expand with `findNodeByPath`, `updateNodeChildren`, and `loadFolderChildren`, and adjust calls to `getRepositoryFiles` in `packages/frontend/src/pages/RepositoryPage.tsx`.
- Adjust unit test `test_list_repository_files_success` to expect the new folder node shape and to assert the backend function was called with the default path.

### Testing
- Ran the focused API unit test with `uv run pytest tests/unit/test_api.py -k list_repository_files`, which passed (1 passed, others deselected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ef6dd99c833296180153fe2d2d63)