### PR TITLE
Persist workflow shell script path from Harness Builder run action

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -9,7 +9,10 @@ import { RefreshIcon } from "./icons/RefreshIcon";
 import { SaveIcon } from "./icons/SaveIcon";
 import { TrashIcon } from "./icons/TrashIcon";
 import { XIcon } from "./icons/XIcon";
-import { buildWorkflowHarnessPrompt } from "../utils/workflowHarnessPrompt";
+import {
+  buildWorkflowHarnessPrompt,
+  workflowShellScriptPath,
+} from "../utils/workflowHarnessPrompt";
 
 export type WorkflowStep = {
   type: "agent" | "bash";
@@ -23,6 +26,7 @@ export type WorkflowDefinition = {
   id: string;
   name: string;
   schedule: string | null;
+  shellScriptPath?: string;
   steps: WorkflowStep[];
 };
 
@@ -204,7 +208,20 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                   className="copy-button workflow-icon-button"
                   title="Run workflow"
                   aria-label="Run workflow"
-                  onClick={() => onRunWorkflow(buildWorkflowHarnessPrompt(workflow, agentCli))}
+                  onClick={async () => {
+                    const shellScriptPath = workflowShellScriptPath(workflow.name);
+                    const next = workflows.map((item) =>
+                      item.id === workflow.id
+                        ? { ...item, shellScriptPath }
+                        : item,
+                    );
+                    await persist(next);
+                    const workflowForPrompt = {
+                      ...workflow,
+                      shellScriptPath,
+                    };
+                    onRunWorkflow(buildWorkflowHarnessPrompt(workflowForPrompt, agentCli));
+                  }}
                 >
                   <PlayIcon />
                 </button>

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -236,6 +236,7 @@ export type WorkflowDefinition = {
   id: string;
   name: string;
   schedule: string | null;
+  shellScriptPath?: string;
   steps: WorkflowStep[];
 };
 

--- a/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
+++ b/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
@@ -4,7 +4,7 @@ Create a single bash script for this workflow.
 
 ## Output requirements
 
-1. Save the bash script in `.harness/{{WORKFLOW_FILE_NAME}}`.
+1. Save the bash script in `{{WORKFLOW_SCRIPT_PATH}}`.
 2. Support exactly one optional flag: `--dry-run`.
 3. Without any parameter, the script should execute the workflow normally.
 4. With `--dry-run`, print/log what would run without executing workflow actions.
@@ -39,6 +39,12 @@ Create a single bash script for this workflow.
   - Message is sent through stdin.
 
 Generate command calls only for the currently configured agent CLI (`{{CURRENT_AGENT_CLI}}`).
+
+## Workflow script path
+
+Use this exact script path when generating the harness script:
+
+`{{WORKFLOW_SCRIPT_PATH}}`
 
 ## Workflow YAML
 
@@ -79,8 +85,8 @@ log "INFO" "Workflow finished: {{WORKFLOW_NAME}}"
 ## Verification requirements
 
 - Run static checks:
-  - `bash -n .harness/{{WORKFLOW_FILE_NAME}}`
-  - `shellcheck .harness/{{WORKFLOW_FILE_NAME}}` (if available)
+  - `bash -n {{WORKFLOW_SCRIPT_PATH}}`
+  - `shellcheck {{WORKFLOW_SCRIPT_PATH}}` (if available)
 - Test dry-run behavior:
-  - `.harness/{{WORKFLOW_FILE_NAME}} --dry-run`
+  - `{{WORKFLOW_SCRIPT_PATH}} --dry-run`
 - Do not run full execution mode during verification.

--- a/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
@@ -23,7 +23,9 @@ describe("buildWorkflowHarnessPrompt", () => {
     expect(prompt).toContain('agent: "default"');
     expect(prompt).toContain('command: "plan"');
     expect(prompt).toContain('run: "echo done"');
-    expect(prompt).toContain(".harness/release-workflow.sh");
+    expect(prompt).toContain("shellScriptPath: \".harness/release-workflow.sh\"");
+    expect(prompt).toContain("Use this exact script path when generating the harness script:");
+    expect(prompt).toContain("`.harness/release-workflow.sh`");
     expect(prompt).toContain("Support exactly one optional flag: `--dry-run`.");
     expect(prompt).toContain("Without any parameter, the script should execute the workflow normally.");
     expect(prompt).toContain(".harness/release-workflow.sh --dry-run");
@@ -42,4 +44,19 @@ describe("buildWorkflowHarnessPrompt", () => {
     expect(prompt).toContain(".harness/workflow.sh");
     expect(prompt).toContain("schedule: null");
   });
+  it("uses explicit workflow shell script path when provided", () => {
+    const workflow: WorkflowDefinition = {
+      id: "wf_3",
+      name: "Any",
+      schedule: null,
+      shellScriptPath: ".harness/custom-script.sh",
+      steps: [],
+    };
+
+    const prompt = buildWorkflowHarnessPrompt(workflow, "opencode");
+
+    expect(prompt).toContain("shellScriptPath: \".harness/custom-script.sh\"");
+    expect(prompt).toContain("`.harness/custom-script.sh`");
+  });
+
 });

--- a/packages/frontend/src/utils/workflowHarnessPrompt.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.ts
@@ -1,6 +1,9 @@
 import workflowPromptTemplate from "../templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md?raw";
 import { WorkflowDefinition, WorkflowStep } from "../components/WorkflowBuilderPanel";
 
+export const workflowShellScriptPath = (workflowName: string) =>
+  `.harness/${normalizeWorkflowName(workflowName)}.sh`;
+
 const escapeYamlValue = (value: string) => {
   const normalized = value.replace(/\r\n/g, "\n");
   return JSON.stringify(normalized);
@@ -19,7 +22,14 @@ const stepToYaml = (step: WorkflowStep, indent: string) => {
 };
 
 const workflowToYaml = (workflow: WorkflowDefinition) => {
-  const lines: string[] = ["workflows:", "  - id: " + escapeYamlValue(workflow.id), "    name: " + escapeYamlValue(workflow.name), "    schedule: " + (workflow.schedule ? escapeYamlValue(workflow.schedule) : "null"), "    steps:"];
+  const lines: string[] = [
+    "workflows:",
+    "  - id: " + escapeYamlValue(workflow.id),
+    "    name: " + escapeYamlValue(workflow.name),
+    "    schedule: " + (workflow.schedule ? escapeYamlValue(workflow.schedule) : "null"),
+    "    shellScriptPath: " + escapeYamlValue(workflow.shellScriptPath || workflowShellScriptPath(workflow.name)),
+    "    steps:",
+  ];
 
   if (!workflow.steps.length) {
     lines.push("      []");
@@ -56,6 +66,7 @@ export const buildWorkflowHarnessPrompt = (
     "{{WORKFLOW_FILE_NAME}}",
     `${normalizeWorkflowName(workflow.name)}.sh`,
   );
+  output = apply(output, "{{WORKFLOW_SCRIPT_PATH}}", workflow.shellScriptPath || workflowShellScriptPath(workflow.name));
   output = apply(output, "{{WORKFLOW_YAML}}", workflowToYaml(workflow));
   output = apply(output, "{{CURRENT_AGENT_CLI}}", agentCli || "opencode");
   return output;

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -1,0 +1,46 @@
+from workflow_service import _normalize_payload
+
+
+def test_normalize_payload_keeps_shell_script_path():
+    payload = {
+        "workflows": [
+            {
+                "id": "wf_1",
+                "name": "Release",
+                "schedule": "0 5 * * *",
+                "shellScriptPath": "  .harness/release.sh  ",
+                "steps": [{"type": "bash", "run": "echo done"}],
+            }
+        ]
+    }
+
+    result = _normalize_payload(payload)
+
+    assert result == {
+        "workflows": [
+            {
+                "id": "wf_1",
+                "name": "Release",
+                "schedule": "0 5 * * *",
+                "shellScriptPath": ".harness/release.sh",
+                "steps": [{"type": "bash", "run": "echo done"}],
+            }
+        ]
+    }
+
+
+def test_normalize_payload_omits_empty_shell_script_path():
+    payload = {
+        "workflows": [
+            {
+                "id": "wf_1",
+                "name": "Release",
+                "shellScriptPath": "   ",
+                "steps": [],
+            }
+        ]
+    }
+
+    result = _normalize_payload(payload)
+
+    assert result["workflows"][0].get("shellScriptPath") is None

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -54,6 +54,7 @@ def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
     workflow_id = _as_string(workflow.get("id")) or f"workflow_{index + 1}"
     name = _as_string(workflow.get("name")) or DEFAULT_WORKFLOW_NAME
     schedule = _as_string(workflow.get("schedule"))
+    shell_script_path = _as_string(workflow.get("shellScriptPath"))
     raw_steps = workflow.get("steps")
     steps: list[dict[str, str]] = []
     if isinstance(raw_steps, list):
@@ -62,12 +63,15 @@ def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
             if step:
                 steps.append(step)
 
-    return {
+    normalized_workflow = {
         "id": workflow_id,
         "name": name,
         "schedule": schedule,
         "steps": steps,
     }
+    if shell_script_path:
+        normalized_workflow["shellScriptPath"] = shell_script_path
+    return normalized_workflow
 
 
 def _normalize_payload(payload: Any) -> dict[str, list[dict[str, Any]]]:


### PR DESCRIPTION
### Motivation
- Ensure traceability between a workflow in the Harness Builder and the harness script generated by the agent by computing and persisting a canonical shell script path when the user clicks Run. 
- Make the generated prompt explicitly reference the exact script path so the agent-created file can be verified and matched back to the workflow.

### Description
- Compute a safe script path `.harness/<safe-workflow-name>.sh` and persist it into the selected workflow as `shellScriptPath` before building and sending the harness prompt. 
- Extend prompt generation in `buildWorkflowHarnessPrompt` to embed `shellScriptPath` in the YAML and pass a dedicated `{{WORKFLOW_SCRIPT_PATH}}` template variable to the prompt template. 
- Update the prompt template to require and verify the exact `{{WORKFLOW_SCRIPT_PATH}}` and update frontend typings (`WorkflowDefinition`) and API types to include optional `shellScriptPath`. 
- Add backend normalization/persistence for `shellScriptPath` in `workflow_service.py` and add unit tests for frontend prompt generation and backend normalization to cover the new field.

### Testing
- Frontend unit tests: ran `npm --prefix packages/frontend test -- --run src/utils/workflowHarnessPrompt.test.ts` and the modified tests passed (`3 passed`).
- Backend unit tests: ran `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_workflow_service.py` and both new tests passed (`2 passed`).
- Frontend build: ran `npm --prefix packages/frontend run build` and production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b8f944508332bf60c52030642aa9)