### PR TITLE
Adjust ARGS badge color for visibility

### DIFF
--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -245,9 +245,9 @@
 }
 
 .command-button__badge--args {
-  background: var(--neutral-strong);
-  border: 1px solid var(--border);
-  color: var(--muted);
+  background: rgba(250, 204, 21, 0.95);
+  border: 1px solid rgba(245, 158, 11, 0.95);
+  color: #1f2937;
   box-shadow: none;
 }
 


### PR DESCRIPTION
### Motivation
- Improve visibility of the `ARGS` badge by using a brighter, yellow-ish background and higher-contrast text so the badge is easily readable in the command list.

### Description
- Update `.command-button__badge--args` in `packages/frontend/src/styles/page.css` to use `background: rgba(250, 204, 21, 0.95)`, `border: 1px solid rgba(245, 158, 11, 0.95)`, and `color: #1f2937` for better contrast.

### Testing
- Started the frontend with `npm run dev:frontend` and captured a screenshot via a Playwright script which successfully produced the `args-badge.png` artifact, confirming the visual change (Vite started and the script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969661929e88332b2eeb54f9cb11a54)