### PR TITLE
Remove branch prefix from badges

### DIFF
--- a/packages/frontend/src/pages/RepositoriesPage.tsx
+++ b/packages/frontend/src/pages/RepositoriesPage.tsx
@@ -136,7 +136,7 @@ export const RepositoriesPage: React.FC = () => {
                         <span className="badge">{repo.technology}</span>
                         <span className="badge">{repo.license}</span>
                         {repo.hasGit && repo.branch && (
-                          <span className="badge">Branch: {repo.branch}</span>
+                          <span className="badge">{repo.branch}</span>
                         )}
                       </div>
                       <div className="meta-secondary">

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1424,7 +1424,7 @@ export const RepositoryPage: React.FC = () => {
             {repository.hasGit ? "Git" : "No Git"}
           </span>
           {repository.hasGit && repository.branch && (
-            <span className="badge">Branch: {repository.branch}</span>
+            <span className="badge">{repository.branch}</span>
           )}
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Display only the branch name in repository badges (no "Branch:" prefix) to match the requested UI simplification.

### Description
- Updated `packages/frontend/src/pages/RepositoriesPage.tsx` and `packages/frontend/src/pages/RepositoryPage.tsx` to drop the `"Branch: "` prefix and render just the branch name inside the badge.

### Testing
- Ran unit tests with `npm --workspace packages/frontend run test` (Vitest), which produced 13 passed and 1 failed test: `src/utils/chat.test.ts > chat utils > mergeChatMessages > uses message IDs for user history entries when available` (failure expected length 2 but got 1).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681bb38da88332ba9973a948232bdc)