### PR TITLE
Make command preview modal scrollable and mobile-friendly

### DIFF
--- a/packages/frontend/src/components/Modal.tsx
+++ b/packages/frontend/src/components/Modal.tsx
@@ -6,6 +6,7 @@ interface ModalProps {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
+  className?: string;
 }
 
 export const Modal: React.FC<ModalProps> = ({
@@ -13,11 +14,12 @@ export const Modal: React.FC<ModalProps> = ({
   title,
   onClose,
   children,
+  className,
 }) => {
   if (!open) return null;
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true">
-      <div className="modal">
+      <div className={`modal${className ? ` ${className}` : ""}`}>
         <header className="modal-header">
           <h2>{title}</h2>
           <button

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1532,6 +1532,7 @@ export const RepositoryPage: React.FC = () => {
           commandPreview ? `Command Preview: ${commandPreview.name}` : "Preview"
         }
         onClose={closeCommandPreview}
+        className="modal--command-preview"
       >
         {commandPreview && commandPreviewContent ? (
           <div

--- a/packages/frontend/src/styles/modal.css
+++ b/packages/frontend/src/styles/modal.css
@@ -20,6 +20,34 @@
   gap: 1rem;
 }
 
+.modal-body {
+  min-height: 0;
+}
+
+.modal--command-preview {
+  width: min(92vw, 640px);
+  max-height: min(85vh, 720px);
+}
+
+.modal--command-preview .modal-body {
+  overflow-y: auto;
+}
+
+.modal--command-preview .markdown {
+  padding-right: 0.5rem;
+}
+
+.modal--command-preview .modal-body > * {
+  margin-top: 0;
+}
+
+@media (max-width: 640px) {
+  .modal--command-preview {
+    padding: 1.5rem;
+    max-height: 78vh;
+  }
+}
+
 .modal-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Limit the command preview dialog size on small screens and make long preview content scrollable so previews remain usable on mobile devices.

### Description
- Add an optional `className` prop to the `Modal` component, apply `modal--command-preview` to the command preview modal in `RepositoryPage.tsx`, and add targeted CSS in `packages/frontend/src/styles/modal.css` to constrain width/max-height and enable internal scrolling with mobile adjustments.

### Testing
- Ran `npm run lint` which passed, and executed an automated Playwright script to capture UI screenshots that produced artifacts while the frontend logged proxy `ECONNREFUSED` errors due to the backend not being available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696966e427488332a217588737e5312e)