### PR TITLE
Add Tasks navigation item with placeholder page

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { KnowledgeArtefactPage } from "./pages/KnowledgeArtefactPage";
 import { ConstitutionsPage } from "./pages/ConstitutionsPage";
 import { ConstitutionPage } from "./pages/ConstitutionPage";
 import { SettingsPage } from "./pages/SettingsPage";
+import { TasksPage } from "./pages/TasksPage";
 import "./styles/layout.css";
 
 const AppShell: React.FC = () => {
@@ -53,6 +54,7 @@ const AppShell: React.FC = () => {
           <Route path="/knowledge/:name" element={<KnowledgeArtefactPage />} />
           <Route path="/constitutions" element={<ConstitutionsPage />} />
           <Route path="/constitutions/:name" element={<ConstitutionPage />} />
+          <Route path="/tasks" element={<TasksPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </main>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   RectangleGroupIcon,
   Squares2X2Icon,
 } from "@heroicons/react/24/outline";
+import { RecurringTasksIcon } from "./icons/RecurringTasksIcon";
 import React from "react";
 import { NavLink } from "react-router-dom";
 import "../styles/sidebar.css";
@@ -22,6 +23,7 @@ const MENU_ITEMS: MenuItem[] = [
   { path: "/repositories", label: "Repositories", icon: RectangleGroupIcon },
   { path: "/knowledge", label: "Knowledge Base", icon: BookOpenIcon },
   { path: "/constitutions", label: "Constitution", icon: CpuChipIcon },
+  { path: "/tasks", label: "Tasks", icon: RecurringTasksIcon },
   { path: "/settings", label: "Settings", icon: AdjustmentsHorizontalIcon },
 ];
 

--- a/packages/frontend/src/components/icons/RecurringTasksIcon.tsx
+++ b/packages/frontend/src/components/icons/RecurringTasksIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export const RecurringTasksIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
+  props,
+) => {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="4" y="5" width="11" height="14" rx="2" />
+      <path d="m7.5 9 1.4 1.4L11 8.2" />
+      <path d="m7.5 13 1.4 1.4L11 12.2" />
+      <path d="M16.8 9.4a4.2 4.2 0 1 1-1 8.28" />
+      <path d="m15.6 16.8.2 1.95 1.85-.66" />
+    </svg>
+  );
+};

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import "../styles/page.css";
+
+export const TasksPage: React.FC = () => {
+  return (
+    <div className="page">
+      <h1>Tasks</h1>
+      <div className="empty">Tasks page coming soon.</div>
+    </div>
+  );
+};


### PR DESCRIPTION
### Motivation
- Provide a top-level "Tasks" area in the app for future recurring-task features and give it a dedicated navigation target and icon. 

### Description
- Add a placeholder `TasksPage` at `packages/frontend/src/pages/TasksPage.tsx` with an empty-state message to be filled later. 
- Add a `RecurringTasksIcon` SVG component at `packages/frontend/src/components/icons/RecurringTasksIcon.tsx` representing recurring tasks (task checklist + arrowed circle). 
- Wire the new menu item into the sidebar by updating `packages/frontend/src/components/Sidebar.tsx` to include a `/tasks` entry that uses the new icon. 
- Wire the route into the app by importing `TasksPage` and adding a `/tasks` route in `packages/frontend/src/App.tsx`.

### Testing
- Ran `npm run build:frontend` and the build completed successfully. 
- Ran `npm run dev:frontend` and verified the UI visually by capturing a Playwright screenshot of the running frontend, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9fd1052883328b123e9516e12933)