### PR TITLE
Add workflow-to-harness prompt generator and wire Run Workflow to send prompt

### DIFF
--- a/packages/frontend/src/components/HarnessesTab.tsx
+++ b/packages/frontend/src/components/HarnessesTab.tsx
@@ -21,6 +21,8 @@ type HarnessesTabProps = {
   loadWorkflows: () => Promise<{ workflows: WorkflowDefinition[] }>;
   saveWorkflows: (workflows: WorkflowDefinition[]) => Promise<{ workflows: WorkflowDefinition[] }>;
   listAgents: () => Promise<{ agents: { name: string }[] }>;
+  onSendMessage: (message: string) => void;
+  agentCli: string;
   historyStorageKey: string;
   maxHistory?: number;
 };
@@ -38,6 +40,8 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
   loadWorkflows,
   saveWorkflows,
   listAgents,
+  onSendMessage,
+  agentCli,
   historyStorageKey,
   maxHistory = 10,
 }) => {
@@ -222,6 +226,8 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
           loadWorkflows={loadWorkflows}
           saveWorkflows={(payload) => saveWorkflows(payload.workflows)}
           listAgents={listAgents}
+          onRunWorkflow={onSendMessage}
+          agentCli={agentCli}
         />
       </Panel>
       <Panel

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -9,6 +9,7 @@ import { RefreshIcon } from "./icons/RefreshIcon";
 import { SaveIcon } from "./icons/SaveIcon";
 import { TrashIcon } from "./icons/TrashIcon";
 import { XIcon } from "./icons/XIcon";
+import { buildWorkflowHarnessPrompt } from "../utils/workflowHarnessPrompt";
 
 export type WorkflowStep = {
   type: "agent" | "bash";
@@ -29,6 +30,8 @@ type WorkflowBuilderPanelProps = {
   loadWorkflows: () => Promise<{ workflows: WorkflowDefinition[] }>;
   saveWorkflows: (payload: { workflows: WorkflowDefinition[] }) => Promise<unknown>;
   listAgents: () => Promise<{ agents: AvailableAgent[] }>;
+  onRunWorkflow: (prompt: string) => void;
+  agentCli: string;
 };
 
 const previewText = (step: WorkflowStep) => {
@@ -69,6 +72,8 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
   loadWorkflows,
   saveWorkflows,
   listAgents,
+  onRunWorkflow,
+  agentCli,
 }) => {
   const [workflows, setWorkflows] = useState<WorkflowDefinition[]>([]);
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
@@ -195,7 +200,12 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                 <button className="copy-button workflow-icon-button" onClick={() => addStep(workflow.id)} title="Add step" aria-label="Add step">
                   <PlusIcon />
                 </button>
-                <button className="copy-button workflow-icon-button" title="Run workflow" aria-label="Run workflow" disabled>
+                <button
+                  className="copy-button workflow-icon-button"
+                  title="Run workflow"
+                  aria-label="Run workflow"
+                  onClick={() => onRunWorkflow(buildWorkflowHarnessPrompt(workflow, agentCli))}
+                >
                   <PlayIcon />
                 </button>
                 <button

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -495,6 +495,8 @@ export const ConstitutionPage: React.FC = () => {
                 loadWorkflows={() => api.getWorkflows()}
                 saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
                 listAgents={() => api.getAgents()}
+                onSendMessage={(message) => void handleSendMessage(message)}
+                agentCli={agentCli}
                 historyStorageKey={harnessHistoryStorageKey}
               />
             ),

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -513,6 +513,8 @@ export const KnowledgeArtefactPage: React.FC = () => {
                 loadWorkflows={() => api.getWorkflows()}
                 saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
                 listAgents={() => api.getAgents()}
+                onSendMessage={(message) => void handleSendMessage(message)}
+                agentCli={agentCli}
                 historyStorageKey={harnessHistoryStorageKey}
               />
             ),

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1534,6 +1534,10 @@ export const RepositoryPage: React.FC = () => {
                 api.saveRepositoryWorkflows(name || "", payload.workflows)
               }
               listAgents={() => api.getAgents()}
+              onRunWorkflow={(message) => {
+                void handleSendMessage(message);
+              }}
+              agentCli={agentCli}
             />
           </Panel>
           <Panel

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -509,6 +509,8 @@ export const TaskPage: React.FC = () => {
                 loadWorkflows={() => api.getWorkflows()}
                 saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
                 listAgents={() => api.getAgents()}
+                onSendMessage={(message) => void handleSendMessage(message)}
+                agentCli={agentCli}
                 historyStorageKey={harnessHistoryStorageKey}
               />
             ),

--- a/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
+++ b/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
@@ -1,0 +1,86 @@
+# Workflow to Harness Script Generator
+
+Create a single bash script for this workflow.
+
+## Output requirements
+
+1. Save the bash script in `.harness/{{WORKFLOW_FILE_NAME}}`.
+2. Support exactly one optional flag: `--dry-run`.
+3. Without any parameter, the script should execute the workflow normally.
+4. With `--dry-run`, print/log what would run without executing workflow actions.
+5. Ignore workflow schedule metadata and execute only the listed steps sequentially.
+6. Keep script sections readable and clearly mapped to the original workflow steps.
+7. Verify the script with bash tools, and test only in dry-run mode.
+
+## Current configured agent CLI
+
+`{{CURRENT_AGENT_CLI}}`
+
+## Supported agent CLI invocation reference (from made code)
+
+- `opencode` and `opencode-legacy`
+  - Base invocation: `opencode run --format json`
+  - Optional session: `-s <session_id>`
+  - Optional agent: `--agent <agent_name>`
+  - Optional model: `--model <model_name>`
+  - Message is sent through stdin.
+- `kiro`
+  - Base invocation: `kiro-cli chat --no-interactive --trust-all-tools`
+  - Optional resume: `--resume`
+  - Optional agent: `--agent <agent_name>`
+  - Optional model: `--model <model_name>`
+  - Message is sent through stdin.
+- `copilot`
+  - Base invocation: `copilot -p "<message>" --allow-all-tools --silent`
+  - Optional resume: `--resume <session_id>`
+- `codex`
+  - Base invocation: `codex exec --json`
+  - Optional resume: `codex exec resume <session_id> --json`
+  - Message is sent through stdin.
+
+Generate command calls only for the currently configured agent CLI (`{{CURRENT_AGENT_CLI}}`).
+
+## Workflow YAML
+
+```yaml
+{{WORKFLOW_YAML}}
+```
+
+## Bash file template (use and adapt)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="{{WORKFLOW_FILE_NAME}}"
+LOG_DIR="/tmp/made-harness-logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME%.sh}.log"
+
+if [[ -w /var/log ]]; then
+  LOG_FILE="/var/log/${SCRIPT_NAME%.sh}.log"
+fi
+
+log() {
+  local level="$1"
+  shift
+  printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$level" "$*" | tee -a "$LOG_FILE"
+}
+
+log "INFO" "Starting workflow: {{WORKFLOW_NAME}}"
+
+# Step 1: ...
+# Step 2: ...
+# Keep one clear section per workflow step.
+
+log "INFO" "Workflow finished: {{WORKFLOW_NAME}}"
+```
+
+## Verification requirements
+
+- Run static checks:
+  - `bash -n .harness/{{WORKFLOW_FILE_NAME}}`
+  - `shellcheck .harness/{{WORKFLOW_FILE_NAME}}` (if available)
+- Test dry-run behavior:
+  - `.harness/{{WORKFLOW_FILE_NAME}} --dry-run`
+- Do not run full execution mode during verification.

--- a/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { WorkflowDefinition } from "../components/WorkflowBuilderPanel";
+import { buildWorkflowHarnessPrompt } from "./workflowHarnessPrompt";
+
+describe("buildWorkflowHarnessPrompt", () => {
+  it("renders the configured cli and workflow yaml", () => {
+    const workflow: WorkflowDefinition = {
+      id: "wf_1",
+      name: "Release Workflow",
+      schedule: "0 5 * * *",
+      steps: [
+        { type: "agent", agent: "default", command: "plan", prompt: "Create release plan" },
+        { type: "bash", run: "echo done" },
+      ],
+    };
+
+    const prompt = buildWorkflowHarnessPrompt(workflow, "codex");
+
+    expect(prompt).toContain("`codex`");
+    expect(prompt).toContain('name: "Release Workflow"');
+    expect(prompt).toContain('schedule: "0 5 * * *"');
+    expect(prompt).toContain('agent: "default"');
+    expect(prompt).toContain('command: "plan"');
+    expect(prompt).toContain('run: "echo done"');
+    expect(prompt).toContain(".harness/release-workflow.sh");
+    expect(prompt).toContain("Support exactly one optional flag: `--dry-run`.");
+    expect(prompt).toContain("Without any parameter, the script should execute the workflow normally.");
+    expect(prompt).toContain(".harness/release-workflow.sh --dry-run");
+  });
+
+  it("falls back to workflow file name when workflow name is empty", () => {
+    const workflow: WorkflowDefinition = {
+      id: "wf_2",
+      name: "",
+      schedule: null,
+      steps: [],
+    };
+
+    const prompt = buildWorkflowHarnessPrompt(workflow, "opencode");
+
+    expect(prompt).toContain(".harness/workflow.sh");
+    expect(prompt).toContain("schedule: null");
+  });
+});

--- a/packages/frontend/src/utils/workflowHarnessPrompt.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.ts
@@ -1,0 +1,62 @@
+import workflowPromptTemplate from "../templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md?raw";
+import { WorkflowDefinition, WorkflowStep } from "../components/WorkflowBuilderPanel";
+
+const escapeYamlValue = (value: string) => {
+  const normalized = value.replace(/\r\n/g, "\n");
+  return JSON.stringify(normalized);
+};
+
+const stepToYaml = (step: WorkflowStep, indent: string) => {
+  const lines: string[] = [`${indent}- type: ${step.type}`];
+  if (step.type === "agent") {
+    if (step.agent) lines.push(`${indent}  agent: ${escapeYamlValue(step.agent)}`);
+    if (step.command) lines.push(`${indent}  command: ${escapeYamlValue(step.command)}`);
+    if (step.prompt) lines.push(`${indent}  prompt: ${escapeYamlValue(step.prompt)}`);
+    return lines;
+  }
+  lines.push(`${indent}  run: ${escapeYamlValue(step.run || "")}`);
+  return lines;
+};
+
+const workflowToYaml = (workflow: WorkflowDefinition) => {
+  const lines: string[] = ["workflows:", "  - id: " + escapeYamlValue(workflow.id), "    name: " + escapeYamlValue(workflow.name), "    schedule: " + (workflow.schedule ? escapeYamlValue(workflow.schedule) : "null"), "    steps:"];
+
+  if (!workflow.steps.length) {
+    lines.push("      []");
+  } else {
+    workflow.steps.forEach((step) => {
+      lines.push(...stepToYaml(step, "      "));
+    });
+  }
+
+  return lines.join("\n");
+};
+
+const normalizeWorkflowName = (value: string) => {
+  const fallback = "workflow";
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || fallback;
+};
+
+export const buildWorkflowHarnessPrompt = (
+  workflow: WorkflowDefinition,
+  agentCli: string,
+) => {
+  const apply = (template: string, key: string, value: string) =>
+    template.split(key).join(value);
+
+  let output = workflowPromptTemplate;
+  output = apply(output, "{{WORKFLOW_NAME}}", workflow.name);
+  output = apply(
+    output,
+    "{{WORKFLOW_FILE_NAME}}",
+    `${normalizeWorkflowName(workflow.name)}.sh`,
+  );
+  output = apply(output, "{{WORKFLOW_YAML}}", workflowToYaml(workflow));
+  output = apply(output, "{{CURRENT_AGENT_CLI}}", agentCli || "opencode");
+  return output;
+};


### PR DESCRIPTION
### Motivation

- Provide an automated way to convert UI workflows into a reproducible bash harness prompt so workflows can be generated as `.harness/*.sh` scripts. 
- Expose the selected agent CLI and ability to send generated prompts from the UI so the "Run workflow" action actually produces and sends the prompt to the backend/agent.

### Description

- Add a new prompt template file at `templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md` that defines the desired harness script output and verification steps. 
- Implement `buildWorkflowHarnessPrompt` in `utils/workflowHarnessPrompt.ts` to render the template with workflow YAML, normalized file names, and the configured `agentCli`, including helpers `workflowToYaml`, `stepToYaml`, `escapeYamlValue`, and `normalizeWorkflowName`.
- Wire the new prompt builder into the UI by adding `onRunWorkflow` and `agentCli` props to `WorkflowBuilderPanel` and invoking `onRunWorkflow(buildWorkflowHarnessPrompt(workflow, agentCli))` when the Run button is clicked.
- Propagate `onSendMessage`/`onRunWorkflow` and `agentCli` through `HarnessesTab` and the top-level pages (`ConstitutionPage`, `KnowledgeArtefactPage`, `RepositoryPage`, `TaskPage`) so the generated prompt can be sent to the existing message handler.
- Add unit tests for the prompt builder in `utils/workflowHarnessPrompt.test.ts` to verify template substitution, YAML output, and file name fallback behavior.

### Testing

- Ran the new unit tests with `vitest` targeting `utils/workflowHarnessPrompt.test.ts`, and the tests passed. 
- Verified the UI wiring by exercising the `Run workflow` button in the workflow builder in a local dev build and confirming the generated prompt is produced and routed to the `onSendMessage` handler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a804226483329d33bb2c579ba6af)