### PR TITLE
Make Create worktree button use primary (blue) style

### DIFF
--- a/packages/frontend/src/components/GitTab.tsx
+++ b/packages/frontend/src/components/GitTab.tsx
@@ -119,7 +119,7 @@ export const GitTab: React.FC<GitTabProps> = ({
       <Panel title="Management">
         <div className="button-bar">
           <button className="primary" onClick={onPull} disabled={pulling}>Pull</button>
-          <button className="secondary" onClick={() => setWorktreeModalOpen(true)}>
+          <button className="primary" onClick={() => setWorktreeModalOpen(true)}>
             Create worktree
           </button>
         </div>


### PR DESCRIPTION
### Motivation
- Make the Git management actions visually consistent by using the same primary/blue styling for the "Create worktree" button as the existing "Pull" button.

### Description
- Change the `className` for the "Create worktree" button from `secondary` to `primary` in `packages/frontend/src/components/GitTab.tsx`.

### Testing
- Ran `npm --workspace packages/frontend run test -- src/components/GitTab.test.tsx` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d0819ad083328871376fe606ace8)