### PR TITLE
Add openai/gpt-5.3 to repository model options

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -136,6 +136,7 @@ const MODEL_OPTIONS = [
     label: "openai/gpt-5.1-codex-mini",
   },
   { value: "openai/gpt-5.2", label: "openai/gpt-5.2" },
+  { value: "openai/gpt-5.3", label: "openai/gpt-5.3" },
   {
     value: "openai/gpt-5.2-codex",
     label: "openai/gpt-5.2-codex",


### PR DESCRIPTION
### Motivation
- Add `openai/gpt-5.3` to the model dropdown so the new OpenAI model is selectable in the repository UI.

### Description
- Inserted `{ value: "openai/gpt-5.3", label: "openai/gpt-5.3" }` into `MODEL_OPTIONS` in `packages/frontend/src/pages/RepositoryPage.tsx`.

### Testing
- Ran `npm run lint` which completed successfully and captured a UI screenshot of the `/repositories` page via an automated Playwright script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998367d62348332aaa34b24acb07ba1)