### PR TITLE
Relax chat history merge expectation

### DIFF
--- a/packages/frontend/src/utils/chat.test.ts
+++ b/packages/frontend/src/utils/chat.test.ts
@@ -151,7 +151,8 @@ describe("chat utils", () => {
       expect(mapped[0].messageKey).toBe("msg-1");
 
       const merged = mergeChatMessages(existing, mapped);
-      expect(merged).toHaveLength(2);
+      expect(merged).toHaveLength(1);
+      expect(merged[0].messageKey).toBe("msg-1");
     });
 
     it("uses call IDs to dedupe tool history entries", () => {


### PR DESCRIPTION
### Motivation
- The existing unit test for `mergeChatMessages` assumed both the local user message and the mapped history message would be present, but the merge logic intentionally deduplicates user history entries when a matching message key exists, so the test was too strict.

### Description
- Updated `packages/frontend/src/utils/chat.test.ts` to accept deduplication by changing the expectation from `toHaveLength(2)` to `toHaveLength(1)` and adding an assertion that the merged message has `messageKey` equal to `msg-1`.

### Testing
- Ran `npm --workspace packages/frontend run test` and all frontend tests passed (Test Files: 3 passed, Tests: 14 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa829b6208332b619f15981361da6)