### PR TITLE
Sort knowledge and constitution artefact lists by name

### DIFF
--- a/packages/pybackend/constitution_service.py
+++ b/packages/pybackend/constitution_service.py
@@ -24,7 +24,7 @@ def list_constitutions():
                     "frontmatter": data,
                 }
             )
-    return constitutions
+    return sorted(constitutions, key=lambda constitution: constitution["name"])
 
 
 def read_constitution(file_name: str):

--- a/packages/pybackend/knowledge_service.py
+++ b/packages/pybackend/knowledge_service.py
@@ -25,7 +25,7 @@ def list_knowledge_artefacts():
                     "frontmatter": data,
                 }
             )
-    return artefacts
+    return sorted(artefacts, key=lambda artefact: artefact["name"])
 
 
 def read_knowledge_artefact(file_name: str):


### PR DESCRIPTION
### Motivation
- Ensure artefact listings are returned in a stable, deterministic order (by file name) so UI lists and consumers get consistent ordering.

### Description
- Return sorted lists from `list_knowledge_artefacts()` by file name by applying `sorted(..., key=lambda artefact: artefact["name"])`.
- Return sorted lists from `list_constitutions()` by file name by applying `sorted(..., key=lambda constitution: constitution["name"])`.

### Testing
- Ran `python -m pytest packages/pybackend/tests/unit/test_api.py::TestConstitutionEndpoints::test_list_constitutions_success packages/pybackend/tests/unit/test_api.py::TestKnowledgeEndpoints::test_list_knowledge_success`, which could not run due to missing dependency (`ModuleNotFoundError: No module named 'fastapi'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9d56e6d08332a04f1d0254b09f1d)