### PR TITLE
Add openai/gpt-5.3-codex to frontend supported models

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -140,6 +140,10 @@ const MODEL_OPTIONS = [
     value: "openai/gpt-5.2-codex",
     label: "openai/gpt-5.2-codex",
   },
+  {
+    value: "openai/gpt-5.3-codex",
+    label: "openai/gpt-5.3-codex",
+  },
 ];
 
 type HarnessRun = {


### PR DESCRIPTION
### Motivation
- Keep the frontend model selector up-to-date by adding the new `openai/gpt-5.3-codex` model so it can be selected in the UI.

### Description
- Inserted a new entry for `openai/gpt-5.3-codex` into the `MODEL_OPTIONS` array in `packages/frontend/src/pages/RepositoryPage.tsx` to expose the model in the dropdown.

### Testing
- Ran `npm run lint` which completed successfully.
- Started the frontend dev server with `npm --workspace packages/frontend run dev -- --host 0.0.0.0 --port 5173` and executed a Playwright script to open the app and capture a screenshot showing the UI (succeeded).
- Automated external checks to fetch model docs via `curl` failed due to outbound network restrictions (received HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba30fafdc833285c64e6ac3b15aee)