### PR TITLE
Add ARGS badge to command buttons when arguments are required

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1366,6 +1366,8 @@ export const RepositoryPage: React.FC = () => {
                   <div className="commands-grid">
                     {availableCommands.map((command) => {
                       const description = command.description || command.name;
+                      const argumentPlan = getCommandArgumentPlan(command);
+                      const usesArguments = argumentPlan.labels.length > 0;
                       return (
                         <button
                           key={command.id}
@@ -1373,8 +1375,15 @@ export const RepositoryPage: React.FC = () => {
                           title={`${command.source} • ${command.name}`}
                           onClick={() => handleCommandSelection(command)}
                         >
-                          <span className="command-button__badge">
-                            {formatCommandSourceLabel(command.source)}
+                          <span className="command-button__badges">
+                            {usesArguments && (
+                              <span className="command-button__badge command-button__badge--args">
+                                ARGS
+                              </span>
+                            )}
+                            <span className="command-button__badge">
+                              {formatCommandSourceLabel(command.source)}
+                            </span>
                           </span>
                           <span className="command-button__title">
                             {command.name}

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -184,10 +184,17 @@
   width: 100%;
 }
 
-.command-button__badge {
+.command-button__badges {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  z-index: 1;
+}
+
+.command-button__badge {
   padding: 0.1rem 0.4rem;
   border-radius: 999px;
   font-size: 0.55rem;
@@ -198,8 +205,14 @@
   background: rgba(14, 116, 144, 0.95);
   border: 1px solid rgba(255, 255, 255, 0.5);
   color: rgba(255, 255, 255, 0.95);
-  z-index: 1;
   box-shadow: 0 6px 16px rgba(8, 47, 73, 0.35);
+}
+
+.command-button__badge--args {
+  background: var(--neutral-strong);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  box-shadow: none;
 }
 
 .command-button__title {


### PR DESCRIPTION
### Motivation
- Improve command list UX by indicating which commands accept arguments so users can spot them quickly. 
- Reuse existing neutral/grey palette so the indicator matches the frontend theme without introducing a new color.

### Description
- Added detection of a command's argument plan via `getCommandArgumentPlan(command)` and compute `usesArguments` in `packages/frontend/src/pages/RepositoryPage.tsx`.
- Render a new `ARGS` badge to the left of the existing source badge when `usesArguments` is true, by wrapping badges in a `.command-button__badges` container.
- Added layout and styling in `packages/frontend/src/styles/page.css` including `.command-button__badges` and `.command-button__badge--args` which uses `--neutral-strong`, `--border`, and `--muted` tokens.

### Testing
- Ran `npm --workspace packages/frontend run lint` and the linter completed successfully.
- Executed an automated Playwright script that loaded the dev frontend and captured a screenshot to verify the badge rendering (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696953bb8e6c8332abdffdfc661d0ce1)