### PR TITLE
Add worktree removal controls: API, service & UI

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -381,6 +381,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ directoryName, branchName }),
     }),
+  removeRepositoryWorktree: (name: string) =>
+    request<{ removed: string }>(`/repositories/${name}/git/worktree`, {
+      method: "DELETE",
+    }),
   runRepositoryHarness: (name: string, path: string, args?: string) =>
     request<{ pid: number; name: string; path: string }>(
       `/repositories/${name}/harnesses/run`,

--- a/packages/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/packages/frontend/src/pages/RepositoriesPage.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RepositoriesPage } from "./RepositoriesPage";
+import { api } from "../hooks/useApi";
+
+vi.mock("../hooks/useApi", async () => {
+  const actual = await vi.importActual<typeof import("../hooks/useApi")>(
+    "../hooks/useApi",
+  );
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listRepositories: vi.fn(),
+      removeRepositoryWorktree: vi.fn(),
+    },
+  };
+});
+
+describe("RepositoriesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows remove worktree button only for worktree repositories", async () => {
+    vi.mocked(api.listRepositories).mockResolvedValue({
+      repositories: [
+        {
+          name: "main-repo",
+          path: "/tmp/main-repo",
+          hasGit: true,
+          isWorktreeChild: false,
+          lastCommit: null,
+          branch: "main",
+          technology: "TypeScript",
+          license: "MIT",
+        },
+        {
+          name: "main-repo-feature",
+          path: "/tmp/main-repo-feature",
+          hasGit: true,
+          isWorktreeChild: true,
+          lastCommit: null,
+          branch: "feature/test",
+          technology: "TypeScript",
+          license: "MIT",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <RepositoriesPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByLabelText("Remove main-repo-feature worktree"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Remove main-repo worktree"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes a worktree after confirmation", async () => {
+    vi.mocked(api.listRepositories).mockResolvedValue({
+      repositories: [
+        {
+          name: "main-repo-feature",
+          path: "/tmp/main-repo-feature",
+          hasGit: true,
+          isWorktreeChild: true,
+          lastCommit: null,
+          branch: "feature/test",
+          technology: "TypeScript",
+          license: "MIT",
+        },
+      ],
+    });
+    vi.mocked(api.removeRepositoryWorktree).mockResolvedValue({
+      removed: "main-repo-feature",
+    });
+
+    render(
+      <MemoryRouter>
+        <RepositoriesPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(
+      await screen.findByLabelText("Remove main-repo-feature worktree"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(api.removeRepositoryWorktree).toHaveBeenCalledWith(
+        "main-repo-feature",
+      );
+    });
+  });
+});

--- a/packages/frontend/src/pages/RepositoriesPage.tsx
+++ b/packages/frontend/src/pages/RepositoriesPage.tsx
@@ -3,6 +3,7 @@ import { api, RepositorySummary } from "../hooks/useApi";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { Modal } from "../components/Modal";
+import { TrashIcon } from "../components/icons/TrashIcon";
 import "../styles/page.css";
 
 export const RepositoriesPage: React.FC = () => {
@@ -15,6 +16,11 @@ export const RepositoriesPage: React.FC = () => {
   const [cloneName, setCloneName] = useState("");
   const [cloneBranch, setCloneBranch] = useState("");
   const [isCloning, setIsCloning] = useState(false);
+  const [isRemovingWorktree, setIsRemovingWorktree] = useState(false);
+  const [removeWorktreeModal, setRemoveWorktreeModal] = useState<{
+    open: boolean;
+    name: string | null;
+  }>({ open: false, name: null });
   const [alert, setAlert] = useState<{
     type: "success" | "error";
     message: string;
@@ -60,6 +66,26 @@ export const RepositoriesPage: React.FC = () => {
     }
   };
 
+
+  const handleRemoveWorktree = async () => {
+    if (!removeWorktreeModal.name) return;
+
+    setIsRemovingWorktree(true);
+    try {
+      await api.removeRepositoryWorktree(removeWorktreeModal.name);
+      setAlert({ type: "success", message: "Worktree removed successfully" });
+      setRemoveWorktreeModal({ open: false, name: null });
+      loadRepositories();
+    } catch (error) {
+      setAlert({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "Failed to remove worktree",
+      });
+    } finally {
+      setIsRemovingWorktree(false);
+    }
+  };
   const handleClone = async () => {
     const trimmedUrl = cloneUrl.trim();
     const trimmedName = cloneName.trim();
@@ -127,6 +153,23 @@ export const RepositoriesPage: React.FC = () => {
                       title={repo.name}
                       to={`/repositories/${repo.name}`}
                       className={repo.isWorktreeChild ? "worktree-child-pill" : undefined}
+                      actions={
+                        repo.isWorktreeChild ? (
+                          <button
+                            type="button"
+                            className="copy-button"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              setRemoveWorktreeModal({ open: true, name: repo.name });
+                            }}
+                            aria-label={`Remove ${repo.name} worktree`}
+                            title={`Remove ${repo.name} worktree`}
+                          >
+                            <TrashIcon />
+                          </button>
+                        ) : undefined
+                      }
                     >
                       <div className="metadata">
                         <span
@@ -230,6 +273,36 @@ export const RepositoriesPage: React.FC = () => {
             disabled={isCloning}
           >
             {isCloning ? "Cloning..." : "Clone"}
+          </button>
+        </div>
+      </Modal>
+      <Modal
+        open={removeWorktreeModal.open}
+        title="Remove Worktree"
+        onClose={() => {
+          if (!isRemovingWorktree) {
+            setRemoveWorktreeModal({ open: false, name: null });
+          }
+        }}
+      >
+        <p>
+          Are you sure you want to remove worktree
+          {removeWorktreeModal.name ? ` ${removeWorktreeModal.name}` : ""}?
+        </p>
+        <div className="modal-actions">
+          <button
+            className="secondary"
+            onClick={() => setRemoveWorktreeModal({ open: false, name: null })}
+            disabled={isRemovingWorktree}
+          >
+            Cancel
+          </button>
+          <button
+            className="primary"
+            onClick={handleRemoveWorktree}
+            disabled={isRemovingWorktree}
+          >
+            {isRemovingWorktree ? "Removing..." : "Remove"}
           </button>
         </div>
       </Modal>

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -56,6 +56,7 @@ from repository_service import (
     clone_repository,
     delete_repository_file,
     create_repository_worktree,
+    remove_repository_worktree,
     get_repository_info,
     get_repository_git_status,
     list_repositories,
@@ -484,6 +485,17 @@ def repository_git_worktree(name: str, payload: dict = Body(...)):
             branch_name,
         )
         return create_repository_worktree(name, directory_name, branch_name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@app.delete("/api/repositories/{name}/git/worktree")
+def repository_git_worktree_delete(name: str):
+    try:
+        logger.info("Removing worktree repository '%s'", name)
+        return remove_repository_worktree(name)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except ValueError as exc:

--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -532,3 +532,36 @@ def create_repository_worktree(
         raise ValueError("Failed to create worktree") from exc
 
     return {"path": str(target_dir), "branch": branch_name}
+
+
+def remove_repository_worktree(repo_name: str) -> Dict[str, str]:
+    workspace = get_workspace_home()
+    worktree_path = workspace / repo_name
+    if not worktree_path.exists() or not worktree_path.is_dir():
+        raise FileNotFoundError("Repository not found")
+
+    git_file = worktree_path / ".git"
+    if not git_file.exists() or not git_file.is_file():
+        raise ValueError("Repository is not a worktree")
+
+    try:
+        git_file_content = git_file.read_text(encoding="utf-8", errors="ignore")
+        gitdir_line = git_file_content.splitlines()[0].strip()
+        if not gitdir_line.startswith("gitdir:"):
+            raise ValueError("Invalid git metadata")
+
+        worktree_gitdir = Path(gitdir_line.split(":", 1)[1].strip())
+        if not worktree_gitdir.is_absolute():
+            worktree_gitdir = (worktree_path / worktree_gitdir).resolve()
+
+        main_repo_path = worktree_gitdir.parents[2]
+        _run_git(
+            main_repo_path,
+            ["worktree", "remove", str(worktree_path)],
+        )
+    except IndexError as exc:
+        raise ValueError("Invalid git metadata") from exc
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise ValueError("Failed to remove worktree") from exc
+
+    return {"removed": repo_name}

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -680,6 +680,26 @@ class TestRepositoryEndpoints:
         assert "directoryName and branchName are required" in response.json()["detail"]
 
 
+    @patch("app.remove_repository_worktree")
+    def test_repository_git_worktree_delete_success(self, mock_remove):
+        mock_remove.return_value = {"removed": "repo-feature"}
+
+        response = client.delete("/api/repositories/repo-feature/git/worktree")
+
+        assert response.status_code == 200
+        assert response.json() == {"removed": "repo-feature"}
+        mock_remove.assert_called_once_with("repo-feature")
+
+    @patch("app.remove_repository_worktree")
+    def test_repository_git_worktree_delete_value_error(self, mock_remove):
+        mock_remove.side_effect = ValueError("Repository is not a worktree")
+
+        response = client.delete("/api/repositories/repo/git/worktree")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Repository is not a worktree"
+
+
 class TestKnowledgeEndpoints:
     """Test knowledge-related endpoints."""
 

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -9,6 +9,7 @@ from repository_service import (
     get_repository_git_status,
     get_repository_info,
     pull_repository,
+    remove_repository_worktree,
 )
 
 
@@ -196,6 +197,46 @@ def test_create_repository_worktree(monkeypatch, tmp_path):
     assert result["path"].endswith("repo-feature")
 
 
+
+
+def test_remove_repository_worktree(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    worktree_path = workspace / "repo-feature"
+    worktree_path.mkdir()
+    (worktree_path / ".git").write_text(
+        "gitdir: /tmp/parent/.git/worktrees/repo-feature\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_run_git(repo_path, command):
+        calls.append((repo_path, command))
+        return ""
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    monkeypatch.setattr("repository_service._run_git", fake_run_git)
+
+    result = remove_repository_worktree("repo-feature")
+
+    assert result == {"removed": "repo-feature"}
+    assert calls[0][0] == Path("/tmp/parent")
+    assert calls[0][1] == ["worktree", "remove", str(worktree_path)]
+
+
+def test_remove_repository_worktree_rejects_non_worktree(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    repo_path = workspace / "repo"
+    _init_local_repo(repo_path)
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+
+    with pytest.raises(ValueError, match="Repository is not a worktree"):
+        remove_repository_worktree("repo")
 def test_get_repository_info_detects_git_worktree_child(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"
     repo_path = workspace / "child-wt1"


### PR DESCRIPTION
### Motivation
- Provide a way to remove worktree worktrees from the Repositories page via a small transparent paperbin button and a confirmation dialog, using the existing `git worktree` tooling.

### Description
- Add `remove_repository_worktree` service in `packages/pybackend/repository_service.py` that validates `.git` metadata, resolves paths, and runs `git worktree remove` via `_run_git`.
- Expose a new `DELETE /api/repositories/{name}/git/worktree` endpoint in `packages/pybackend/app.py` that calls `remove_repository_worktree` and returns appropriate `404`/`400` responses on error.
- Add `removeRepositoryWorktree` client method in `packages/frontend/src/hooks/useApi.ts` to call the new endpoint.
- Update `packages/frontend/src/pages/RepositoriesPage.tsx` to show a transparent `TrashIcon` paperbin button on worktree panels (top-right via panel `actions`), open a confirmation `Modal`, and call the API to remove and refresh the list.
- Add unit tests covering the service and API (`packages/pybackend/tests/unit/test_repository_service.py`, `packages/pybackend/tests/unit/test_api.py`) and frontend component tests (`packages/frontend/src/pages/RepositoriesPage.test.tsx`).

### Testing
- Ran backend unit tests in the project environment with `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_repository_service.py packages/pybackend/tests/unit/test_api.py`, which completed successfully (`99 passed`, `1 warning`).
- Ran frontend unit tests with `npm --workspace packages/frontend run test -- --run src/pages/RepositoriesPage.test.tsx`, which completed successfully (the added test file passed: `2 passed`).
- Ran backend lint/format checks with `uv run ruff` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d1ad984083329c83cee9325c7588)