### PR TITLE
Switch to agent tab after launching Harness Builder workflow

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1536,6 +1536,7 @@ export const RepositoryPage: React.FC = () => {
               listAgents={() => api.getAgents()}
               onRunWorkflow={(message) => {
                 void handleSendMessage(message);
+                setActiveTab("agent");
               }}
               agentCli={agentCli}
             />


### PR DESCRIPTION
### Motivation
- When the Harness Builder injects a workflow message into the conversation, the related Agent conversation should be visible immediately so users can see the injected message and interact with agents without manually switching tabs.

### Description
- After sending the workflow message via `handleSendMessage`, call `setActiveTab("agent")` so the UI switches to the Agent tab (change in `packages/frontend/src/pages/RepositoryPage.tsx`).

### Testing
- Ran frontend unit tests with `npm test --prefix packages/frontend`, which completed successfully (`vitest` run; 7 test files, 22 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a91eab72448332a23e64fb2177c4af)