### PR TITLE
Add Dry Run button and red Run button in harness modal

### DIFF
--- a/packages/frontend/src/components/HarnessesTab.tsx
+++ b/packages/frontend/src/components/HarnessesTab.tsx
@@ -188,14 +188,17 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
   const closeHarnessModal = () =>
     setHarnessModal({ open: false, harness: null, args: "" });
 
-  const handleHarnessRun = async () => {
+  const handleHarnessRun = async (options?: { dryRun?: boolean }) => {
     if (!harnessModal.harness) return;
     setHarnessRunError(null);
     try {
-      const argsValue = harnessModal.args;
+      const argsValue = harnessModal.args.trim();
+      const finalArgs = options?.dryRun
+        ? `${argsValue} --dry-run`.trim()
+        : argsValue;
       const response = await runHarness(
         harnessModal.harness.path,
-        argsValue.trim() ? argsValue : undefined,
+        finalArgs || undefined,
       );
       const entry: HarnessRun = {
         pid: response.pid,
@@ -351,7 +354,10 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
           <button className="secondary" onClick={closeHarnessModal}>
             Cancel
           </button>
-          <button className="primary" onClick={handleHarnessRun}>
+          <button className="primary" onClick={() => handleHarnessRun({ dryRun: true })}>
+            Dry Run
+          </button>
+          <button className="danger" onClick={() => handleHarnessRun()}>
             Run
           </button>
         </div>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1093,16 +1093,19 @@ export const RepositoryPage: React.FC = () => {
   const closeHarnessModal = () =>
     setHarnessModal({ open: false, harness: null, args: "" });
 
-  const handleHarnessRun = async () => {
+  const handleHarnessRun = async (options?: { dryRun?: boolean }) => {
     if (!name) return;
     if (!harnessModal.harness) return;
     setHarnessRunError(null);
     try {
-      const argsValue = harnessModal.args;
+      const argsValue = harnessModal.args.trim();
+      const finalArgs = options?.dryRun
+        ? `${argsValue} --dry-run`.trim()
+        : argsValue;
       const response = await api.runRepositoryHarness(
         name,
         harnessModal.harness.path,
-        argsValue.trim() ? argsValue : undefined,
+        finalArgs || undefined,
       );
       const entry: HarnessRun = {
         pid: response.pid,
@@ -1959,7 +1962,10 @@ export const RepositoryPage: React.FC = () => {
           <button className="secondary" onClick={closeHarnessModal}>
             Cancel
           </button>
-          <button className="primary" onClick={handleHarnessRun}>
+          <button className="primary" onClick={() => handleHarnessRun({ dryRun: true })}>
+            Dry Run
+          </button>
+          <button className="danger" onClick={() => handleHarnessRun()}>
             Run
           </button>
         </div>


### PR DESCRIPTION
### Motivation
- Allow users to execute a harness in dry-run mode so commands are shown but not executed, and make the destructive `Run` action visually distinct.

### Description
- Changed `handleHarnessRun` in `packages/frontend/src/components/HarnessesTab.tsx` and `packages/frontend/src/pages/RepositoryPage.tsx` to accept `options?: { dryRun?: boolean }` and compute `finalArgs` accordingly.
- When `dryRun` is true the code appends `--dry-run` to the harness arguments before calling `runHarness` / `api.runRepositoryHarness`.
- Added a `Dry Run` button (keeps `primary` styling) and switched the regular `Run` button to use the `danger` class in both harness run modals.

### Testing
- Ran `npm --workspace packages/frontend run test` and all Vitest tests passed (`22 tests, all passed`).
- Ran `npm run build:frontend` and the frontend build completed successfully.
- Executed Playwright scripts to capture the UI; Chromium failed to launch in this environment but Firefox completed and produced a screenshot of the modal UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92fca2b008332bc4031998db0d2ec)