### PR TITLE
Add timing logs for agent CLI runs

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -378,6 +378,7 @@ def send_agent_message(
         else:
             # Use typed interface
             agent_cli = get_agent_cli()
+            start_time = time.monotonic()
             result = agent_cli.run_agent(
                 message,
                 active_session,
@@ -385,6 +386,13 @@ def send_agent_message(
                 working_dir,
                 cancel_event=cancel_event,
                 on_process=lambda process: _register_active_process(channel, process),
+            )
+            duration_seconds = time.monotonic() - start_time
+            logger.info(
+                "Agent CLI run completed (channel: %s, session: %s, duration=%.3fs)",
+                channel,
+                active_session,
+                duration_seconds,
             )
 
             if result.success:


### PR DESCRIPTION
### Motivation
- Add precise timing logs around the agent CLI invocation to quantify per-request latency and support performance analysis.

### Description
- In `packages/pybackend/agent_service.py` inside `send_agent_message` wrap the call to `agent_cli.run_agent(...)` with `start_time = time.monotonic()`, compute `duration_seconds = time.monotonic() - start_time`, and log `"Agent CLI run completed (channel: %s, session: %s, duration=%.3fs)"` including the measured duration.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c3f3e60548332b9766405a09e7122)