### PR TITLE
Rename Documents panel label to Tasks on Tasks page

### DIFF
--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -98,7 +98,7 @@ export const TasksPage: React.FC = () => {
                     </Panel>
                   )}
                   {documentTasks.length > 0 && (
-                    <Panel title="Documents">
+                    <Panel title="Tasks">
                       <div className="panel-column">
                         {documentTasks.map((task) => (
                           <Panel


### PR DESCRIPTION
### Motivation
- Align the panel label with the page/domain terminology so non-template artefacts appear under a "Tasks" heading instead of "Documents".

### Description
- Change the panel title in `packages/frontend/src/pages/TasksPage.tsx` for non-template entries from `"Documents"` to `"Tasks"`.

### Testing
- Ran the unit tests with `npm --prefix packages/frontend test -- src/pages/TasksPage.test.tsx` and they passed (2 tests).
- Attempted an automated Playwright snapshot of `/tasks`, but the headless Chromium process crashed (SIGSEGV) in this environment so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ced122348332b73305138bfa3a5c)