### PR TITLE
Add scroll-to-last-message icon in agent chat panels

### DIFF
--- a/packages/frontend/src/components/icons/ArrowDownIcon.tsx
+++ b/packages/frontend/src/components/icons/ArrowDownIcon.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export const ArrowDownIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M12 5v14" />
+    <path d="m19 12-7 7-7-7" />
+  </svg>
+);

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../utils/chat";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
+import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
 
 export const ConstitutionPage: React.FC = () => {
@@ -368,6 +369,16 @@ export const ConstitutionPage: React.FC = () => {
                 title="Agent Conversation"
                 actions={
                   <div className="panel-action-buttons">
+                    <button
+                      type="button"
+                      className="copy-button"
+                      onClick={scrollToBottom}
+                      aria-label="Scroll to last message"
+                      title="Scroll to last message"
+                      disabled={!chat.length}
+                    >
+                      <ArrowDownIcon />
+                    </button>
                     <button
                       type="button"
                       className={`copy-button${chat.length ? "" : " is-muted"}`}

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../utils/chat";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
+import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
 
 export const KnowledgeArtefactPage: React.FC = () => {
@@ -386,6 +387,16 @@ export const KnowledgeArtefactPage: React.FC = () => {
                 title="Agent Conversation"
                 actions={
                   <div className="panel-action-buttons">
+                    <button
+                      type="button"
+                      className="copy-button"
+                      onClick={scrollToBottom}
+                      aria-label="Scroll to last message"
+                      title="Scroll to last message"
+                      disabled={!chat.length}
+                    >
+                      <ArrowDownIcon />
+                    </button>
                     <button
                       type="button"
                       className={`copy-button${chat.length ? "" : " is-muted"}`}

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -34,6 +34,7 @@ import {
   mergeChatMessages,
 } from "../utils/chat";
 import { ClearSessionModal } from "../components/ClearSessionModal";
+import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
 
 const stripCommandFrontmatter = (content: string) => {
@@ -1091,6 +1092,16 @@ export const RepositoryPage: React.FC = () => {
           title="Agent Collaboration"
           actions={
             <div className="panel-action-buttons">
+              <button
+                type="button"
+                className="copy-button"
+                onClick={scrollToBottom}
+                aria-label="Scroll to last message"
+                title="Scroll to last message"
+                disabled={!chat.length}
+              >
+                <ArrowDownIcon />
+              </button>
               <button
                 type="button"
                 className={`copy-button${chat.length ? "" : " is-muted"}`}


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to jump to the last chat message in agent panels next to the existing session picker control to improve UX for long conversations.

### Description
- Add a reusable `ArrowDownIcon` component at `packages/frontend/src/components/icons/ArrowDownIcon.tsx`.
- Add a scroll-to-last-message button that calls `scrollToBottom` and shows the arrow icon in the agent panel action area of `ConstitutionPage`, `KnowledgeArtefactPage`, and `RepositoryPage` next to the session `DatabaseIcon`.
- The new button uses `aria-label`/`title` of `Scroll to last message` and is disabled when the chat has no messages.
- Changes are limited to imports and the action button markup in `packages/frontend/src/pages/ConstitutionPage.tsx`, `packages/frontend/src/pages/KnowledgeArtefactPage.tsx`, and `packages/frontend/src/pages/RepositoryPage.tsx`.

### Testing
- Ran frontend unit tests with `npm --workspace packages/frontend run test`, and the test suite passed (`14 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab40249ac8332b8420835a1f6b6d5)