### PR TITLE
Replace agent emoji in chat timestamps

### DIFF
--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -19,7 +19,7 @@ const formatTimestamp = (message: ChatMessage) => {
         : message.messageType === "tool"
           ? "🛠️ "
           : message.messageType === "final"
-            ? "🎯 "
+            ? "🤖 "
             : ""
       : "";
 


### PR DESCRIPTION
### Motivation
- Replace the 🎯 emoji used for agent final message timestamps with 🤖 to make agent outputs visually clearer in the chat UI.

### Description
- Update `formatTimestamp` in `packages/frontend/src/components/ChatWindow.tsx` to change the agent `messageType === "final"` prefix from `"🎯 "` to `"🤖 "`.

### Testing
- Ran frontend unit tests with `npm --workspace packages/frontend run test` (Vitest) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f24d41bf08332ad6e1c4e1a3a2c9e)