### PR TITLE
Fix Copilot CLI timestamp parsing

### DIFF
--- a/packages/pybackend/copilot_agent_cli.py
+++ b/packages/pybackend/copilot_agent_cli.py
@@ -71,7 +71,16 @@ class CopilotAgentCLI(AgentCLI):
         try:
             return int(float(raw_value))
         except (TypeError, ValueError):
-            return None
+            pass
+
+        if isinstance(raw_value, str):
+            try:
+                parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            return int(parsed.timestamp() * 1000)
+
+        return None
 
     def _session_matches_directory(self, session_id: str, cwd: Path) -> bool:
         """Check whether a session belongs to the provided working directory."""

--- a/packages/pybackend/tests/unit/test_copilot_agent_cli.py
+++ b/packages/pybackend/tests/unit/test_copilot_agent_cli.py
@@ -405,6 +405,7 @@ class TestCopilotAgentCLI:
         assert cli._to_milliseconds(1000) == 1000
         assert cli._to_milliseconds("1000") == 1000
         assert cli._to_milliseconds(1000.5) == 1000
+        assert cli._to_milliseconds("2026-02-01T07:40:11.105Z") == 1769931611105
 
         # Invalid conversions
         assert cli._to_milliseconds(None) is None


### PR DESCRIPTION
### Motivation
- Copilot CLI exported timestamps in ISO 8601 format (e.g. `2026-02-01T07:40:11.105Z`) were not converted to milliseconds causing the frontend to display `Unknown time`.

### Description
- Update `CopilotAgentCLI._to_milliseconds` to detect ISO 8601 string timestamps and parse them via `datetime.fromisoformat(...).timestamp()` (handles trailing `Z` by replacing with `+00:00`).
- Add unit coverage asserting an ISO timestamp string returns the expected millisecond value.
- Files changed: `packages/pybackend/copilot_agent_cli.py` and `packages/pybackend/tests/unit/test_copilot_agent_cli.py`.

### Testing
- Ran unit tests with `python -m pytest packages/pybackend/tests/unit/test_copilot_agent_cli.py` and all tests passed (22 passed, e.g. `22 passed in 0.24s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f03d3c18c8332a8c08053296cda3b)