### PR TITLE
Move magnifying glass preview button to bottom-right of command cards

### DIFF
--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -221,11 +221,9 @@
 }
 
 .command-button__preview {
-  position: relative;
-  grid-area: 1 / 1;
-  justify-self: end;
-  align-self: end;
-  margin: 0.75rem;
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
   width: 1.25rem;
   height: 1.25rem;
   border: none;


### PR DESCRIPTION
### Motivation
- Prevent the magnifying glass (command preview) button from overlapping and hiding command text on command cards.

### Description
- Update `.command-button__preview` in `packages/frontend/src/styles/page.css` to use `position: absolute` with `right: 0.75rem` and `bottom: 0.75rem`, replacing the previous grid-relative placement so the icon sits in the card corner.

### Testing
- Ran unit tests with `npm test` in `packages/frontend` which reported 1 failing test: `src/utils/chat.test.ts` "uses message IDs for user history entries when available" (13 passed, 1 failed).
- Launched the frontend with `npm run dev` and captured a Playwright screenshot to visually verify the icon placement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d9eaf6888332b7e93434225ca84c)