### PR TITLE
Add agent selection dropdown to chat interfaces

### DIFF
--- a/packages/frontend/src/components/AgentSelector.tsx
+++ b/packages/frontend/src/components/AgentSelector.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { api, AvailableAgent } from "../hooks/useApi";
+
+type AgentSelectorProps = {
+  selectedAgent: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  selectId: string;
+};
+
+const DEFAULT_AGENT_VALUE = "default";
+
+export const AgentSelector: React.FC<AgentSelectorProps> = ({
+  selectedAgent,
+  onChange,
+  disabled = false,
+  selectId,
+}) => {
+  const [agents, setAgents] = useState<AvailableAgent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const loadAgents = async () => {
+      setLoading(true);
+      try {
+        const response = await api.getAgents();
+        if (!active) return;
+        setAgents(response.agents || []);
+        setError(null);
+      } catch (fetchError) {
+        if (!active) return;
+        console.error("Failed to load agents", fetchError);
+        setError("Unable to load agents");
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadAgents();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const groupedAgents = useMemo(() => {
+    const primary = agents.filter((agent) => agent.type === "primary");
+    const subagent = agents.filter((agent) => agent.type === "subagent");
+    const other = agents.filter(
+      (agent) => agent.type !== "primary" && agent.type !== "subagent",
+    );
+    return { primary, subagent, other };
+  }, [agents]);
+
+  const renderAgentOption = (agent: AvailableAgent) => {
+    const typeSuffix = agent.type ? ` (${agent.type})` : "";
+    return (
+      <option key={`${agent.name}-${agent.type || "unknown"}`} value={agent.name}>
+        {`${agent.name}${typeSuffix}`}
+      </option>
+    );
+  };
+
+  return (
+    <label className="model-select" htmlFor={selectId}>
+      <select
+        id={selectId}
+        value={selectedAgent}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled || loading}
+        aria-label="Agent"
+      >
+        <option value={DEFAULT_AGENT_VALUE}>Default</option>
+        {groupedAgents.primary.length > 0 && (
+          <option disabled value="">
+            ------- primary -------
+          </option>
+        )}
+        {groupedAgents.primary.map(renderAgentOption)}
+        {groupedAgents.subagent.length > 0 && (
+          <option disabled value="">
+            ------ subagent ------
+          </option>
+        )}
+        {groupedAgents.subagent.map(renderAgentOption)}
+        {groupedAgents.other.length > 0 && (
+          <option disabled value="">
+            ------- other -------
+          </option>
+        )}
+        {groupedAgents.other.map(renderAgentOption)}
+      </select>
+      {error && <span className="muted">{error}</span>}
+    </label>
+  );
+};
+
+export { DEFAULT_AGENT_VALUE };

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -182,6 +182,12 @@ export type CommandDefinition = {
   argumentHint?: string | string[] | null;
 };
 
+export type AvailableAgent = {
+  name: string;
+  type?: string;
+  source?: string;
+};
+
 
 export type GitDiffEntry = {
   path: string;
@@ -282,10 +288,11 @@ export const api = {
     message: string,
     sessionId?: string,
     model?: string,
+    agent?: string,
   ) =>
     request<AgentReply>(`/repositories/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message, sessionId, model }),
+      body: JSON.stringify({ message, sessionId, model, agent }),
     }),
   getRepositoryAgentStatus: (name: string) =>
     request<AgentStatus>(`/repositories/${name}/agent/status`),
@@ -402,6 +409,7 @@ export const api = {
     }),
   getHarnessStatus: (pid: number) =>
     request<{ pid: number; running: boolean }>(`/harnesses/${pid}/status`),
+  getAgents: () => request<{ agents: AvailableAgent[] }>("/agents"),
   listKnowledge: () => request<{ artefacts: ArtefactSummary[] }>("/knowledge"),
   getKnowledge: (name: string) => request<MatterFile>(`/knowledge/${name}`),
   saveKnowledge: (name: string, payload: MatterFile) =>
@@ -409,10 +417,16 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
-  sendKnowledgeAgent: (name: string, message: string, sessionId?: string) =>
+  sendKnowledgeAgent: (
+    name: string,
+    message: string,
+    sessionId?: string,
+    model?: string,
+    agent?: string,
+  ) =>
     request<AgentReply>(`/knowledge/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message, sessionId }),
+      body: JSON.stringify({ message, sessionId, model, agent }),
     }),
   getKnowledgeAgentStatus: (name: string) =>
     request<AgentStatus>(`/knowledge/${name}/agent/status`),
