### PR TITLE
Fix command preview icon alignment

### DIFF
--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -176,6 +176,7 @@
 
 .command-button-wrapper {
   position: relative;
+  display: grid;
   width: 100%;
 }
 
@@ -219,9 +220,11 @@
 }
 
 .command-button__preview {
-  position: absolute;
-  right: 0.75rem;
-  bottom: 0.75rem;
+  position: relative;
+  grid-area: 1 / 1;
+  justify-self: end;
+  align-self: end;
+  margin: 0.75rem;
   width: 1.25rem;
   height: 1.25rem;
   border: none;
@@ -232,6 +235,7 @@
   justify-content: center;
   box-shadow: none;
   padding: 0;
+  z-index: 1;
 }
 
 .command-button__preview svg {


### PR DESCRIPTION
### Motivation
- Fix the command preview (magnifying glass) icon that was visually detached from the command button by anchoring it to the button corner using a grid-based layout.

### Description
- Update `packages/frontend/src/styles/page.css` to set `.command-button-wrapper` to `display: grid` and reposition `.command-button__preview` using `grid-area`, `justify-self`, `align-self`, `margin`, and `z-index` so the preview icon stays aligned with the command card corner.

### Testing
- Ran unit tests with `npm --workspace packages/frontend run test` (Vitest) which produced 13 passing and 1 failing test (`uses message IDs for user history entries when available`), and ran the frontend dev server and a Playwright script to capture a screenshot to verify the layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696967af91d883329958ef42406a2fe7)