### PR TITLE
Add Agent Workflow Builder UI and YAML-backed workflow APIs

### DIFF
--- a/packages/frontend/src/components/HarnessesTab.tsx
+++ b/packages/frontend/src/components/HarnessesTab.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Panel } from "./Panel";
 import { Modal } from "./Modal";
-import { HarnessDefinition } from "../hooks/useApi";
+import { HarnessDefinition, WorkflowDefinition } from "../hooks/useApi";
+import { WorkflowBuilderPanel } from "./WorkflowBuilderPanel";
 
 type HarnessRun = {
   pid: number;
@@ -17,6 +18,9 @@ type HarnessesTabProps = {
     args?: string,
   ) => Promise<{ pid: number; name: string; path: string }>;
   getHarnessStatus: (pid: number) => Promise<{ pid: number; running: boolean }>;
+  loadWorkflows: () => Promise<{ workflows: WorkflowDefinition[] }>;
+  saveWorkflows: (workflows: WorkflowDefinition[]) => Promise<{ workflows: WorkflowDefinition[] }>;
+  listAgents: () => Promise<{ agents: { name: string }[] }>;
   historyStorageKey: string;
   maxHistory?: number;
 };
@@ -31,6 +35,9 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
   loadHarnesses,
   runHarness,
   getHarnessStatus,