@@ -427,10 +441,16 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
-  sendConstitutionAgent: (name: string, message: string, sessionId?: string) =>
+  sendConstitutionAgent: (
+    name: string,
+    message: string,
+    sessionId?: string,
+    model?: string,
+    agent?: string,
+  ) =>
     request<AgentReply>(`/constitutions/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message, sessionId }),
+      body: JSON.stringify({ message, sessionId, model, agent }),
     }),
   getConstitutionAgentStatus: (name: string) =>
     request<AgentStatus>(`/constitutions/${name}/agent/status`),
@@ -443,10 +463,16 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
-  sendTaskAgent: (name: string, message: string, sessionId?: string) =>
+  sendTaskAgent: (
+    name: string,
+    message: string,
+    sessionId?: string,
+    model?: string,
+    agent?: string,
+  ) =>
     request<AgentReply>(`/tasks/${name}/agent`, {
       method: "POST",
-      body: JSON.stringify({ message, sessionId }),
+      body: JSON.stringify({ message, sessionId, model, agent }),
     }),
   getTaskAgentStatus: (name: string) =>
     request<AgentStatus>(`/tasks/${name}/agent/status`),

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -28,6 +28,7 @@ import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
+import { AgentSelector, DEFAULT_AGENT_VALUE } from "../components/AgentSelector";
 
 export const ConstitutionPage: React.FC = () => {
   const { name } = useParams();
@@ -54,8 +55,17 @@ export const ConstitutionPage: React.FC = () => {
         : "constitution-harness-history",
     [name],
   );
+  const agentStorageKey = useMemo(
+    () => (name ? `constitution-agent-${name}` : "constitution-agent"),
+    [name],
+  );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [selectedAgent, setSelectedAgent] = usePersistentString(
+    agentStorageKey,
+    DEFAULT_AGENT_VALUE,
+  );
+  const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
@@ -185,10 +195,16 @@ export const ConstitutionPage: React.FC = () => {
           userMessage.text,
           name,
         );
+        const agent =
+          normalizedSelectedAgent === DEFAULT_AGENT_VALUE
+            ? undefined
+            : normalizedSelectedAgent.trim();
         const reply = await api.sendConstitutionAgent(
           name,
           promptWithPolicy,
           sessionId || undefined,
+          undefined,
+          agent,
         );
         
         // No immediate message processing - polling handles everything
@@ -218,6 +234,7 @@ export const ConstitutionPage: React.FC = () => {
     [
       name,
       refreshAgentStatus,
+      normalizedSelectedAgent,
       sessionId,
       setActiveTab,
       setAgentStatus,
@@ -251,11 +268,13 @@ export const ConstitutionPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
   };
 
   const handleClearSessionAndHistory = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
     setClearSessionModalOpen(false);
   };
@@ -437,7 +456,16 @@ export const ConstitutionPage: React.FC = () => {
                   onChange={(event) => setPrompt(event.target.value)}
                   placeholder="Ask the agent to update governance rules..."
                 />
-                <div className="button-bar">
+                <div className="button-bar chat-controls">
+                  <div className="chat-controls__left">
+                    <AgentSelector
+                      selectId="agent-select"
+                      selectedAgent={normalizedSelectedAgent}
+                      onChange={setSelectedAgent}
+                      disabled={chatLoading}
+                    />
+                  </div>
+                  <div className="chat-controls__right">
                   {chatLoading ? (
                     <button className="danger" onClick={handleCancel}>
                       Cancel
@@ -451,6 +479,7 @@ export const ConstitutionPage: React.FC = () => {
                       Send
                     </button>
                   )}
+                                  </div>
                 </div>
               </Panel>
             ),

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -28,6 +28,7 @@ import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
+import { AgentSelector, DEFAULT_AGENT_VALUE } from "../components/AgentSelector";
 
 export const KnowledgeArtefactPage: React.FC = () => {
   const { name } = useParams();
@@ -54,8 +55,17 @@ export const KnowledgeArtefactPage: React.FC = () => {
         : "knowledge-harness-history",
     [name],
   );
+  const agentStorageKey = useMemo(
+    () => (name ? `knowledge-agent-${name}` : "knowledge-agent"),
+    [name],
+  );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [selectedAgent, setSelectedAgent] = usePersistentString(
+    agentStorageKey,
+    DEFAULT_AGENT_VALUE,
+  );
+  const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
@@ -185,10 +195,16 @@ export const KnowledgeArtefactPage: React.FC = () => {
           userMessage.text,
           name,
         );
+        const agent =
+          normalizedSelectedAgent === DEFAULT_AGENT_VALUE
+            ? undefined
+            : normalizedSelectedAgent.trim();
         const reply = await api.sendKnowledgeAgent(
           name,
           promptWithPolicy,
           sessionId || undefined,
+          undefined,
+          agent,
         );
         
         // No immediate message processing - polling handles everything
@@ -218,6 +234,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     [
       name,
       refreshAgentStatus,
+      normalizedSelectedAgent,
       sessionId,
       setActiveTab,
       setAgentStatus,
@@ -251,11 +268,13 @@ export const KnowledgeArtefactPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
   };
 
   const handleClearSessionAndHistory = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
     setClearSessionModalOpen(false);
   };
@@ -455,7 +474,16 @@ export const KnowledgeArtefactPage: React.FC = () => {
                   onChange={(event) => setPrompt(event.target.value)}
                   placeholder="Ask the agent about this artefact..."
                 />
-                <div className="button-bar">
+                <div className="button-bar chat-controls">
+                  <div className="chat-controls__left">
+                    <AgentSelector
+                      selectId="agent-select"
+                      selectedAgent={normalizedSelectedAgent}
+                      onChange={setSelectedAgent}
+                      disabled={chatLoading}
+                    />
+                  </div>
+                  <div className="chat-controls__right">
                   {chatLoading ? (
                     <button className="danger" onClick={handleCancel}>
                       Cancel
@@ -469,6 +497,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
                       Send
                     </button>
                   )}
+                                  </div>
                 </div>
               </Panel>
             ),

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -14,6 +14,7 @@ import { TerminalTab } from "../components/TerminalTab";
 import { GitTab } from "../components/GitTab";
 import { ChatWindow } from "../components/ChatWindow";
 import { SessionPickerModal } from "../components/SessionPickerModal";
+import { AgentSelector, DEFAULT_AGENT_VALUE } from "../components/AgentSelector";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { useAgentCli } from "../hooks/useAgentCli";
@@ -321,6 +322,10 @@ export const RepositoryPage: React.FC = () => {
     () => (name ? `repository-model-${name}` : "repository-model"),
     [name],
   );
+  const agentStorageKey = useMemo(
+    () => (name ? `repository-agent-${name}` : "repository-agent"),
+    [name],
+  );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
   const [pendingPrompt, setPendingPrompt] = useState("");
@@ -328,7 +333,12 @@ export const RepositoryPage: React.FC = () => {
     modelStorageKey,
     "default",
   );
+  const [selectedAgent, setSelectedAgent] = usePersistentString(
+    agentStorageKey,
+    DEFAULT_AGENT_VALUE,
+  );
   const normalizedSelectedModel = selectedModel ?? "default";
+  const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
   const [chatLoading, setChatLoading] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
@@ -883,11 +893,16 @@ export const RepositoryPage: React.FC = () => {
         normalizedSelectedModel === "default"
           ? undefined
           : normalizedSelectedModel.trim();
+      const agent =
+        normalizedSelectedAgent === DEFAULT_AGENT_VALUE
+          ? undefined
+          : normalizedSelectedAgent.trim();
       const reply = await api.sendAgentMessage(
         name,
         message,
         sessionId || undefined,
         model,
+        agent,
       );
       
       // No immediate message processing - polling handles everything
@@ -934,11 +949,13 @@ export const RepositoryPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
   };
 
   const handleClearSessionAndHistory = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
     setClearSessionModalOpen(false);
   };
@@ -1438,6 +1455,12 @@ export const RepositoryPage: React.FC = () => {
           />
           <div className="button-bar chat-controls">
             <div className="chat-controls__left">
+              <AgentSelector
+                selectId="agent-select"
+                selectedAgent={normalizedSelectedAgent}
+                onChange={setSelectedAgent}
+                disabled={chatLoading}
+              />
               <label className="model-select" htmlFor="agent-model-select">
                 <select
                   id="agent-model-select"

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -28,6 +28,7 @@ import { ClearSessionModal } from "../components/ClearSessionModal";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { ArrowDownIcon } from "../components/icons/ArrowDownIcon";
 import { DatabaseIcon } from "../components/icons/DatabaseIcon";
+import { AgentSelector, DEFAULT_AGENT_VALUE } from "../components/AgentSelector";
 
 export const TaskPage: React.FC = () => {
   const { name } = useParams();
@@ -54,8 +55,17 @@ export const TaskPage: React.FC = () => {
         : "task-harness-history",
     [name],
   );
+  const agentStorageKey = useMemo(
+    () => (name ? `task-agent-${name}` : "task-agent"),
+    [name],
+  );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [selectedAgent, setSelectedAgent] = usePersistentString(
+    agentStorageKey,
+    DEFAULT_AGENT_VALUE,
+  );
+  const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
@@ -185,10 +195,16 @@ export const TaskPage: React.FC = () => {
           userMessage.text,
           name,
         );
+        const agent =
+          normalizedSelectedAgent === DEFAULT_AGENT_VALUE
+            ? undefined
+            : normalizedSelectedAgent.trim();
         const reply = await api.sendTaskAgent(
           name,
           promptWithPolicy,
           sessionId || undefined,
+          undefined,
+          agent,
         );
         
         // No immediate message processing - polling handles everything
@@ -218,6 +234,7 @@ export const TaskPage: React.FC = () => {
     [
       name,
       refreshAgentStatus,
+      normalizedSelectedAgent,
       sessionId,
       setActiveTab,
       setAgentStatus,
@@ -251,11 +268,13 @@ export const TaskPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
   };
 
   const handleClearSessionAndHistory = () => {
     setSessionId(null);
+    setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
     setClearSessionModalOpen(false);
   };
@@ -451,7 +470,16 @@ export const TaskPage: React.FC = () => {
                   onChange={(event) => setPrompt(event.target.value)}
                   placeholder="Ask the agent to refine this task..."
                 />
-                <div className="button-bar">
+                <div className="button-bar chat-controls">
+                  <div className="chat-controls__left">
+                    <AgentSelector
+                      selectId="agent-select"
+                      selectedAgent={normalizedSelectedAgent}
+                      onChange={setSelectedAgent}
+                      disabled={chatLoading}
+                    />
+                  </div>
+                  <div className="chat-controls__right">
                   {chatLoading ? (
                     <button className="danger" onClick={handleCancel}>
                       Cancel
@@ -465,6 +493,7 @@ export const TaskPage: React.FC = () => {
                       Send
                     </button>
                   )}
+                                  </div>
                 </div>
               </Panel>
             ),

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -286,7 +286,9 @@ textarea {
 }
 
 .chat-controls__left {
-  flex: 0 1 360px;
+  flex: 0 1 420px;
+  display: flex;
+  gap: 0.75rem;
 }
 
 .chat-controls__right {


### PR DESCRIPTION
### Motivation
- Provide a frontend UI to select which AI agent handles chat requests, matching existing backend support for an `agent` parameter and improving UX for repository/knowledge/constitution/task chats.

### Description
- Added a reusable `AgentSelector` component that fetches `GET /api/agents`, shows a top `Default` option, groups agents by type, and surfaces non-blocking fetch errors. (new file `packages/frontend/src/components/AgentSelector.tsx`)
- Extended frontend API helpers with `AvailableAgent` typing and `api.getAgents()`, and updated agent send endpoints to accept an optional `agent` parameter (and added optional `model` where missing) in `packages/frontend/src/hooks/useApi.ts`.
- Wired the selector into repository, knowledge, constitution and task chat pages so the chosen agent is persisted per-page, reset to `Default` on new/cleared sessions, and only sent when non-default; updated pages in `packages/frontend/src/pages/{RepositoryPage,KnowledgeArtefactPage,ConstitutionPage,TaskPage}.tsx`.
- Adjusted chat control layout CSS so agent and model selectors align (`packages/frontend/src/styles/index.css`).

### Testing
- Ran frontend lint with `npm run lint` which completed successfully.
- Built the frontend with `npm run build:frontend` which completed successfully (Vite reported chunk-size advisory only).
- Started the frontend dev server (`npm --workspace packages/frontend run dev -- --host 0.0.0.0 --port 5173`) and executed an automated Playwright script to open `/repositories/demo` and capture a screenshot to validate the UI, which produced the artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86d9e4f1c8332befd417c27cf61ff)