### PR TITLE
Add empty Harness Builder panel above Harness Scripts

### DIFF
--- a/packages/frontend/src/components/HarnessesTab.tsx
+++ b/packages/frontend/src/components/HarnessesTab.tsx
@@ -210,6 +210,7 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
 
   return (
     <div className="harness-center">
+      <Panel title="Harness Builder">{null}</Panel>
       <Panel
         title="Harness Scripts"
         actions={

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1526,6 +1526,7 @@ export const RepositoryPage: React.FC = () => {
       label: "Harnesses",
       content: (
         <div className="harness-center">
+          <Panel title="Harness Builder">{null}</Panel>
           <Panel
             title="Harness Scripts"
             actions={


### PR DESCRIPTION
### Motivation

- Reserve visual space for a future Harness Builder UI above the existing harness scripts list so pages using the harness UI can show a consistent layout.
- Apply the same placeholder in both the shared harness component and the repository-specific harness tab to keep UIs consistent.

### Description

- Inserted an empty panel `<Panel title="Harness Builder">{null}</Panel>` above the `Harness Scripts` panel in the shared component at `packages/frontend/src/components/HarnessesTab.tsx`.
- Inserted the same empty panel in the repository page harness tab layout at `packages/frontend/src/pages/RepositoryPage.tsx`.

### Testing

- Ran the frontend production build with `npm run build:frontend`, and the build completed successfully.
- Launched the dev server with `npm run dev:frontend` and exercised the UI with a Playwright script that captured a screenshot showing the new panel at `artifacts/harness-builder-panel.png`, after an initial navigation attempt that returned an empty response.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8809c7cec8332b5fd81d9b9d55314)