### PR TITLE
Prepend access policy and strip frontmatter in chat

### DIFF
--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -34,6 +34,14 @@ const copyText = (text: string) => {
   });
 };
 
+const stripFrontmatter = (content: string) => {
+  const delimiterPattern =
+    /^\s*---(?:[\r\n]+[\s\S]*?[\r\n]+---|[\s\S]*?---)\s*/;
+  return delimiterPattern.test(content)
+    ? content.replace(delimiterPattern, "").trim()
+    : content.trim();
+};
+
 const CopyIcon: React.FC = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -84,31 +92,34 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   onClearSession,
 }) => (
   <div className="chat-window" ref={chatWindowRef}>
-    {chat.map((message) => (
-      <div
-        key={message.id}
-        className={`chat-message ${message.role} ${message.messageType || ""}`}
-      >
-        <div className="chat-meta">{formatTimestamp(message)}</div>
-        <button
-          type="button"
-          className="copy-button chat-copy-button"
-          aria-label="Copy message"
-          title="Copy message"
-          onClick={() => copyText(message.text || "")}
-        >
-          <CopyIcon />
-        </button>
+    {chat.map((message) => {
+      const strippedMessage = stripFrontmatter(message.text || "");
+      return (
         <div
-          className="markdown"
-          dangerouslySetInnerHTML={{
-            __html: message.text?.trim() 
-              ? marked(message.text) 
-              : "<em>Empty message</em>",
-          }}
-        />
-      </div>
-    ))}
+          key={message.id}
+          className={`chat-message ${message.role} ${message.messageType || ""}`}
+        >
+          <div className="chat-meta">{formatTimestamp(message)}</div>
+          <button
+            type="button"
+            className="copy-button chat-copy-button"
+            aria-label="Copy message"
+            title="Copy message"
+            onClick={() => copyText(strippedMessage)}
+          >
+            <CopyIcon />
+          </button>
+          <div
+            className="markdown"
+            dangerouslySetInnerHTML={{
+              __html: strippedMessage.trim()
+                ? marked(strippedMessage)
+                : "<em>Empty message</em>",
+            }}
+          />
+        </div>
+      );
+    })}
     {loading && (
       <div className="loading-indicator">
         <div className="loading-spinner"></div>

--- a/packages/frontend/src/utils/agentPrompt.ts
+++ b/packages/frontend/src/utils/agentPrompt.ts
@@ -15,5 +15,5 @@ export const appendRestrictedAccessPolicy = (
 ): string => {
   const trimmed = message.trim();
   if (!trimmed) return trimmed;
-  return `${trimmed}\n\n${ACCESS_POLICY_BLOCK(fileName)}`;
+  return `${ACCESS_POLICY_BLOCK(fileName)}\n\n${trimmed}`;
 };


### PR DESCRIPTION
### Motivation
- Ensure the file-scope preamble (access policy) is prepended to user prompts so the agent receives the policy before the user message. 
- Prevent YAML frontmatter from being displayed or copied in the frontend chat to avoid leaking metadata and improve message readability.

### Description
- Update `appendRestrictedAccessPolicy` to prepend the `ACCESS_POLICY_BLOCK` before the message so the file-scope preamble always appears first.
- Add a `stripFrontmatter` helper in `packages/frontend/src/components/ChatWindow.tsx` to remove YAML frontmatter from messages before rendering.
- Use the stripped message for both rendering (via `marked`) and for the copy-to-clipboard action so copied text omits frontmatter.

### Testing
- Ran `npm --workspace packages/frontend run test` (Vitest) and all frontend tests passed: 14 tests passed across 3 test files.
- Attempted an automated Playwright script to capture a screenshot, but the browser crashed (TargetClosedError / SIGSEGV) and the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696abdd9a52083328a82370ce0d908e4)