### PR TITLE
Add cron schedule metadata support for tasks

### DIFF
--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -336,6 +336,20 @@ export const TaskPage: React.FC = () => {
                   }
                 >
                   <div className="form-group">
+                    <label htmlFor="task-schedule">Schedule (cron)</label>
+                    <input
+                      id="task-schedule"
+                      value={(frontmatter.schedule as string) || ""}
+                      onChange={(event) =>
+                        setFrontmatter({
+                          ...frontmatter,
+                          schedule: event.target.value,
+                        })
+                      }
+                      placeholder="0 9 * * 1-5"
+                    />
+                  </div>
+                  <div className="form-group">
                     <label htmlFor="task-type">Type</label>
                     <select
                       id="task-type"

--- a/packages/frontend/src/pages/TasksPage.test.tsx
+++ b/packages/frontend/src/pages/TasksPage.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TasksPage } from "./TasksPage";
+import { api } from "../hooks/useApi";
+
+vi.mock("../hooks/useApi", async () => {
+  const actual = await vi.importActual<typeof import("../hooks/useApi")>(
+    "../hooks/useApi",
+  );
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listTasks: vi.fn(),
+      saveTask: vi.fn(),
+    },
+  };
+});
+
+describe("TasksPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders task schedules as green schedule tags", async () => {
+    vi.mocked(api.listTasks).mockResolvedValue({
+      tasks: [
+        {
+          name: "daily-report.md",
+          frontmatter: { type: "task", schedule: "0 9 * * 1-5" },
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("0 9 * * 1-5")).toBeInTheDocument();
+    expect(screen.getByText("0 9 * * 1-5")).toHaveClass("success");
+  });
+
+  it("creates tasks with schedule metadata", async () => {
+    vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
+    vi.mocked(api.saveTask).mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /create task/i }));
+    fireEvent.change(screen.getByLabelText(/file name/i), {
+      target: { value: "new-task" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(api.saveTask).toHaveBeenCalledWith("new-task.md", {
+        content: "# New Task\n\n- [ ] Define work\n",
+        frontmatter: { type: "task", schedule: "" },
+      });
+    });
+  });
+});

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -42,7 +42,7 @@ export const TasksPage: React.FC = () => {
       : `${newName.trim()}.md`;
     await api.saveTask(filename, {
       content: "# New Task\n\n- [ ] Define work\n",
-      frontmatter: { type: "task" },
+      frontmatter: { type: "task", schedule: "" },
     });
     setCreateOpen(false);
     setNewName("");
@@ -79,6 +79,12 @@ export const TasksPage: React.FC = () => {
                             to={`/tasks/${task.name}`}
                           >
                             <div className="metadata">
+                              {typeof task.frontmatter?.schedule === "string" &&
+                                task.frontmatter.schedule.trim() && (
+                                  <span className="badge success">
+                                    {String(task.frontmatter.schedule)}
+                                  </span>
+                                )}
                               {typeof task.frontmatter?.type ===
                                 "string" && (
                                 <span className="badge">
@@ -101,6 +107,12 @@ export const TasksPage: React.FC = () => {
                             to={`/tasks/${task.name}`}
                           >
                             <div className="metadata">
+                              {typeof task.frontmatter?.schedule === "string" &&
+                                task.frontmatter.schedule.trim() && (
+                                  <span className="badge success">
+                                    {String(task.frontmatter.schedule)}
+                                  </span>
+                                )}
                               {typeof task.frontmatter?.type ===
                                 "string" && (
                                 <span className="badge">


### PR DESCRIPTION
### Motivation
- Tasks need an editable cron-compatible `schedule` metadata so recurring work can be tracked and displayed. 
- The tasks list should surface schedule strings as a visual hint using an existing badge style.

### Description
- Added a `Schedule (cron)` input bound to `frontmatter.schedule` in the Task detail page so users can edit and save cron strings (`packages/frontend/src/pages/TaskPage.tsx`).
- Initialize new tasks with an empty `schedule` field when creating a task so the frontmatter key is always present (`packages/frontend/src/pages/TasksPage.tsx`).
- Display non-empty `frontmatter.schedule` values as a green-ish `badge success` tag on task cards in both Templates and Documents lists (`packages/frontend/src/pages/TasksPage.tsx`).
- Added unit tests in `packages/frontend/src/pages/TasksPage.test.tsx` covering schedule tag rendering and inclusion of `schedule` in the create payload.

### Testing
- Ran the frontend unit tests with `npm --workspace packages/frontend run test -- --run TasksPage.test.tsx` and the two new tests passed. 
- Executed an automated Playwright script to open the Task page and capture a screenshot which ran successfully and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d3d133308332bca23ec96de34151)