### PR TITLE
Ignore code blocks when inferring command argument placeholders

### DIFF
--- a/packages/frontend/src/components/CommandsTab.tsx
+++ b/packages/frontend/src/components/CommandsTab.tsx
@@ -14,6 +14,11 @@ const stripCommandFrontmatter = (content: string) => {
 
 const ARGUMENT_SPECIFIER_PATTERN = /\[([^\]]+)\]|<([^>]+)>/g;
 const PARENTHETICAL_COMMENT_PATTERN = /\s*\([^()]*\)\s*$/g;
+const CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
+const INLINE_CODE_PATTERN = /`[^`]*`/g;
+
+const stripCodeBlocks = (content: string) =>
+  content.replace(CODE_BLOCK_PATTERN, "").replace(INLINE_CODE_PATTERN, "");
 
 const normalizeArgumentHint = (argumentHint?: string | string[] | null) => {
   if (!argumentHint) return "";
@@ -187,9 +192,10 @@ export const CommandsTab: React.FC<CommandsTabProps> = ({
       };
     }
 
+    const contentWithoutCode = stripCodeBlocks(command.content);
     const numericPlaceholders = Array.from(
       new Set(
-        Array.from(command.content.matchAll(/\$([1-9]\d*)/g)).map(
+        Array.from(contentWithoutCode.matchAll(/\$([1-9]\d*)/g)).map(
           (match) => match[1],
         ),
       ),
@@ -202,7 +208,7 @@ export const CommandsTab: React.FC<CommandsTabProps> = ({
       };
     }
 
-    if (command.content.includes("$ARGUMENTS")) {
+    if (contentWithoutCode.includes("$ARGUMENTS")) {
       return { labels: ["Arguments"], placeholders: ["$ARGUMENTS"] };
     }
 

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -52,6 +52,8 @@ const stripCommandFrontmatter = (content: string) => {
 
 const ARGUMENT_SPECIFIER_PATTERN = /\[([^\]]+)\]|<([^>]+)>/g;
 const PARENTHETICAL_COMMENT_PATTERN = /\s*\([^()]*\)\s*$/g;
+const CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
+const INLINE_CODE_PATTERN = /`[^`]*`/g;
 
 type HarnessRun = {
   pid: number;
@@ -84,6 +86,9 @@ const extractArgumentLabels = (argumentHint?: ArgumentHint) => {
         .filter(Boolean)
     : [];
 };
+
+const stripCodeBlocks = (content: string) =>
+  content.replace(CODE_BLOCK_PATTERN, "").replace(INLINE_CODE_PATTERN, "");
 
 const formatArgumentHint = (argumentHint?: ArgumentHint) => {
   const normalizedHint = normalizeArgumentHint(argumentHint);
@@ -797,9 +802,10 @@ export const RepositoryPage: React.FC = () => {
       };
     }
 
+    const contentWithoutCode = stripCodeBlocks(command.content);
     const numericPlaceholders = Array.from(
       new Set(
-        Array.from(command.content.matchAll(/\$([1-9]\d*)/g)).map(
+        Array.from(contentWithoutCode.matchAll(/\$([1-9]\d*)/g)).map(
           (match) => match[1],
         ),
       ),
@@ -812,7 +818,7 @@ export const RepositoryPage: React.FC = () => {
       };
     }
 
-    if (command.content.includes("$ARGUMENTS")) {
+    if (contentWithoutCode.includes("$ARGUMENTS")) {
       return { labels: ["Arguments"], placeholders: ["$ARGUMENTS"] };
     }
 


### PR DESCRIPTION
### Motivation
- Prevent the UI from offering spurious argument prompts when command files contain example snippets or inline code that include `$` placeholders.

### Description
- Add `CODE_BLOCK_PATTERN` and `INLINE_CODE_PATTERN` and a `stripCodeBlocks` helper to remove fenced code and inline code from command content.
- Use `stripCodeBlocks` before scanning for numeric `$N` placeholders and `$ARGUMENTS` in both `CommandsTab` and `RepositoryPage` so placeholder inference ignores example code.
- Changes applied to `packages/frontend/src/components/CommandsTab.tsx` and `packages/frontend/src/pages/RepositoryPage.tsx`.

### Testing
- Ran frontend unit tests with `npm --workspace packages/frontend run test` and all tests passed (`Test Files 3 passed, Tests 14 passed`).
- Verified no runtime errors in the modified command placeholder inference code during local test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f67bab7bc8332ae95cf2c6ece0b87)