### PR TITLE
Use document/template for knowledge artefact types (default to document)

### DIFF
--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -297,7 +297,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
                     <label htmlFor="artefact-type">Type</label>
                     <select
                       id="artefact-type"
-                      value={(frontmatter.type as string) || "internal"}
+                      value={(frontmatter.type as string) || "document"}
                       onChange={(event) =>
                         setFrontmatter({
                           ...frontmatter,
@@ -305,8 +305,8 @@ export const KnowledgeArtefactPage: React.FC = () => {
                         })
                       }
                     >
-                      <option value="internal">Internal</option>
-                      <option value="external">External</option>
+                      <option value="document">Document</option>
+                      <option value="template">Template</option>
                     </select>
                   </div>
                 </Panel>

--- a/packages/frontend/src/pages/KnowledgePage.tsx
+++ b/packages/frontend/src/pages/KnowledgePage.tsx
@@ -33,7 +33,7 @@ export const KnowledgePage: React.FC = () => {
     await api.saveKnowledge(filename, {
       content: "# New Artefact\n",
       frontmatter: {
-        type: "internal",
+        type: "document",
         tags: newTags ? newTags.split(",").map((tag) => tag.trim()) : [],
       },
     });
@@ -71,7 +71,7 @@ export const KnowledgePage: React.FC = () => {
                     >
                       <div className="metadata">
                         <span className="badge">
-                          {artefact.type ?? "internal"}
+                          {artefact.type ?? "document"}
                         </span>
                         {artefact.tags && artefact.tags.length > 0 && (
                           <span className="badge">

--- a/packages/pybackend/knowledge_service.py
+++ b/packages/pybackend/knowledge_service.py
@@ -19,7 +19,7 @@ def list_knowledge_artefacts():
             artefacts.append(
                 {
                     "name": entry.name,
-                    "type": data.get("type", "internal"),
+                    "type": data.get("type", "document"),
                     "tags": data.get("tags", []),
                     "content": parsed.content,
                     "frontmatter": data,

--- a/packages/pybackend/tests/unit/test_matter_storage.py
+++ b/packages/pybackend/tests/unit/test_matter_storage.py
@@ -41,7 +41,7 @@ def test_write_knowledge_creates_file(tmp_path, monkeypatch):
 
     name = "notes.md"
     content = "# Notes\nDetails about the system."
-    metadata = {"type": "internal", "tags": ["notes", "docs"]}
+    metadata = {"type": "document", "tags": ["notes", "docs"]}
 
     write_knowledge_artefact(name, metadata, content)
 


### PR DESCRIPTION
### Motivation
- Replace the previous `internal`/`external` knowledge artefact types with the new `document` and `template` options and make `document` the default fallback.
- Ensure backend listing, frontend creation/display, and tests use the new type names for consistency.

### Description
- Changed backend artefact listing to use `data.get("type", "document")` as the default in `packages/pybackend/knowledge_service.py`.
- Updated the new-artefact frontmatter default in `packages/frontend/src/pages/KnowledgePage.tsx` to set `type: "document"` when creating artefacts, and changed the UI badge fallback to `"document"`.
- Replaced the artefact type select in `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` to offer `Document` and `Template` options and use `"document"` as the fallback value.
- Adjusted the unit test metadata in `packages/pybackend/tests/unit/test_matter_storage.py` to expect `{"type": "document", ...}`.

### Testing
- Started the frontend dev server and launched a Playwright script that navigated to `/knowledge` and captured a screenshot showing the updated type options, which completed successfully.
- No backend unit or integration test suite was executed as part of this change; updated unit test file was modified but not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9d162d648332be50b0438225d1ee)