### PR TITLE
Fix repository chat controls layout

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1358,12 +1358,12 @@ export const RepositoryPage: React.FC = () => {
           <div className="button-bar chat-controls">
             <div className="chat-controls__left">
               <label className="model-select" htmlFor="agent-model-select">
-                <span>Model</span>
                 <select
                   id="agent-model-select"
                   value={selectedModel}
                   onChange={(event) => setSelectedModel(event.target.value)}
                   disabled={chatLoading}
+                  aria-label="Model"
                 >
                   {MODEL_OPTIONS.map((option) => (
                     <option

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -283,17 +283,15 @@ textarea {
 
 .chat-controls {
   align-items: center;
-  justify-content: space-between;
 }
 
 .chat-controls__left {
-  flex: 1;
-  max-width: 360px;
+  flex: 0 1 360px;
 }
 
 .chat-controls__right {
   display: flex;
-  flex: 1;
+  margin-left: auto;
   justify-content: flex-end;
   gap: 1rem;
 }
@@ -302,11 +300,6 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-}
-
-.model-select span {
-  font-size: 0.85rem;
-  color: var(--muted);
 }
 
 .form-group {


### PR DESCRIPTION
### Motivation
- The repository chat controls needed layout adjustments so the `Send` button is right-aligned and the visible "Model" label should be removed for a cleaner UI while remaining accessible.

### Description
- Removed the visible `Model` caption from the model selector and added an `aria-label="Model"` to the `<select>` in `packages/frontend/src/pages/RepositoryPage.tsx`.
- Adjusted flex sizing for chat controls by changing `.chat-controls__left` to `flex: 0 1 360px` and giving `.chat-controls__right` `margin-left: auto` in `packages/frontend/src/styles/index.css` so the `Send` button aligns to the right.
- Dropped the unused `.model-select span` styling from `packages/frontend/src/styles/index.css`.

### Testing
- Ran frontend unit tests with `npm --workspace packages/frontend run test`, and all tests passed (`3` test files, `14` tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697125cf317c8332b3554827b0133f84)