### PR TITLE
Fix command preview icon styling

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -182,7 +182,14 @@ const FileIcon: React.FC = () => (
 
 const MagnifyingGlassIcon: React.FC = () => (
   <svg aria-hidden="true" viewBox="0 0 24 24" role="img" focusable="false">
-    <path d="M11 4a7 7 0 1 0 4.39 12.46l3.58 3.58a1 1 0 0 0 1.42-1.42l-3.58-3.58A7 7 0 0 0 11 4Zm0 2a5 5 0 1 1 0 10 5 5 0 0 1 0-10Z" />
+    <path
+      d="M11 4a7 7 0 1 0 4.39 12.46l3.58 3.58a1 1 0 0 0 1.42-1.42l-3.58-3.58A7 7 0 0 0 11 4Zm0 2a5 5 0 1 1 0 10 5 5 0 0 1 0-10Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 );
 

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -220,28 +220,28 @@
 
 .command-button__preview {
   position: absolute;
-  right: 0.6rem;
-  bottom: 0.6rem;
-  width: 1.7rem;
-  height: 1.7rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  background: rgba(15, 23, 42, 0.75);
-  color: rgba(255, 255, 255, 0.95);
+  right: 0.75rem;
+  bottom: 0.75rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: none;
+  background: transparent;
+  color: #fff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 6px 16px rgba(8, 47, 73, 0.35);
+  box-shadow: none;
+  padding: 0;
 }
 
 .command-button__preview svg {
-  width: 0.9rem;
-  height: 0.9rem;
+  width: 1.1rem;
+  height: 1.1rem;
 }
 
 .command-button__preview:hover,
 .command-button__preview:focus-visible {
-  background: rgba(30, 41, 59, 0.9);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .command-button__badge--args {


### PR DESCRIPTION
### Motivation
- The magnifying glass preview icon was rendered as a filled circle with a background and misaligned inside the command button, but the design requires a white stroked outline with no background positioned at the lower-right of the button.

### Description
- Replace the filled SVG path in `MagnifyingGlassIcon` with a stroked outline (`fill="none"`, `stroke="currentColor"`, adjusted stroke attributes) and update `.command-button__preview` in `packages/frontend/src/styles/page.css` to remove the circular background, border and shadow, shrink and align the control to the lower-right, and set the icon color to white.

### Testing
- Ran `npm --workspace packages/frontend run lint` which succeeded, and ran a Playwright capture of the repository page that produced a screenshot (`artifacts/commands.png`) verifying the visual change, although the frontend hit API proxy `ECONNREFUSED` errors during the run because the backend was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696965d4b2cc83328899965953927061)