### PR TITLE
Fix: Extract content from text field and handle OpenCode part types

### DIFF
--- a/packages/pybackend/opencode_database_agent_cli.py
+++ b/packages/pybackend/opencode_database_agent_cli.py
@@ -265,11 +265,38 @@ class OpenCodeDatabaseAgentCLI(AgentCLI):
                         # If there are parts, combine them
                         content_parts = []
                         for part in parts:
-                            part_content = part["json"].get("content", "")
+                            part_data = part["json"]
+                            part_type = part_data.get("type", "")
+
+                            # Extract content from different OpenCode part types
+                            part_content = ""
+                            if part_type == "text":
+                                # User input or initial text content
+                                part_content = part_data.get("text", "")
+                            elif part_type == "reasoning":
+                                # Assistant reasoning steps
+                                part_content = part_data.get("text", "")
+                            elif part_type == "tool":
+                                # Tool invocations - show tool name
+                                tool_name = part_data.get("tool", "")
+                                if tool_name:
+                                    part_content = f"[Tool: {tool_name}]"
+                            elif part_type in ["step-start", "step-finish"]:
+                                # Skip metadata-only parts
+                                continue
+                            else:
+                                # Fallback: check text, content, or other fields
+                                part_content = (
+                                    part_data.get("text", "")
+                                    or part_data.get("content", "")
+                                    or part_data.get("tool", "")
+                                )
+
                             if part_content:
                                 content_parts.append(part_content)
+
                         content = (
-                            "\n".join(content_parts)
+                            "\n\n".join(content_parts)
                             if content_parts
                             else msg_json.get("content", "")
                         )


### PR DESCRIPTION
## Problem
OpenCode database sessions were showing completely empty message content in MADE chat history export. For example, session `ses_37fc51f42ffeDiWK1LoHn1OvsB` displayed only timestamps with no actual conversation content:

```
[agent:final] 2026-02-21 13:44:28
[agent:final] 2026-02-21 13:44:28  
[agent:final] 2026-02-21 13:44:44
```

Investigation revealed that OpenCode stores message content in a different JSON structure than other agent CLIs, using specialized part types with content in the `text` field rather than `content` field.

## Solution
Implemented proper OpenCode part type handling with content extraction from the correct database fields:

1. **User messages**: Extract from `text` parts containing user input
2. **Assistant reasoning**: Extract from `reasoning` parts with thought process
3. **Tool invocations**: Format as `[Tool: tool_name]` from `tool` parts
4. **Metadata filtering**: Skip `step-start`/`step-finish` parts that contain no user-visible content
5. **Fallback handling**: Check `text`, `content`, or `tool` fields for unknown part types

## Changes
- **Modified:** `packages/pybackend/opencode_database_agent_cli.py`
  - Updated part content extraction logic in `export_session()` method
  - Added OpenCode part type detection and specialized handling
  - Changed content separator from `\n` to `\n\n` for better readability
  - Added comprehensive fallback logic for robust content extraction

## Testing
Validated with the problematic session `ses_37fc51f42ffeDiWK1LoHn1OvsB`:

**Before:**
```
Message 1: role=user, content_len=0
Message 2: role=assistant, content_len=0  
Message 3: role=assistant, content_len=0
```

**After:**
```
Message 1: role=user, content_len=228
  Preview: "With opencode_database_agent_cli.py: For 'ses_37fe73a42ffe511wDK9r0YKjcW'..."

Message 2: role=assistant, content_len=51  
  Preview: "**Inspecting path and parsing issue**\n\n[Tool: glob]"

Message 3: role=assistant, content_len=52
  Preview: "**Handling external directory access**\n\n[Tool: glob]"
```

✅ All 64 messages now have proper content extraction  
✅ User questions are fully visible  
✅ Assistant reasoning steps are preserved  
✅ Tool usage is clearly indicated  
✅ Conversation flow is maintained with proper formatting

## Example Output
**User Message:**
```
With opencode_database_agent_cli.py: For "ses_37fe73a42ffe511wDK9r0YKjcW" in "/home/tom/workspace/ai/made/workspace/ciagent/" I get the error "year 58112 is out of range" and the session history returns "unknown" session dates.
```

**Assistant Response:**
```
**Inspecting path and parsing issue**

[Tool: glob]
```

## Notes
- This fix complements the previous timestamp normalization fix
- OpenCode database schema: `~/.local/share/opencode/opencode.db`
- Part types documented: `text`, `reasoning`, `tool`, `step-start`, `step-finish`
- No breaking changes to existing functionality
- Maintains backward compatibility with other agent CLI implementations

Resolves empty message content in OpenCode session exports and restores full conversation visibility in MADE chat interface.