+  loadWorkflows,
+  saveWorkflows,
+  listAgents,
   historyStorageKey,
   maxHistory = 10,
 }) => {
@@ -210,7 +217,13 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
 
   return (
     <div className="harness-center">
-      <Panel title="Harness Builder">{null}</Panel>
+      <Panel title="Harness Builder">
+        <WorkflowBuilderPanel
+          loadWorkflows={loadWorkflows}
+          saveWorkflows={(payload) => saveWorkflows(payload.workflows)}
+          listAgents={listAgents}
+        />
+      </Panel>
       <Panel
         title="Harness Scripts"
         actions={

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -1,0 +1,395 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Modal } from "./Modal";
+import { AvailableAgent } from "../hooks/useApi";
+
+export type WorkflowStep = {
+  type: "agent" | "bash";
+  agent?: string;
+  command?: string;
+  prompt?: string;
+  run?: string;
+};
+
+export type WorkflowDefinition = {
+  id: string;
+  name: string;
+  schedule: string | null;
+  steps: WorkflowStep[];
+};
+
+type WorkflowBuilderPanelProps = {
+  loadWorkflows: () => Promise<{ workflows: WorkflowDefinition[] }>;
+  saveWorkflows: (payload: { workflows: WorkflowDefinition[] }) => Promise<unknown>;
+  listAgents: () => Promise<{ agents: AvailableAgent[] }>;
+};
+
+const previewText = (step: WorkflowStep) => {
+  const raw =
+    step.type === "bash"
+      ? step.run || ""
+      : step.command
+        ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
+        : step.prompt || "";
+  const [firstLine] = raw.split(/\r?\n/, 1);
+  return firstLine || (step.type === "bash" ? "Bash command" : "Prompt");
+};
+
+const parseAgentText = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/")) {
+    return { prompt: value, command: undefined as string | undefined };
+  }
+  const withoutSlash = trimmed.slice(1).trim();
+  if (!withoutSlash) {
+    return { prompt: "", command: undefined as string | undefined };
+  }
+  const [command, ...rest] = withoutSlash.split(/\s+/);
+  return {
+    command,
+    prompt: rest.join(" "),
+  };
+};
+
+const newWorkflow = (): WorkflowDefinition => ({
+  id: `wf_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`,
+  name: "New workflow",
+  schedule: null,
+  steps: [],
+});
+
+export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
+  loadWorkflows,
+  saveWorkflows,
+  listAgents,
+}) => {
+  const [workflows, setWorkflows] = useState<WorkflowDefinition[]>([]);
+  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
+  const [agents, setAgents] = useState<AvailableAgent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editStep, setEditStep] = useState<{ workflowId: string; stepIndex: number } | null>(null);
+  const [editStepValue, setEditStepValue] = useState("");
+  const [scheduleEditor, setScheduleEditor] = useState<{ workflowId: string; value: string }>({
+    workflowId: "",
+    value: "",
+  });
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [workflowData, agentData] = await Promise.all([loadWorkflows(), listAgents()]);
+      setWorkflows(workflowData.workflows || []);
+      setAgents(agentData.agents || []);
+      setExpandedIds((prev) => {
+        const next = { ...prev };
+        (workflowData.workflows || []).forEach((workflow) => {
+          if (next[workflow.id] === undefined) {
+            next[workflow.id] = true;
+          }
+        });
+        return next;
+      });
+    } catch (loadError) {
+      const message = loadError instanceof Error ? loadError.message : "Failed to load workflows";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const persist = async (nextWorkflows: WorkflowDefinition[]) => {
+    setWorkflows(nextWorkflows);
+    setSaving(true);
+    setError(null);
+    try {
+      await saveWorkflows({ workflows: nextWorkflows });
+    } catch (saveError) {
+      const message = saveError instanceof Error ? saveError.message : "Failed to save workflows";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const agentNames = useMemo(() => agents.map((agent) => agent.name), [agents]);
+
+  const addStep = (workflowId: string) => {
+    const defaultAgent = agentNames[0] || "default";
+    const next = workflows.map((workflow) =>
+      workflow.id === workflowId
+        ? {
+            ...workflow,
+            steps: [...workflow.steps, { type: "agent" as const, agent: defaultAgent, prompt: "" }],
+          }
+        : workflow,
+    );
+    void persist(next);
+  };
+
+  return (
+    <div className="workflow-builder">
+      <div className="workflow-builder__header">
+        <h3>AGENT WORKFLOW BUILDER</h3>
+        <div className="workflow-builder__actions">
+          <button className="secondary" onClick={load} disabled={loading || saving}>Refresh</button>
+          <button className="primary" onClick={() => void persist([...workflows, newWorkflow()])} disabled={saving}>＋ Add Workflow</button>
+        </div>
+      </div>
+      {loading && <div className="alert">Loading workflows...</div>}
+      {saving && <div className="alert">Saving workflows...</div>}
+      {error && <div className="alert error">{error}</div>}
+      {!loading && workflows.length === 0 && <div className="empty">No workflows yet.</div>}
+      <div className="workflow-list">
+        {workflows.map((workflow) => {
+          const expanded = expandedIds[workflow.id] ?? true;
+          return (
+            <div className="workflow-card" key={workflow.id}>
+              <div className="workflow-card__header">
+                <button
+                  className="icon-button"
+                  onClick={() => setExpandedIds((prev) => ({ ...prev, [workflow.id]: !expanded }))}
+                  title={expanded ? "Collapse" : "Expand"}
+                >
+                  {expanded ? "▼" : "▶"}
+                </button>
+                <input
+                  className="workflow-name-input"
+                  value={workflow.name}
+                  onChange={(event) => {
+                    const next = workflows.map((item) =>
+                      item.id === workflow.id ? { ...item, name: event.target.value } : item,
+                    );
+                    void persist(next);
+                  }}
+                />
+                <button
+                  className="icon-button"
+                  title={workflow.schedule || "Not scheduled"}
+                  onClick={() =>
+                    setScheduleEditor({ workflowId: workflow.id, value: workflow.schedule || "" })
+                  }
+                >
+                  ⏰
+                </button>
+                <button className="icon-button" onClick={() => addStep(workflow.id)} title="Add step">＋</button>
+                <button className="icon-button" title="Run workflow" disabled>▶</button>
+                <button
+                  className="icon-button danger"
+                  title="Remove workflow"
+                  onClick={() => void persist(workflows.filter((item) => item.id !== workflow.id))}
+                >
+                  ✕
+                </button>
+              </div>
+              {expanded && (
+                <div className="workflow-steps">
+                  {workflow.steps.length === 0 ? (
+                    <div className="empty">No steps yet.</div>
+                  ) : (
+                    workflow.steps.map((step, stepIndex) => (
+                      <div className="workflow-step-row" key={`${workflow.id}-${stepIndex}`}>
+                        <div className="workflow-step-target">
+                          <select
+                            value={step.type}
+                            onChange={(event) => {
+                              const nextType = event.target.value as "agent" | "bash";
+                              const nextStep: WorkflowStep =
+                                nextType === "bash"
+                                  ? { type: "bash", run: "" }
+                                  : { type: "agent", agent: agentNames[0] || "default", prompt: "" };
+                              const next = workflows.map((item) =>
+                                item.id === workflow.id
+                                  ? {
+                                      ...item,
+                                      steps: item.steps.map((itemStep, itemIndex) =>
+                                        itemIndex === stepIndex ? nextStep : itemStep,
+                                      ),
+                                    }
+                                  : item,
+                              );
+                              void persist(next);
+                            }}
+                          >
+                            <option value="agent">Agent</option>
+                            <option value="bash">Bash</option>
+                          </select>
+                          {step.type === "agent" ? (
+                            <select
+                              value={step.agent || "default"}
+                              onChange={(event) => {
+                                const next = workflows.map((item) =>
+                                  item.id === workflow.id
+                                    ? {
+                                        ...item,
+                                        steps: item.steps.map((itemStep, itemIndex) =>
+                                          itemIndex === stepIndex
+                                            ? { ...itemStep, agent: event.target.value }
+                                            : itemStep,
+                                        ),
+                                      }
+                                    : item,
+                                );
+                                void persist(next);
+                              }}
+                            >
+                              {agentNames.length === 0 ? (
+                                <option value="default">default</option>
+                              ) : (
+                                agentNames.map((agentName) => <option key={agentName}>{agentName}</option>)
+                              )}
+                            </select>
+                          ) : (
+                            <span className="workflow-step-target__label">Bash</span>
+                          )}
+                        </div>
+                        <button
+                          className="workflow-step-preview"
+                          onClick={() => {
+                            const currentText =
+                              step.type === "bash"
+                                ? step.run || ""
+                                : step.command
+                                  ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
+                                  : step.prompt || "";
+                            setEditStep({ workflowId: workflow.id, stepIndex });
+                            setEditStepValue(currentText);
+                          }}
+                        >
+                          {previewText(step)}
+                        </button>
+                        <div className="workflow-step-controls">
+                          <button
+                            className="icon-button"
+                            disabled={stepIndex === 0}
+                            onClick={() => {
+                              const next = workflows.map((item) => {
+                                if (item.id !== workflow.id || stepIndex === 0) return item;
+                                const steps = [...item.steps];
+                                [steps[stepIndex - 1], steps[stepIndex]] = [steps[stepIndex], steps[stepIndex - 1]];
+                                return { ...item, steps };
+                              });
+                              void persist(next);
+                            }}
+                          >
+                            ▲
+                          </button>
+                          <button
+                            className="icon-button"
+                            disabled={stepIndex === workflow.steps.length - 1}
+                            onClick={() => {
+                              const next = workflows.map((item) => {
+                                if (item.id !== workflow.id || stepIndex >= item.steps.length - 1) return item;
+                                const steps = [...item.steps];
+                                [steps[stepIndex + 1], steps[stepIndex]] = [steps[stepIndex], steps[stepIndex + 1]];
+                                return { ...item, steps };
+                              });
+                              void persist(next);
+                            }}
+                          >
+                            ▼
+                          </button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <Modal
+        open={Boolean(editStep)}
+        title="Edit Step"
+        onClose={() => {
+          setEditStep(null);
+          setEditStepValue("");
+        }}
+      >
+        <div className="form-group">
+          <label htmlFor="workflow-step-editor">Command or Prompt</label>
+          <textarea
+            id="workflow-step-editor"
+            rows={8}
+            value={editStepValue}
+            onChange={(event) => setEditStepValue(event.target.value)}
+          />
+        </div>
+        <div className="modal-actions">
+          <button className="secondary" onClick={() => setEditStep(null)}>Cancel</button>
+          <button
+            className="primary"
+            onClick={() => {
+              if (!editStep) return;
+              const next = workflows.map((workflow) => {
+                if (workflow.id !== editStep.workflowId) return workflow;
+                return {
+                  ...workflow,
+                  steps: workflow.steps.map((step, index) => {
+                    if (index !== editStep.stepIndex) return step;
+                    if (step.type === "bash") {
+                      return { ...step, run: editStepValue };
+                    }
+                    const parsed = parseAgentText(editStepValue);
+                    return {
+                      ...step,
+                      command: parsed.command,
+                      prompt: parsed.prompt,
+                    };
+                  }),
+                };
+              });
+              setEditStep(null);
+              setEditStepValue("");
+              void persist(next);
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </Modal>
+
+      <Modal
+        open={Boolean(scheduleEditor.workflowId)}
+        title="Edit Schedule"
+        onClose={() => setScheduleEditor({ workflowId: "", value: "" })}
+      >
+        <div className="form-group">
+          <label htmlFor="workflow-schedule">Cron expression</label>
+          <input
+            id="workflow-schedule"
+            value={scheduleEditor.value}
+            onChange={(event) =>
+              setScheduleEditor((prev) => ({ ...prev, value: event.target.value }))
+            }
+            placeholder="*/15 * * * *"
+          />
+        </div>
+        <div className="modal-actions">
+          <button className="secondary" onClick={() => setScheduleEditor({ workflowId: "", value: "" })}>Cancel</button>
+          <button
+            className="primary"
+            onClick={() => {
+              const next = workflows.map((workflow) =>
+                workflow.id === scheduleEditor.workflowId
+                  ? { ...workflow, schedule: scheduleEditor.value.trim() || null }
+                  : workflow,
+              );
+              setScheduleEditor({ workflowId: "", value: "" });
+              void persist(next);
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </Modal>
+    </div>
+  );
+};

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -223,6 +223,22 @@ export type HarnessDefinition = {
   source: string;
 };
 
+
+export type WorkflowStep = {
+  type: "agent" | "bash";
+  agent?: string;
+  command?: string;
+  prompt?: string;
+  run?: string;
+};
+
+export type WorkflowDefinition = {
+  id: string;
+  name: string;
+  schedule: string | null;
+  steps: WorkflowStep[];
+};
+
 export const api = {
   getDashboard: () =>
     request<{
@@ -400,6 +416,14 @@ export const api = {
         body: JSON.stringify({ path, args }),
       },
     ),
+
+  getRepositoryWorkflows: (name: string) =>
+    request<{ workflows: WorkflowDefinition[] }>(`/repositories/${name}/workflows`),
+  saveRepositoryWorkflows: (name: string, workflows: WorkflowDefinition[]) =>
+    request<{ workflows: WorkflowDefinition[] }>(`/repositories/${name}/workflows`, {
+      method: "PUT",
+      body: JSON.stringify({ workflows }),
+    }),
   getCommands: () => request<{ commands: CommandDefinition[] }>("/commands"),
   getHarnesses: () => request<{ harnesses: HarnessDefinition[] }>("/harnesses"),
   runHarness: (path: string, args?: string) =>
@@ -409,6 +433,13 @@ export const api = {
     }),
   getHarnessStatus: (pid: number) =>
     request<{ pid: number; running: boolean }>(`/harnesses/${pid}/status`),
+
+  getWorkflows: () => request<{ workflows: WorkflowDefinition[] }>("/workflows"),
+  saveWorkflows: (workflows: WorkflowDefinition[]) =>
+    request<{ workflows: WorkflowDefinition[] }>("/workflows", {
+      method: "PUT",
+      body: JSON.stringify({ workflows }),
+    }),
   getAgents: () => request<{ agents: AvailableAgent[] }>("/agents"),
   listKnowledge: () => request<{ artefacts: ArtefactSummary[] }>("/knowledge"),
   getKnowledge: (name: string) => request<MatterFile>(`/knowledge/${name}`),

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -492,6 +492,9 @@ export const ConstitutionPage: React.FC = () => {
                 loadHarnesses={loadHarnesses}
                 runHarness={runHarness}
                 getHarnessStatus={getHarnessStatus}
+                loadWorkflows={() => api.getWorkflows()}
+                saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
+                listAgents={() => api.getAgents()}
                 historyStorageKey={harnessHistoryStorageKey}
               />
             ),

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -510,6 +510,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
                 loadHarnesses={loadHarnesses}
                 runHarness={runHarness}
                 getHarnessStatus={getHarnessStatus}
+                loadWorkflows={() => api.getWorkflows()}
+                saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
+                listAgents={() => api.getAgents()}
                 historyStorageKey={harnessHistoryStorageKey}
               />
             ),

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -13,6 +13,7 @@ import { Modal } from "../components/Modal";
 import { TerminalTab } from "../components/TerminalTab";
 import { GitTab } from "../components/GitTab";
 import { ChatWindow } from "../components/ChatWindow";
+import { WorkflowBuilderPanel } from "../components/WorkflowBuilderPanel";
 import { SessionPickerModal } from "../components/SessionPickerModal";
 import { AgentSelector, DEFAULT_AGENT_VALUE } from "../components/AgentSelector";
 import { usePersistentChat } from "../hooks/usePersistentChat";
@@ -1526,7 +1527,15 @@ export const RepositoryPage: React.FC = () => {
       label: "Harnesses",
       content: (
         <div className="harness-center">
-          <Panel title="Harness Builder">{null}</Panel>
+          <Panel title="Harness Builder">
+            <WorkflowBuilderPanel
+              loadWorkflows={() => api.getRepositoryWorkflows(name || "")}
+              saveWorkflows={(payload) =>
+                api.saveRepositoryWorkflows(name || "", payload.workflows)
+              }
+              listAgents={() => api.getAgents()}
+            />
+          </Panel>
           <Panel
             title="Harness Scripts"
             actions={

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -506,6 +506,9 @@ export const TaskPage: React.FC = () => {
                 loadHarnesses={loadHarnesses}
                 runHarness={runHarness}
                 getHarnessStatus={getHarnessStatus}
+                loadWorkflows={() => api.getWorkflows()}
+                saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
+                listAgents={() => api.getAgents()}
                 historyStorageKey={harnessHistoryStorageKey}
               />
             ),

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -333,3 +333,96 @@
 .harness-status.pending {
   color: #94a3b8;
 }
+
+.workflow-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.workflow-builder__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.workflow-builder__header h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+}
+
+.workflow-builder__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.workflow-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.workflow-card {
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 0.5rem;
+  background: var(--panel-bg);
+}
+
+.workflow-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.workflow-name-input {
+  min-width: 0;
+}
+
+.workflow-steps {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.workflow-step-row {
+  display: grid;
+  grid-template-columns: 220px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.workflow-step-target {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.25rem;
+}
+
+.workflow-step-target__label {
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+}
+
+.workflow-step-preview {
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.workflow-step-controls {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.icon-button {
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  background: transparent;
+  padding: 0.3rem 0.45rem;
+}

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -50,6 +50,7 @@ from knowledge_service import (
 )
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
+from workflow_service import read_workflows, write_workflows
 from repository_service import (
     create_repository,
     create_repository_file,
@@ -501,6 +502,61 @@ def repository_git_worktree_delete(name: str):
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
+
+
+
+@app.get("/api/repositories/{name}/workflows")
+def repository_workflows(name: str):
+    try:
+        logger.info("Listing workflows for repository '%s'", name)
+        _repository_path(name)
+        return read_workflows(name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Failed to list workflows for repository '%s'", name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.put("/api/repositories/{name}/workflows")
+def save_repository_workflows(name: str, payload: dict = Body(...)):
+    try:
+        logger.info("Saving workflows for repository '%s'", name)
+        _repository_path(name)
+        return write_workflows(payload, name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Failed to save workflows for repository '%s'", name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.get("/api/workflows")
+def global_workflows():
+    try:
+        logger.info("Listing global workflows")
+        return read_workflows()
+    except Exception as exc:
+        logger.exception("Failed to list global workflows")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.put("/api/workflows")
+def save_global_workflows(payload: dict = Body(...)):
+    try:
+        logger.info("Saving global workflows")
+        return write_workflows(payload)
+    except Exception as exc:
+        logger.exception("Failed to save global workflows")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
 
 @app.get("/api/commands")
 def global_commands():

--- a/packages/pybackend/pyproject.toml
+++ b/packages/pybackend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "pytest>=7.0.0",
   "pytest-cov>=4.0.0",
   "httpx>=0.24.0",
+  "PyYAML>=6.0.1",
 ]
 
 [project.scripts]

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1037,3 +1037,45 @@ class TestAgentMessageValidation:
 
         assert response.status_code == 400
         assert "Message is required" in response.json()["detail"]
+
+
+class TestWorkflowEndpoints:
+    @patch("app.read_workflows")
+    def test_global_workflows_success(self, mock_read):
+        mock_read.return_value = {"workflows": []}
+
+        response = client.get("/api/workflows")
+
+        assert response.status_code == 200
+        assert response.json() == {"workflows": []}
+
+    @patch("app.write_workflows")
+    def test_save_global_workflows_success(self, mock_write):
+        mock_write.return_value = {"workflows": [{"id": "wf_1", "name": "x", "schedule": None, "steps": []}]}
+
+        response = client.put("/api/workflows", json={"workflows": []})
+
+        assert response.status_code == 200
+        mock_write.assert_called_once_with({"workflows": []})
+
+    @patch("app.read_workflows")
+    @patch("app._repository_path")
+    def test_repository_workflows_success(self, mock_repo_path, mock_read):
+        mock_repo_path.return_value = "/workspace/repo"
+        mock_read.return_value = {"workflows": []}
+
+        response = client.get("/api/repositories/sample/workflows")
+
+        assert response.status_code == 200
+        mock_read.assert_called_once_with("sample")
+
+    @patch("app.write_workflows")
+    @patch("app._repository_path")
+    def test_save_repository_workflows_success(self, mock_repo_path, mock_write):
+        mock_repo_path.return_value = "/workspace/repo"
+        mock_write.return_value = {"workflows": []}
+
+        response = client.put("/api/repositories/sample/workflows", json={"workflows": []})
+
+        assert response.status_code == 200
+        mock_write.assert_called_once_with({"workflows": []}, "sample")

--- a/packages/pybackend/uv.lock
+++ b/packages/pybackend/uv.lock
@@ -351,6 +351,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-frontmatter" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "uvicorn" },
 ]
@@ -362,6 +363,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "python-frontmatter", specifier = "==1.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "uvicorn", specifier = "==0.29.0" },
 ]

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from config import ensure_directory, get_made_directory, get_workspace_home
+
+DEFAULT_WORKFLOW_NAME = "New workflow"
+
+
+def _workflow_path(repo_name: str | None = None) -> Path:
+    if repo_name:
+        base_path = get_workspace_home() / repo_name
+    else:
+        base_path = get_made_directory()
+    workflow_dir = ensure_directory(base_path / ".made") if repo_name else base_path
+    return workflow_dir / "workflows.yml"
+
+
+def _as_string(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped if stripped else None
+    return None
+
+
+def _normalize_step(step: Any) -> dict[str, str]:
+    if not isinstance(step, dict):
+        return {}
+    step_type = _as_string(step.get("type"))
+    if step_type == "bash":
+        run = _as_string(step.get("run"))
+        return {"type": "bash", "run": run or ""}
+    if step_type == "agent":
+        normalized: dict[str, str] = {"type": "agent"}
+        agent = _as_string(step.get("agent"))
+        command = _as_string(step.get("command"))
+        prompt = _as_string(step.get("prompt"))
+        if agent:
+            normalized["agent"] = agent
+        if command:
+            normalized["command"] = command
+        if prompt:
+            normalized["prompt"] = prompt
+        return normalized
+    return {}
+
+
+def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
+    if not isinstance(workflow, dict):
+        return None
+    workflow_id = _as_string(workflow.get("id")) or f"workflow_{index + 1}"
+    name = _as_string(workflow.get("name")) or DEFAULT_WORKFLOW_NAME
+    schedule = _as_string(workflow.get("schedule"))
+    raw_steps = workflow.get("steps")
+    steps: list[dict[str, str]] = []
+    if isinstance(raw_steps, list):
+        for raw_step in raw_steps:
+            step = _normalize_step(raw_step)
+            if step:
+                steps.append(step)
+
+    return {
+        "id": workflow_id,
+        "name": name,
+        "schedule": schedule,
+        "steps": steps,
+    }
+
+
+def _normalize_payload(payload: Any) -> dict[str, list[dict[str, Any]]]:
+    workflows: list[dict[str, Any]] = []
+    if isinstance(payload, dict) and isinstance(payload.get("workflows"), list):
+        for index, raw_workflow in enumerate(payload["workflows"]):
+            normalized = _normalize_workflow(raw_workflow, index)
+            if normalized:
+                workflows.append(normalized)
+    return {"workflows": workflows}
+
+
+def read_workflows(repo_name: str | None = None) -> dict[str, list[dict[str, Any]]]:
+    workflow_file = _workflow_path(repo_name)
+    if not workflow_file.exists():
+        return {"workflows": []}
+
+    data = yaml.safe_load(workflow_file.read_text(encoding="utf-8"))
+    return _normalize_payload(data)
+
+
+def write_workflows(
+    workflows_payload: dict[str, Any], repo_name: str | None = None
+) -> dict[str, list[dict[str, Any]]]:
+    normalized = _normalize_payload(workflows_payload)
+    workflow_file = _workflow_path(repo_name)
+    ensure_directory(workflow_file.parent)
+    workflow_file.write_text(
+        yaml.safe_dump(normalized, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return normalized


### PR DESCRIPTION
### Motivation
- Provide a visual Agent Workflow Builder in the Harness panel so users can create, edit and persist automation workflows per the spec and store them as YAML in `.made/workflows.yml`.
- Expose simple backend APIs to read and write workflows both globally and per-repository to enable the UI to persist state.

### Description
- Frontend: added a new `WorkflowBuilderPanel` component implementing workflow cards, expand/collapse, editable names, cron schedule editor, add/remove workflows, add/reorder steps, agent/bash step selector, first-line preview, multiline editor modal, and slash-command parsing; wired it into `HarnessesTab` and repository/knowledge/task/constitution pages. (`packages/frontend/src/components/WorkflowBuilderPanel.tsx`, modifications to `HarnessesTab.tsx`, `RepositoryPage.tsx`, `KnowledgeArtefactPage.tsx`, `TaskPage.tsx`, `ConstitutionPage.tsx`, `page.css`, and `useApi.ts` API types/methods). 
- Backend: added `workflow_service.py` to normalize and read/write workflows as YAML and added new API endpoints: `GET/PUT /api/workflows` and `GET/PUT /api/repositories/{name}/workflows` (integration into `app.py`), plus `PyYAML` as a dependency. (`packages/pybackend/workflow_service.py`, `packages/pybackend/app.py`, `pyproject.toml`).
- Tests: extended backend API unit tests to cover the new workflow endpoints and added minimal normalization/validation in the service.

### Testing
- Ran backend unit tests with dependency setup and test runner: `cd packages/pybackend && uv sync` then `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py`, result: `90 passed, 1 warning`.
- Built the frontend to validate TypeScript and bundling: `npm run build:frontend`, result: build completed successfully.
- Ran frontend lint: `npm --workspace packages/frontend run lint`, result: lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a888ae4e688332b9ef6f92e90eb0e7)