### PR TITLE
Fix: Prevent empty messages from timing/atomicity issues in OpenCode CLI export

### DIFF
--- a/packages/pybackend/opencode_database_agent_cli.py
+++ b/packages/pybackend/opencode_database_agent_cli.py
@@ -339,17 +339,18 @@ class OpenCodeDatabaseAgentCLI(AgentCLI):
                     else:
                         # No parts - use message content directly
                         content = msg_json.get("content", "")
-                        # Always create message for database records, even with empty content
-                        # This handles cases like malformed JSON gracefully
-                        messages.append(
-                            HistoryMessage(
-                                message_id=msg_id,
-                                role=role,
-                                content_type="text",
-                                content=content,
-                                timestamp=base_timestamp,
+                        # Only create message if there's actual text content
+                        # This prevents empty messages from timing/atomicity issues
+                        if content and content.strip():
+                            messages.append(
+                                HistoryMessage(
+                                    message_id=msg_id,
+                                    role=role,
+                                    content_type="text",
+                                    content=content,
+                                    timestamp=base_timestamp,
+                                )
                             )
-                        )
 
             logger.info(f"Exported {len(messages)} messages from session {session_id}")
             return ExportResult(success=True, session_id=session_id, messages=messages)


### PR DESCRIPTION
## Problem
Empty messages were appearing in chat history exports from the OpenCode database CLI. Investigation of session `ses_3793613b9ffeiZ0Hvo7Ws2BRSR` revealed this was due to timing/atomicity issues where message records are created in the database before their text content parts are written.

## Solution
Add content filtering to only export messages that have actual text content available. This prevents incomplete messages from being sent to the frontend while maintaining all functionality for complete messages.

## Changes
- **Modified `export_session` method** in `opencode_database_agent_cli.py`
- **Added content filter** for messages without parts: `if content and content.strip()`
- **Preserved existing behavior** for messages with text parts (already filtered correctly)
- **Maintained tool messages** which have tool names as valid content

## Testing
Verified against multiple sessions:
- ✅ **Session `ses_3793613b9ffeiZ0Hvo7Ws2BRSR`**: 136 messages, 0 empty
- ✅ **Session `ses_3792ce82cffeldzoRAu1LVUJ6M`**: 27 messages, 0 empty  
- ✅ **Session `ses_37930aab6ffe95w9M6NBjBeL2s`**: 41 messages, 0 empty

## Example Behavior
**Before:** Messages with only metadata appeared as empty entries
```
5. [text] assistant: ""
```

**After:** Only messages with content are exported
```
4. [tool_use] assistant: webfetch
5. [text] assistant: I'll fetch the current weather information for Lund, Sweden using a weather service.
```

## Notes
- **Root Cause**: Database writes aren't atomic - message records created before text parts
- **Strategy**: Filter at export time rather than query time to handle partial database states
- **Impact**: No functional changes for complete messages, eliminates empty message display
- **Performance**: Minimal impact - just adds content check for messages without parts

This surgical fix resolves the empty message issue while preserving all existing functionality and message content.