### PR TITLE
Group documents by template status

### DIFF
--- a/packages/frontend/src/pages/ConstitutionsPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionsPage.tsx
@@ -12,6 +12,17 @@ export const ConstitutionsPage: React.FC = () => {
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const navigate = useNavigate();
+  const isTemplate = (constitution: ArtefactSummary) => {
+    if (typeof constitution.type === "string") {
+      return constitution.type === "template";
+    }
+    const frontmatterType = constitution.frontmatter?.type;
+    return typeof frontmatterType === "string" && frontmatterType === "template";
+  };
+  const templateConstitutions = constitutions.filter(isTemplate);
+  const documentConstitutions = constitutions.filter(
+    (constitution) => !isTemplate(constitution),
+  );
 
   const loadConstitutions = () => {
     api
@@ -58,21 +69,50 @@ export const ConstitutionsPage: React.FC = () => {
                   </button>
                 </div>
                 <div className="panel-column">
-                  {constitutions.map((constitution) => (
-                    <Panel
-                      key={constitution.name}
-                      title={constitution.name}
-                      to={`/constitutions/${constitution.name}`}
-                    >
-                      <div className="metadata">
-                        {typeof constitution.frontmatter?.type === "string" && (
-                          <span className="badge">
-                            {String(constitution.frontmatter.type)}
-                          </span>
-                        )}
+                  {templateConstitutions.length > 0 && (
+                    <Panel title="Templates">
+                      <div className="panel-column">
+                        {templateConstitutions.map((constitution) => (
+                          <Panel
+                            key={constitution.name}
+                            title={constitution.name}
+                            to={`/constitutions/${constitution.name}`}
+                          >
+                            <div className="metadata">
+                              {typeof constitution.frontmatter?.type ===
+                                "string" && (
+                                <span className="badge">
+                                  {String(constitution.frontmatter.type)}
+                                </span>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
                       </div>
                     </Panel>
-                  ))}
+                  )}
+                  {documentConstitutions.length > 0 && (
+                    <Panel title="Documents">
+                      <div className="panel-column">
+                        {documentConstitutions.map((constitution) => (
+                          <Panel
+                            key={constitution.name}
+                            title={constitution.name}
+                            to={`/constitutions/${constitution.name}`}
+                          >
+                            <div className="metadata">
+                              {typeof constitution.frontmatter?.type ===
+                                "string" && (
+                                <span className="badge">
+                                  {String(constitution.frontmatter.type)}
+                                </span>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
+                      </div>
+                    </Panel>
+                  )}
                   {constitutions.length === 0 && (
                     <div className="empty">No constitutions available.</div>
                   )}

--- a/packages/frontend/src/pages/KnowledgePage.tsx
+++ b/packages/frontend/src/pages/KnowledgePage.tsx
@@ -13,6 +13,15 @@ export const KnowledgePage: React.FC = () => {
   const [newName, setNewName] = useState("");
   const [newTags, setNewTags] = useState("");
   const navigate = useNavigate();
+  const isTemplate = (artefact: ArtefactSummary) => {
+    if (typeof artefact.type === "string") {
+      return artefact.type === "template";
+    }
+    const frontmatterType = artefact.frontmatter?.type;
+    return typeof frontmatterType === "string" && frontmatterType === "template";
+  };
+  const templateArtefacts = artefacts.filter(isTemplate);
+  const documentArtefacts = artefacts.filter((artefact) => !isTemplate(artefact));
 
   const loadArtefacts = () => {
     api
@@ -63,24 +72,54 @@ export const KnowledgePage: React.FC = () => {
                   </button>
                 </div>
                 <div className="panel-column">
-                  {artefacts.map((artefact) => (
-                    <Panel
-                      key={artefact.name}
-                      title={artefact.name}
-                      to={`/knowledge/${artefact.name}`}
-                    >
-                      <div className="metadata">
-                        <span className="badge">
-                          {artefact.type ?? "document"}
-                        </span>
-                        {artefact.tags && artefact.tags.length > 0 && (
-                          <span className="badge">
-                            {artefact.tags.join(", ")}
-                          </span>
-                        )}
+                  {templateArtefacts.length > 0 && (
+                    <Panel title="Templates">
+                      <div className="panel-column">
+                        {templateArtefacts.map((artefact) => (
+                          <Panel
+                            key={artefact.name}
+                            title={artefact.name}
+                            to={`/knowledge/${artefact.name}`}
+                          >
+                            <div className="metadata">
+                              <span className="badge">
+                                {artefact.type ?? "document"}
+                              </span>
+                              {artefact.tags && artefact.tags.length > 0 && (
+                                <span className="badge">
+                                  {artefact.tags.join(", ")}
+                                </span>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
                       </div>
                     </Panel>
-                  ))}
+                  )}
+                  {documentArtefacts.length > 0 && (
+                    <Panel title="Documents">
+                      <div className="panel-column">
+                        {documentArtefacts.map((artefact) => (
+                          <Panel
+                            key={artefact.name}
+                            title={artefact.name}
+                            to={`/knowledge/${artefact.name}`}
+                          >
+                            <div className="metadata">
+                              <span className="badge">
+                                {artefact.type ?? "document"}
+                              </span>
+                              {artefact.tags && artefact.tags.length > 0 && (
+                                <span className="badge">
+                                  {artefact.tags.join(", ")}
+                                </span>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
+                      </div>
+                    </Panel>
+                  )}
                   {artefacts.length === 0 && (
                     <div className="empty">No artefacts available.</div>
                   )}


### PR DESCRIPTION
### Motivation
- Improve discoverability by separating "template" artefacts from regular documents in the Knowledge Base and Constitution lists.
- Only show panels when there are documents for that category to avoid empty headings cluttering the UI.

### Description
- Add an `isTemplate` predicate and compute `template` and `document` arrays in `packages/frontend/src/pages/KnowledgePage.tsx` to separate artefacts by type.
- Apply the same `isTemplate` grouping in `packages/frontend/src/pages/ConstitutionsPage.tsx` to split constitutions into Templates and Documents panels.
- Render `Panel` sections for `Templates` and `Documents` only when those arrays have content, and preserve the existing empty-state message when there are no artefacts.
- Keep existing metadata and navigation for each artefact/constitution item and reuse the `Panel` component for nested lists.

### Testing
- Ran unit tests with `npm --workspace packages/frontend run test` (Vitest), result: 13 tests passed and 1 test failed (`src/utils/chat.test.ts > mergeChatMessages > uses message IDs for user history entries when available`).
- Started the frontend dev server with `npm --workspace packages/frontend run dev` as a smoke test and verified the app served at `http://localhost:5173/` and screenshots of the `/knowledge` and `/constitutions` pages were captured successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa559e6688332a98adbb0c5554f04)