### PR TITLE
Append restricted access policy to artefact agent prompts

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -24,6 +24,7 @@ import {
   mapAgentReplyToMessages,
   mapHistoryToMessages,
 } from "../utils/chat";
+import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
@@ -180,9 +181,13 @@ export const ConstitutionPage: React.FC = () => {
       }
       setChatLoading(true);
       try {
+        const promptWithPolicy = appendRestrictedAccessPolicy(
+          userMessage.text,
+          name,
+        );
         const reply = await api.sendConstitutionAgent(
           name,
-          userMessage.text,
+          promptWithPolicy,
           sessionId || undefined,
         );
         setChat((prev) => [...prev, ...mapAgentReplyToMessages(reply)]);

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -24,6 +24,7 @@ import {
   mapAgentReplyToMessages,
   mapHistoryToMessages,
 } from "../utils/chat";
+import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
@@ -180,9 +181,13 @@ export const KnowledgeArtefactPage: React.FC = () => {
       }
       setChatLoading(true);
       try {
+        const promptWithPolicy = appendRestrictedAccessPolicy(
+          userMessage.text,
+          name,
+        );
         const reply = await api.sendKnowledgeAgent(
           name,
-          userMessage.text,
+          promptWithPolicy,
           sessionId || undefined,
         );
         setChat((prev) => [...prev, ...mapAgentReplyToMessages(reply)]);

--- a/packages/frontend/src/utils/agentPrompt.ts
+++ b/packages/frontend/src/utils/agentPrompt.ts
@@ -1,0 +1,19 @@
+const ACCESS_POLICY_BLOCK = (fileName: string) => `---
+mode: restricted
+file: ${fileName}
+access_policy: >
+  By default, you may access ONLY the referenced file if needed.
+  All other files are inaccessible unless the prompt explicitly
+  requests broader access.
+  If required information is not accessible under the default scope,
+  respond with: "Not answerable with the provided files."
+---`;
+
+export const appendRestrictedAccessPolicy = (
+  message: string,
+  fileName: string,
+): string => {
+  const trimmed = message.trim();
+  if (!trimmed) return trimmed;
+  return `${trimmed}\n\n${ACCESS_POLICY_BLOCK(fileName)}`;
+};


### PR DESCRIPTION
### Motivation
- Ensure agents invoked from artefact pages are constrained to the artefact in scope by injecting a restricted-access policy block into outgoing prompts. 
- Apply the policy for both knowledge and constitution artefacts so command-driven or user messages from those pages carry the same access guard.

### Description
- Add `packages/frontend/src/utils/agentPrompt.ts` which exports `appendRestrictedAccessPolicy(message, fileName)` that appends a `mode: restricted` policy block referencing the artefact filename to non-empty messages.
- Update `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` to call `appendRestrictedAccessPolicy` before sending messages via `api.sendKnowledgeAgent`.
- Update `packages/frontend/src/pages/ConstitutionPage.tsx` to call `appendRestrictedAccessPolicy` before sending messages via `api.sendConstitutionAgent`.
- The helper trims empty messages and only appends the policy when the message is non-empty, preserving existing behavior.

### Testing
- Ran frontend unit tests with `npm --workspace packages/frontend run test`, which executed Vitest and resulted in `14 passed (14)` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab2499c0c8332a0d8dbb95e2523db)