### PR TITLE
Prepend restricted scope block to artefact and constitution agent prompts

### DIFF
--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -57,6 +57,22 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [sessionListLoading, setSessionListLoading] = useState(false);
   const chatWindowRef = useRef<HTMLDivElement>(null);
 
+  const buildRestrictedPrompt = useCallback(
+    (fileName: string, message: string) => `---
+mode: restricted
+file: ${fileName}
+access_policy: >
+  By default, you may access ONLY the referenced file if needed.
+  All other files are inaccessible unless the prompt explicitly
+  requests broader access.
+  If required information is not accessible under the default scope,
+  respond with: "Not answerable with the provided files."
+---
+
+${message}`,
+    [],
+  );
+
   const scrollToBottom = () => {
     if (chatWindowRef.current) {
       chatWindowRef.current.scrollTop = chatWindowRef.current.scrollHeight;
@@ -156,10 +172,11 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const handleSend = async () => {
     if (!name || !prompt.trim()) return;
     const timestamp = new Date().toISOString();
+    const trimmedPrompt = prompt.trim();
     const userMessage: ChatMessage = {
       id: `${timestamp}-user`,
       role: "user",
-      text: prompt.trim(),
+      text: trimmedPrompt,
       timestamp,
     };
     setChat((prev) => [...prev, userMessage]);
@@ -168,7 +185,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     try {
       const reply = await api.sendKnowledgeAgent(
         name,
-        userMessage.text,
+        buildRestrictedPrompt(name, trimmedPrompt),
         sessionId || undefined,
       );
       setChat((prev) => [...prev, ...mapAgentReplyToMessages(reply)]);


### PR DESCRIPTION
### Motivation
- Constrain agent prompts to the artefact in scope by prepending a restricted-scope block that instructs the agent to only access the referenced file.

### Description
- Added a `buildRestrictedPrompt(fileName, message)` helper in `KnowledgeArtefactPage.tsx` and `ConstitutionPage.tsx` that prepends a YAML `mode: restricted` block with `file` and `access_policy` to the user message.
- Use the helper when calling `api.sendKnowledgeAgent` and `api.sendConstitutionAgent`, sending the wrapped prompt instead of the raw text while preserving the original user-visible message in chat history.
- Trim the prompt before sending to avoid duplicate whitespace and ensure consistent message content.

### Testing
- Ran `npm --workspace packages/frontend run test` (Vitest), and the frontend test suite completed successfully with `Test Files 3 passed` and `Tests 14 passed`.
- No backend or additional automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab03a65388332b59beb7f5d0c6ada)