### PR TITLE
Document uv-based pytest usage for backend CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Focus on lightweight, fast feedback — only essential tests are included.
 
 ### CI/CD Note for Backend Pytest
 - If CI runs `python -m pytest packages/pybackend/tests/unit` directly, install backend dependencies first (e.g., `cd packages/pybackend && uv sync` or `python -m pip install -e packages/pybackend`) to avoid missing-import collection errors.
+- If CI runs `python -m pytest` outside the `uv` environment, dependencies like `fastapi` can be missing. Prefer running tests with `uv run` (for example: `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit`) or activate the `.venv` created by `uv sync` before executing pytest.
 
 ### ⚙️ Frontend Testing Checklist
 - [ ] **Unit Tests** — Cover core React components and utilities.

--- a/README.md
+++ b/README.md
@@ -153,15 +153,22 @@ make qa
 
 ### CI/CD Notes for Python Tests
 
-If your CI/CD environment runs `python -m pytest packages/pybackend/tests/unit` directly, make sure to install the backend dependencies first. Otherwise, collection can fail with missing imports like `fastapi` or `frontmatter`.
+If your CI/CD environment runs `python -m pytest packages/pybackend/tests/unit` directly, make sure to install the backend dependencies first and run pytest inside the `uv` environment. Otherwise, collection can fail with missing imports like `fastapi` or `frontmatter`.
 
 ```bash
 # Option A: use uv (recommended)
 cd packages/pybackend
 uv sync
+uv run python -m pytest tests/unit
 
 # Option B: use pip
 python -m pip install -e packages/pybackend
+```
+
+If you run tests from the repo root, use `uv run` with the backend project so `pytest` sees the `uv` environment:
+
+```bash
+uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit
 ```
 
 ### Testing Execution Patterns


### PR DESCRIPTION
### Motivation
- Ensure CI runs backend `pytest` inside the `uv` environment to avoid missing-import collection errors (e.g., `fastapi` or `frontmatter`).

### Description
- Update `README.md` and `AGENTS.md` to recommend running `uv sync`, activating the `.venv`, and using `uv run` with an example `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit` so tests executed from the repo root or CI see the `uv` environment.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca9cbffd08332aa684fae3b33fd69)