### PR TITLE
Expand harness search to MADE knowledge and constitutions

### DIFF
--- a/packages/pybackend/harness_service.py
+++ b/packages/pybackend/harness_service.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-from config import get_made_home, get_workspace_home
+from config import get_made_directory, get_made_home, get_workspace_home
 
 
 def _load_harness_file(file_path: Path, source: str) -> Dict[str, Any]:
@@ -44,8 +44,11 @@ def _load_repo_harnesses(repo_name: str | None) -> List[Dict[str, Any]]:
 
 def list_harnesses(repo_name: str | None = None) -> List[Dict[str, Any]]:
     harnesses: List[Dict[str, Any]] = []
+    made_directory = get_made_directory()
     harness_roots: List[Tuple[Path, str]] = [
         (get_made_home(), "made"),
+        (made_directory / "knowledge", "knowledge"),
+        (made_directory / "constitutions", "constitution"),
         (get_workspace_home(), "workspace"),
         (Path.home(), "user"),
     ]


### PR DESCRIPTION
### Motivation
- Ensure harness scripts placed in MADE-managed knowledge or constitution folders are discovered by the service and reuse the existing MADE directory helper for correctness.

### Description
- Import `get_made_directory`, assign `made_directory = get_made_directory()`, and add `(made_directory / "knowledge", "knowledge")` and `(made_directory / "constitutions", "constitution")` to the `harness_roots` list in `packages/pybackend/harness_service.py` so those locations are scanned for harness scripts.

### Testing
- Ran `cd packages/pybackend && uv run pytest tests/unit/test_harness_service.py` and the suite completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696abff1f5b48332a2045efaeb90a201)