### PR TITLE
Persist repository agent model selection

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -311,10 +311,18 @@ export const RepositoryPage: React.FC = () => {
         : `repository-session-${agentCli}`,
     [agentCli, name],
   );
+  const modelStorageKey = useMemo(
+    () => (name ? `repository-model-${name}` : "repository-model"),
+    [name],
+  );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
   const [pendingPrompt, setPendingPrompt] = useState("");
-  const [selectedModel, setSelectedModel] = useState("default");
+  const [selectedModel, setSelectedModel] = usePersistentString(
+    modelStorageKey,
+    "default",
+  );
+  const normalizedSelectedModel = selectedModel ?? "default";
   const [chatError, setChatError] = useState<string | null>(null);
   const [chatLoading, setChatLoading] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
@@ -805,7 +813,9 @@ export const RepositoryPage: React.FC = () => {
     setChatLoading(true);
     try {
       const model =
-        selectedModel === "default" ? undefined : selectedModel.trim();
+        normalizedSelectedModel === "default"
+          ? undefined
+          : normalizedSelectedModel.trim();
       const reply = await api.sendAgentMessage(
         name,
         message,
@@ -1360,7 +1370,7 @@ export const RepositoryPage: React.FC = () => {
               <label className="model-select" htmlFor="agent-model-select">
                 <select
                   id="agent-model-select"
-                  value={selectedModel}
+                  value={normalizedSelectedModel}
                   onChange={(event) => setSelectedModel(event.target.value)}
                   disabled={chatLoading}
                   aria-label="Model"


### PR DESCRIPTION
### Motivation
- The agent model selector was not persisted per repository, so the chosen model reverted after a page reload.

### Description
- Added a per-repository `modelStorageKey` and replaced the local `selectedModel` state with `usePersistentString` so the selection is stored in `localStorage` in `packages/frontend/src/pages/RepositoryPage.tsx`.
- Introduced `normalizedSelectedModel` defaulting to `"default"` and used it to render the selector and to determine the `model` argument when calling `api.sendAgentMessage` (mapping `"default"` to `undefined`).
- Updated the `<select>` value and the message-sending logic to use the normalized/persisted value so selection survives reloads.

### Testing
- Ran `npm --workspace packages/frontend run test` and all frontend tests passed (3 test files, 14 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aa68010483328b9da083dd063018)