### PR TITLE
Show behind/ahead ordering and use remote branch line stats

### DIFF
--- a/packages/frontend/src/components/GitTab.test.tsx
+++ b/packages/frontend/src/components/GitTab.test.tsx
@@ -39,6 +39,8 @@ describe("GitTab", () => {
 
     expect(screen.getByText("Branch")).toBeInTheDocument();
     expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getByText("Commits behind/ahead")).toBeInTheDocument();
+    expect(screen.getByText("2/1")).toBeInTheDocument();
     expect(screen.getByText("+10")).toBeInTheDocument();
     expect(screen.getByText("-4")).toBeInTheDocument();
     expect(

--- a/packages/frontend/src/components/GitTab.tsx
+++ b/packages/frontend/src/components/GitTab.tsx
@@ -103,9 +103,9 @@ export const GitTab: React.FC<GitTabProps> = ({
                 <td>{status.branch || "Unknown"}</td>
               </tr>
               <tr>
-                <th>Commits ahead/behind</th>
+                <th>Commits behind/ahead</th>
                 <td>
-                  {status.aheadBehind.ahead}/{status.aheadBehind.behind}
+                  {status.aheadBehind.behind}/{status.aheadBehind.ahead}
                 </td>
               </tr>
               <tr>

--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -373,6 +373,15 @@ def _ahead_behind(repo_path: Path) -> dict[str, int]:
         return {"ahead": 0, "behind": 0}
 
 
+def _remote_line_stats(repo_path: Path) -> dict[str, int]:
+    try:
+        numstat_output = _run_git(repo_path, ["diff", "--numstat", "@{upstream}..HEAD"])
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {"green": 0, "red": 0}
+
+    return _line_stats_from_numstat(numstat_output)
+
+
 def _line_stats_from_numstat(numstat_output: str) -> dict[str, int]:
     green = 0
     red = 0
@@ -408,7 +417,7 @@ def get_repository_git_status(
     except (subprocess.CalledProcessError, FileNotFoundError):
         diff_numstat = ""
 
-    line_stats = _line_stats_from_numstat(diff_numstat)
+    line_stats = _remote_line_stats(repo_path)
 
     diff_files = []
     for line in diff_numstat.splitlines():

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -264,3 +264,36 @@ def test_get_repository_info_marks_non_worktree_repo(monkeypatch, tmp_path):
 
     assert result["hasGit"] is True
     assert result["isWorktreeChild"] is False
+
+
+def test_get_repository_git_status_uses_remote_line_stats(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_path = workspace / "repo"
+    _init_local_repo(repo_path)
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    monkeypatch.setattr("repository_service._github_repo", lambda *_: None)
+
+    def fake_run_git(path, command):
+        if command == ["rev-parse", "--abbrev-ref", "HEAD"]:
+            return "main"
+        if command == ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"]:
+            return "1 2"
+        if command == ["diff", "--numstat", "@{upstream}..HEAD"]:
+            return "4\t1\tsrc/main.py"
+        if command == ["diff", "--numstat", "HEAD"]:
+            return "10\t8\tsrc/local.py"
+        if command == ["log", "-1", "--format=%H\t%cI"]:
+            return "abc123\t2024-01-01T00:00:00Z"
+        if command == ["worktree", "list", "--porcelain"]:
+            return "worktree /tmp/repo"
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr("repository_service._run_git", fake_run_git)
+
+    result = get_repository_git_status("repo")
+
+    assert result["aheadBehind"] == {"ahead": 1, "behind": 2}
+    assert result["lineStats"] == {"green": 4, "red": 1}
+    assert result["diff"] == [{"path": "src/local.py", "green": 10, "red": 8}]


### PR DESCRIPTION
### Motivation
- Align the UI with GitHub-style divergence by showing commit divergence as `behind/ahead` instead of `ahead/behind` for clarity and consistency.
- Ensure `lineStats` reflect changes between the remote tracking branch and local HEAD (i.e. branch-level divergence) rather than only local working-tree changes.

### Description
- Update the Git status UI label and value ordering in `packages/frontend/src/components/GitTab.tsx` to show `Commits behind/ahead` and render `{behind}/{ahead}`.
- Add a backend helper ` _remote_line_stats` and switch `get_repository_git_status` in `packages/pybackend/repository_service.py` to compute `lineStats` from `git diff --numstat @{upstream}..HEAD` while keeping the per-file `diff` list from local `git diff --numstat HEAD`.
- Add a unit test `test_get_repository_git_status_uses_remote_line_stats` to `packages/pybackend/tests/unit/test_repository_service.py` to verify `lineStats` come from the remote-tracking diff and add assertions to the frontend test `packages/frontend/src/components/GitTab.test.tsx` for the new label and `behind/ahead` value.

### Testing
- Ran backend unit tests with `pytest -q packages/pybackend/tests/unit/test_repository_service.py` and all tests passed (`14 passed`).
- Ran the frontend component test with `npm --workspace packages/frontend run test -- GitTab.test.tsx` (Vitest) and the file passed (`1 test file, 2 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e9bf4844833294b63a09f961ee7a)