### PR TITLE
Add CLI timing logs for agent operations

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -237,7 +237,15 @@ def export_chat_history(
 
     # Use typed interface
     agent_cli = get_agent_cli()
+    start_time = time.monotonic()
     result = agent_cli.export_session(session_id, working_dir)
+    duration_seconds = time.monotonic() - start_time
+    logger.info(
+        "Agent CLI export completed (channel: %s, session: %s, duration=%.3fs)",
+        channel or "<unspecified>",
+        session_id,
+        duration_seconds,
+    )
 
     if not result.success:
         logger.error(
@@ -275,7 +283,14 @@ def list_chat_sessions(
     )
 
     agent_cli = get_agent_cli()
+    start_time = time.monotonic()
     result = agent_cli.list_sessions(working_dir)
+    duration_seconds = time.monotonic() - start_time
+    logger.info(
+        "Agent CLI list sessions completed (channel: %s, duration=%.3fs)",
+        channel or "<unspecified>",
+        duration_seconds,
+    )
 
     if not result.success:
         logger.error(
@@ -297,7 +312,12 @@ def list_agents() -> list[dict[str, object]]:
     logger.info("Listing available %s agents", AGENT_CLI.cli_name)
 
     agent_cli = get_agent_cli()
+    start_time = time.monotonic()
     result = agent_cli.list_agents()
+    duration_seconds = time.monotonic() - start_time
+    logger.info(
+        "Agent CLI list agents completed (duration=%.3fs)", duration_seconds
+    )
 
     if not result.success:
         logger.error("Listing agents failed: %s", result.error_message)


### PR DESCRIPTION
### Motivation
- Surface the execution duration of external agent CLI calls to aid debugging and performance monitoring.
- Timing was missing for session export and listing operations which makes it harder to correlate CLI runtimes with backend logs.

### Description
- Record start/end using `time.monotonic()` around `agent_cli.export_session` and log `Agent CLI export completed (channel: %s, session: %s, duration=%.3fs)` in `packages/pybackend/agent_service.py`.
- Record start/end around `agent_cli.list_sessions` and log `Agent CLI list sessions completed (channel: %s, duration=%.3fs)`.
- Record start/end around `agent_cli.list_agents` and log `Agent CLI list agents completed (duration=%.3fs)`.

### Testing
- Ran unit tests with `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py`, and all tests passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cbc5e910883329ff1ba3d73b5c4f3)