### PR TITLE
Add constitution-style agent and UI features to Tasks

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -403,6 +403,37 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
+  sendTaskAgent: (name: string, message: string, sessionId?: string) =>
+    request<AgentReply>(`/tasks/${name}/agent`, {
+      method: "POST",
+      body: JSON.stringify({ message, sessionId }),
+    }),
+  getTaskAgentStatus: (name: string) =>
+    request<AgentStatus>(`/tasks/${name}/agent/status`),
+  cancelTaskAgent: (name: string) =>
+    request(`/tasks/${name}/agent/cancel`, { method: "POST" }),
+  getTaskAgentHistory: (
+    name: string,
+    sessionId: string,
+    startTimestamp?: number,
+    signal?: AbortSignal,
+  ) => {
+    const params = new URLSearchParams({ session_id: sessionId });
+    if (typeof startTimestamp === "number" && Number.isFinite(startTimestamp)) {
+      params.append("start", Math.floor(startTimestamp).toString());
+    }
+
+    return request<ChatHistoryResponse>(
+      `/tasks/${name}/agent/history?${params.toString()}`,
+      { signal },
+    );
+  },
+  getTaskAgentSessions: (name: string, limit = 10) => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    return request<{ sessions: ChatSession[] }>(
+      `/tasks/${name}/agent/sessions?${params.toString()}`,
+    );
+  },
   getSettings: () => request<Record<string, unknown>>("/settings"),
   saveSettings: (settings: Record<string, unknown>) =>
     request("/settings", {

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -1,36 +1,162 @@
-import React, { useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { marked } from "marked";
-import { api } from "../hooks/useApi";
+import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
+import { ChatWindow } from "../components/ChatWindow";
+import { CommandsTab } from "../components/CommandsTab";
+import { HarnessesTab } from "../components/HarnessesTab";
+import { usePersistentChat } from "../hooks/usePersistentChat";
+import { usePersistentString } from "../hooks/usePersistentString";
+import { useAgentCli } from "../hooks/useAgentCli";
+import { api, ChatSession } from "../hooks/useApi";
+import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
+import {
+  formatChatMessageLabel,
+  formatChatMessageTimestamp,
+  mapAgentReplyToMessages,
+  mapHistoryToMessages,
+} from "../utils/chat";
+import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
+import { ClearSessionModal } from "../components/ClearSessionModal";
+import { SessionPickerModal } from "../components/SessionPickerModal";
+import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
+import { DatabaseIcon } from "../components/icons/DatabaseIcon";
 
 export const TaskPage: React.FC = () => {
-  const { name } = useParams<{ name: string }>();
+  const { name } = useParams();
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState("edit");
+  const [activeTab, setActiveTab] = useState("content");
+  const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
+  const agentCli = useAgentCli();
+  const chatStorageKey = useMemo(
+    () => (name ? `task-chat-${name}` : "task-chat"),
+    [name],
+  );
+  const sessionStorageKey = useMemo(
+    () =>
+      name
+        ? `task-session-${name}-${agentCli}`
+        : `task-session-${agentCli}`,
+    [agentCli, name],
+  );
+  const harnessHistoryStorageKey = useMemo(
+    () =>
+      name
+        ? `task-harness-history-${name}`
+        : "task-harness-history",
+    [name],
+  );
+  const [chat, setChat] = usePersistentChat(chatStorageKey);
+  const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
+  const [agentStatus, setAgentStatus] = useState<string | null>(null);
+  const [chatLoading, setChatLoading] = useState(false);
+  const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
+  const [sessionModalOpen, setSessionModalOpen] = useState(false);
+  const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
+  const [sessionListError, setSessionListError] = useState<string | null>(null);
+  const [sessionListLoading, setSessionListLoading] = useState(false);
+  const chatWindowRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    if (chatWindowRef.current) {
+      chatWindowRef.current.scrollTop = chatWindowRef.current.scrollHeight;
+    }
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [chat]);
+
+  const copyAllMessages = useCallback(() => {
+    if (!navigator.clipboard || !chat.length) return;
+
+    const content = chat
+      .map((message) => {
+        const label = formatChatMessageLabel(message);
+        const timestamp = formatChatMessageTimestamp(message);
+        const messageText = message.text || "";
+        const header = `${label} ${timestamp}`.trim();
+        return messageText ? `${header} ${messageText}` : header;
+      })
+      .join("\n\n")
+      .trim();
+
+    navigator.clipboard.writeText(content).catch((error) => {
+      console.error("Failed to copy chat history", error);
+    });
+  }, [chat]);
 
   useEffect(() => {
     if (!name) {
       navigate("/tasks");
       return;
     }
-
     api
       .getTask(name)
-      .then((data) => setContent(data.content ?? ""))
+      .then((data) => {
+        setFrontmatter(data.frontmatter ?? data.data ?? {});
+        setContent(data.content ?? "");
+      })
       .catch((error) => {
         console.error("Failed to load task", error);
         setStatus("Failed to load task");
       });
   }, [name, navigate]);
 
+  const refreshAgentStatus = useCallback(async () => {
+    if (!name) return false;
+    try {
+      const status = await api.getTaskAgentStatus(name);
+      setChatLoading(status.processing);
+      setAgentStatus(
+        status.processing
+          ? "Agent is still processing the previous message."
+          : null,
+      );
+      return status.processing;
+    } catch (error) {
+      console.error("Failed to load agent status", error);
+      return false;
+    }
+  }, [name]);
+
+  useEffect(() => {
+    refreshAgentStatus();
+  }, [refreshAgentStatus]);
+
+  const openSessionModal = useCallback(async () => {
+    if (!name) return;
+    setSessionModalOpen(true);
+    setSessionListLoading(true);
+    try {
+      const response = await api.getTaskAgentSessions(name, 10);
+      setSessionOptions(response.sessions || []);
+      setSessionListError(null);
+    } catch (error) {
+      console.error("Failed to load sessions", error);
+      const message =
+        error instanceof Error ? error.message : "Unable to load sessions";
+      setSessionListError(message);
+    } finally {
+      setSessionListLoading(false);
+    }
+  }, [name]);
+
   const handleSave = async () => {
     if (!name) return;
     try {
-      await api.saveTask(name, { content, frontmatter: { type: "task" } });
+      await api.saveTask(name, { content, frontmatter });
       setStatus("Saved successfully");
     } catch (error) {
       console.error("Failed to save task", error);
@@ -38,36 +164,314 @@ export const TaskPage: React.FC = () => {
     }
   };
 
+  const handleSendMessage = useCallback(
+    async (message: string, options?: { clearPrompt?: boolean }) => {
+      if (!name) return;
+      const trimmed = message.trim();
+      if (!trimmed) return;
+      const timestamp = new Date().toISOString();
+      const userMessage: ChatMessage = {
+        id: `${timestamp}-user`,
+        role: "user",
+        text: trimmed,
+        timestamp,
+      };
+      setChat((prev) => [...prev, userMessage]);
+      if (options?.clearPrompt) {
+        setPrompt("");
+      }
+      setChatLoading(true);
+      try {
+        const promptWithPolicy = appendRestrictedAccessPolicy(
+          userMessage.text,
+          name,
+        );
+        const reply = await api.sendTaskAgent(
+          name,
+          promptWithPolicy,
+          sessionId || undefined,
+        );
+        setChat((prev) => [...prev, ...mapAgentReplyToMessages(reply)]);
+        if (reply.sessionId) {
+          setSessionId(reply.sessionId);
+        }
+        setActiveTab("agent");
+        setAgentStatus(null);
+        setChatLoading(false);
+      } catch (error) {
+        console.error("Failed to contact agent", error);
+        const errorMessage = error instanceof Error ? error.message : "";
+        const busy = errorMessage.toLowerCase().includes("processing");
+        setAgentStatus(
+          busy
+            ? "Agent is still processing the previous message."
+            : "Agent unavailable",
+        );
+        const processing = await refreshAgentStatus();
+        if (!processing) {
+          setChatLoading(false);
+        }
+      }
+    },
+    [
+      name,
+      refreshAgentStatus,
+      sessionId,
+      setActiveTab,
+      setAgentStatus,
+      setChat,
+      setChatLoading,
+      setPrompt,
+      setSessionId,
+    ],
+  );
+
+  const handleSend = async () => {
+    if (!prompt.trim()) return;
+    await handleSendMessage(prompt, { clearPrompt: true });
+  };
+
+  const handleCancel = async () => {
+    if (!name) return;
+    try {
+      await api.cancelTaskAgent(name);
+    } catch (error) {
+      console.error("Failed to cancel agent request", error);
+      setAgentStatus("Unable to cancel the agent request.");
+    } finally {
+      await refreshAgentStatus();
+    }
+  };
+
+  const handleCancelClearSession = () => {
+    setClearSessionModalOpen(false);
+  };
+
+  const handleClearSessionOnly = () => {
+    setSessionId(null);
+    setClearSessionModalOpen(false);
+  };
+
+  const handleClearSessionAndHistory = () => {
+    setSessionId(null);
+    setChat([]);
+    setClearSessionModalOpen(false);
+  };
+
+  const handleSessionSelect = async (session: ChatSession) => {
+    if (!name) return;
+    setSessionModalOpen(false);
+    setChat([]);
+    setSessionId(session.id);
+    setChatLoading(true);
+    try {
+      const history = await api.getTaskAgentHistory(name, session.id);
+      const mapped = mapHistoryToMessages(history.messages || []);
+      setChat(mapped);
+      setAgentStatus(null);
+    } catch (error) {
+      console.error("Failed to load session history", error);
+      const message =
+        error instanceof Error ? error.message : "Failed to load session history";
+      setAgentStatus(message);
+    } finally {
+      setChatLoading(false);
+    }
+  };
+
+  const loadCommands = useCallback(async () => {
+    const response = await api.getCommands();
+    return response.commands;
+  }, []);
+
+  const loadHarnesses = useCallback(async () => {
+    const response = await api.getHarnesses();
+    return response.harnesses;
+  }, []);
+
+  const runHarness = useCallback(
+    async (harnessPath: string, args?: string) =>
+      api.runHarness(harnessPath, args),
+    [],
+  );
+
+  const getHarnessStatus = useCallback(
+    async (pid: number) => api.getHarnessStatus(pid),
+    [],
+  );
+
   return (
     <div className="page">
-      <h1>{name}</h1>
+      <h1>Task: {name}</h1>
+      {status && (
+        <div
+          className={`alert ${
+            status.includes("successfully")
+              ? "success"
+              : status.includes("failed") ||
+                  status.includes("Failed") ||
+                  status.includes("unavailable")
+                ? "error"
+                : ""
+          }`}
+        >
+          {status}
+        </div>
+      )}
       <TabView
         tabs={[
           {
-            id: "edit",
-            label: "Edit",
+            id: "content",
+            label: "Content",
             content: (
-              <>
-                <div className="button-bar">
-                  <button className="primary" onClick={handleSave}>
-                    Save
-                  </button>
-                </div>
-                <textarea
-                  className="editor"
-                  value={content}
-                  onChange={(event) => setContent(event.target.value)}
-                />
-              </>
+              <div className="artefact-grid">
+                <Panel
+                  title="Metadata"
+                  actions={
+                    <button className="primary" onClick={handleSave}>
+                      Save
+                    </button>
+                  }
+                >
+                  <div className="form-group">
+                    <label htmlFor="task-type">Type</label>
+                    <select
+                      id="task-type"
+                      value={(frontmatter.type as string) || "task"}
+                      onChange={(event) =>
+                        setFrontmatter({
+                          ...frontmatter,
+                          type: event.target.value,
+                        })
+                      }
+                    >
+                      <option value="task">Task</option>
+                      <option value="template">Template</option>
+                    </select>
+                  </div>
+                </Panel>
+                <Panel title="Markdown">
+                  <textarea
+                    value={content}
+                    onChange={(event) => setContent(event.target.value)}
+                    className="editor-input"
+                  />
+                </Panel>
+                <Panel title="Preview">
+                  <div
+                    className="markdown"
+                    dangerouslySetInnerHTML={{ __html: marked(content || "") }}
+                  />
+                </Panel>
+              </div>
             ),
           },
           {
-            id: "preview",
-            label: "Preview",
+            id: "agent",
+            label: "Agent",
             content: (
-              <div
-                className="markdown-preview"
-                dangerouslySetInnerHTML={{ __html: marked.parse(content) }}
+              <Panel
+                title="Agent Conversation"
+                actions={
+                  <div className="panel-action-buttons">
+                    <button
+                      type="button"
+                      className="copy-button"
+                      onClick={scrollToBottom}
+                      aria-label="Scroll to last message"
+                      title="Scroll to last message"
+                      disabled={!chat.length}
+                    >
+                      <ArrowDownIcon />
+                    </button>
+                    <button
+                      type="button"
+                      className={`copy-button${chat.length ? "" : " is-muted"}`}
+                      onClick={openSessionModal}
+                      aria-label="Choose a session"
+                      title="Choose a session"
+                    >
+                      <DatabaseIcon />
+                    </button>
+                    <button
+                      type="button"
+                      className="copy-button"
+                      onClick={copyAllMessages}
+                      aria-label="Copy chat messages"
+                      title="Copy chat messages"
+                      disabled={!chat.length}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                      </svg>
+                    </button>
+                  </div>
+                }
+              >
+                <ChatWindow
+                  chat={chat}
+                  chatWindowRef={chatWindowRef}
+                  loading={chatLoading}
+                  emptyMessage="Start a conversation to discuss this task."
+                  sessionId={sessionId}
+                  onClearSession={() => setClearSessionModalOpen(true)}
+                />
+                {agentStatus && <div className="alert">{agentStatus}</div>}
+                <textarea
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  placeholder="Ask the agent to refine this task..."
+                />
+                <div className="button-bar">
+                  {chatLoading ? (
+                    <button className="danger" onClick={handleCancel}>
+                      Cancel
+                    </button>
+                  ) : (
+                    <button
+                      className="primary"
+                      onClick={handleSend}
+                      disabled={!prompt.trim()}
+                    >
+                      Send
+                    </button>
+                  )}
+                </div>
+              </Panel>
+            ),
+          },
+          {
+            id: "harnesses",
+            label: "Harnesses",
+            content: (
+              <HarnessesTab
+                loadHarnesses={loadHarnesses}
+                runHarness={runHarness}
+                getHarnessStatus={getHarnessStatus}
+                historyStorageKey={harnessHistoryStorageKey}
+              />
+            ),
+          },
+          {
+            id: "commands",
+            label: "Commands",
+            content: (
+              <CommandsTab
+                loadCommands={loadCommands}
+                onSendMessage={(message) => handleSendMessage(message)}
               />
             ),
           },
@@ -75,7 +479,20 @@ export const TaskPage: React.FC = () => {
         activeTab={activeTab}
         onTabChange={setActiveTab}
       />
-      {status && <div className="status">{status}</div>}
+      <ClearSessionModal
+        open={clearSessionModalOpen}
+        onCancel={handleCancelClearSession}
+        onClearSessionOnly={handleClearSessionOnly}
+        onClearSessionAndHistory={handleClearSessionAndHistory}
+      />
+      <SessionPickerModal
+        open={sessionModalOpen}
+        loading={sessionListLoading}
+        error={sessionListError}
+        sessions={sessionOptions}
+        onClose={() => setSessionModalOpen(false)}
+        onSelect={handleSessionSelect}
+      />
     </div>
   );
 };

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -12,6 +12,17 @@ export const TasksPage: React.FC = () => {
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const navigate = useNavigate();
+  const isTemplate = (task: ArtefactSummary) => {
+    if (typeof task.type === "string") {
+      return task.type === "template";
+    }
+    const frontmatterType = task.frontmatter?.type;
+    return typeof frontmatterType === "string" && frontmatterType === "template";
+  };
+  const templateTasks = tasks.filter(isTemplate);
+  const documentTasks = tasks.filter(
+    (task) => !isTemplate(task),
+  );
 
   const loadTasks = () => {
     api
@@ -29,12 +40,10 @@ export const TasksPage: React.FC = () => {
     const filename = newName.trim().endsWith(".md")
       ? newName.trim()
       : `${newName.trim()}.md`;
-
     await api.saveTask(filename, {
       content: "# New Task\n\n- [ ] Define work\n",
       frontmatter: { type: "task" },
     });
-
     setCreateOpen(false);
     setNewName("");
     loadTasks();
@@ -59,24 +68,55 @@ export const TasksPage: React.FC = () => {
                     Create Task
                   </button>
                 </div>
-                <Panel title="Tasks">
-                  <div className="panel-column">
-                    {tasks.map((task) => (
-                      <Panel
-                        key={task.name}
-                        title={task.name}
-                        to={`/tasks/${task.name}`}
-                      >
-                        <div className="metadata">
-                          <span className="badge">task</span>
-                        </div>
-                      </Panel>
-                    ))}
-                  </div>
-                </Panel>
-                {tasks.length === 0 && (
-                  <div className="empty">No tasks available.</div>
-                )}
+                <div className="panel-column">
+                  {templateTasks.length > 0 && (
+                    <Panel title="Templates">
+                      <div className="panel-column">
+                        {templateTasks.map((task) => (
+                          <Panel
+                            key={task.name}
+                            title={task.name}
+                            to={`/tasks/${task.name}`}
+                          >
+                            <div className="metadata">
+                              {typeof task.frontmatter?.type ===
+                                "string" && (
+                                <span className="badge">
+                                  {String(task.frontmatter.type)}
+                                </span>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
+                      </div>
+                    </Panel>
+                  )}
+                  {documentTasks.length > 0 && (
+                    <Panel title="Documents">
+                      <div className="panel-column">
+                        {documentTasks.map((task) => (
+                          <Panel
+                            key={task.name}
+                            title={task.name}
+                            to={`/tasks/${task.name}`}
+                          >
+                            <div className="metadata">
+                              {typeof task.frontmatter?.type ===
+                                "string" && (
+                                <span className="badge">
+                                  {String(task.frontmatter.type)}
+                                </span>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
+                      </div>
+                    </Panel>
+                  )}
+                  {tasks.length === 0 && (
+                    <div className="empty">No tasks available.</div>
+                  )}
+                </div>
               </>
             ),
           },
@@ -85,7 +125,11 @@ export const TasksPage: React.FC = () => {
         onTabChange={setActiveTab}
       />
 
-      <Modal open={createOpen} title="Create Task" onClose={() => setCreateOpen(false)}>
+      <Modal
+        open={createOpen}
+        title="Create Task"
+        onClose={() => setCreateOpen(false)}
+      >
         <div className="form-group">
           <label htmlFor="task-name">File name</label>
           <input


### PR DESCRIPTION
### Motivation
- Make the Tasks UI and agent experience consistent with the Constitutions pages by providing the same metadata, editor, preview, agent chat, session controls, harnesses and commands functionality.
- Surface task agent capabilities on the backend so the frontend can reuse the existing channel/session agent patterns used by constitutions and knowledge artefacts.

### Description
- Frontend: added an enhanced `TaskPage` that mirrors `ConstitutionPage` with `Content`, `Agent`, `Harnesses` and `Commands` tabs, persistent chat and session state, session picker and clear-session modal, copy/scroll controls, and save metadata handling (file: `packages/frontend/src/pages/TaskPage.tsx`).
- Frontend: updated the tasks index to group tasks into `Templates` and `Documents` based on frontmatter/type and show typed badges (file: `packages/frontend/src/pages/TasksPage.tsx`).
- Frontend: extended the API client with task-agent methods `sendTaskAgent`, `getTaskAgentStatus`, `cancelTaskAgent`, `getTaskAgentHistory`, and `getTaskAgentSessions` (file: `packages/frontend/src/hooks/useApi.ts`).
- Backend: added task-agent endpoints that follow the same channel/session semantics as constitutions: `POST /api/tasks/{name}/agent`, `GET /api/tasks/{name}/agent/status`, `POST /api/tasks/{name}/agent/cancel`, `GET /api/tasks/{name}/agent/history`, and `GET /api/tasks/{name}/agent/sessions` (file: `packages/pybackend/app.py`).
- Tests: added unit tests covering the new task-agent endpoints and validation for missing message payloads (file: `packages/pybackend/tests/unit/test_api.py`).

### Testing
- Ran frontend lint: `npm --workspace packages/frontend run lint` and frontend unit tests: `npm --workspace packages/frontend run test`, all frontend tests passed.
- Ran backend unit tests: `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py`, backend unit suite passed (80 passed, 1 warning).
- Booted the frontend dev server and captured a screenshot of the updated tasks page at `/tasks` to validate the UI (Vite dev server started and screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a4eaad7883328af262c59c10029f)