### PR TITLE
Add workspace workflows overview to Tasks page

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -232,6 +232,15 @@ export type WorkflowStep = {
   run?: string;
 };
 
+export type WorkspaceWorkflowSummary = {
+  repository: string;
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: string | null;
+  shellScriptPath?: string;
+};
+
 export type WorkflowDefinition = {
   id: string;
   name: string;
@@ -437,6 +446,8 @@ export const api = {
     request<{ pid: number; running: boolean }>(`/harnesses/${pid}/status`),
 
   getWorkflows: () => request<{ workflows: WorkflowDefinition[] }>("/workflows"),
+  getWorkspaceWorkflows: () =>
+    request<{ workflows: WorkspaceWorkflowSummary[] }>("/workspace/workflows"),
   saveWorkflows: (workflows: WorkflowDefinition[]) =>
     request<{ workflows: WorkflowDefinition[] }>("/workflows", {
       method: "PUT",

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
@@ -303,6 +303,7 @@ export const RepositoryPage: React.FC = () => {
   const { name } = useParams();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("agent");
+  const [searchParams] = useSearchParams();
   const [repository, setRepository] = useState<RepositorySummary | null>(null);
   const [fileTree, setFileTree] = useState<FileNode | null>(null);
   const [fileActionError, setFileActionError] = useState<string | null>(null);
@@ -453,6 +454,13 @@ export const RepositoryPage: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [chat]);
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    if (tab) {
+      setActiveTab(tab);
+    }
+  }, [searchParams]);
+
   const lastKnownTimestamp = useMemo(() => {
     if (!chat.length) return undefined;
     const parsed = Date.parse(chat[chat.length - 1].timestamp);

--- a/packages/frontend/src/pages/TasksPage.test.tsx
+++ b/packages/frontend/src/pages/TasksPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../hooks/useApi", async () => {
       ...actual.api,
       listTasks: vi.fn(),
       saveTask: vi.fn(),
+      getWorkspaceWorkflows: vi.fn(),
     },
   };
 });
@@ -24,6 +25,7 @@ vi.mock("../hooks/useApi", async () => {
 describe("TasksPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getWorkspaceWorkflows).mockResolvedValue({ workflows: [] });
   });
 
   it("renders task schedules as green schedule tags", async () => {
@@ -44,6 +46,35 @@ describe("TasksPage", () => {
 
     expect(await screen.findByText("0 9 * * 1-5")).toBeInTheDocument();
     expect(screen.getByText("0 9 * * 1-5")).toHaveClass("success");
+  });
+
+  it("shows workspace workflows and links to the repository harness tab", async () => {
+    vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
+    vi.mocked(api.getWorkspaceWorkflows).mockResolvedValue({
+      workflows: [
+        {
+          repository: "sample-repo",
+          id: "wf_release",
+          name: "Release",
+          enabled: true,
+          schedule: "0 8 * * 1",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("0 8 * * 1")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Release" });
+    expect(link).toHaveAttribute(
+      "href",
+      "/repositories/sample-repo?tab=harnesses",
+    );
+    expect(screen.getByLabelText("Release enabled")).toBeChecked();
   });
 
   it("creates tasks with schedule metadata", async () => {

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { api, ArtefactSummary } from "../hooks/useApi";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  api,
+  ArtefactSummary,
+  WorkspaceWorkflowSummary,
+} from "../hooks/useApi";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { Modal } from "../components/Modal";
@@ -9,6 +13,7 @@ import "../styles/page.css";
 export const TasksPage: React.FC = () => {
   const [tasks, setTasks] = useState<ArtefactSummary[]>([]);
   const [activeTab, setActiveTab] = useState("tasks");
+  const [workspaceWorkflows, setWorkspaceWorkflows] = useState<WorkspaceWorkflowSummary[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const navigate = useNavigate();
@@ -33,6 +38,12 @@ export const TasksPage: React.FC = () => {
 
   useEffect(() => {
     loadTasks();
+    api
+      .getWorkspaceWorkflows()
+      .then((res) => setWorkspaceWorkflows(res.workflows))
+      .catch((error) =>
+        console.error("Failed to load workspace workflows", error),
+      );
   }, []);
 
   const handleCreate = async () => {
@@ -60,6 +71,46 @@ export const TasksPage: React.FC = () => {
             label: "Tasks",
             content: (
               <>
+                <Panel title="Workflows">
+                  {workspaceWorkflows.length === 0 ? (
+                    <div className="empty">
+                      No workflows found in repository .made/workflows.yml files.
+                    </div>
+                  ) : (
+                    <table className="git-table">
+                      <thead>
+                        <tr>
+                          <th>Enabled</th>
+                          <th>Schedule</th>
+                          <th>Name</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {workspaceWorkflows.map((workflow) => (
+                          <tr key={`${workflow.repository}:${workflow.id}`}>
+                            <td>
+                              <input
+                                type="checkbox"
+                                checked={workflow.enabled}
+                                readOnly
+                                aria-label={`${workflow.name} enabled`}
+                              />
+                            </td>
+                            <td>{workflow.schedule || "-"}</td>
+                            <td>
+                              <Link
+                                to={`/repositories/${encodeURIComponent(workflow.repository)}?tab=harnesses`}
+                              >
+                                {workflow.name}
+                              </Link>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </Panel>
+
                 <div className="button-bar">
                   <button
                     className="primary"

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -50,7 +50,7 @@ from knowledge_service import (
 )
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
-from workflow_service import read_workflows, write_workflows
+from workflow_service import list_workspace_workflows, read_workflows, write_workflows
 from repository_service import (
     create_repository,
     create_repository_file,
@@ -554,6 +554,18 @@ def save_global_workflows(payload: dict = Body(...)):
         return write_workflows(payload)
     except Exception as exc:
         logger.exception("Failed to save global workflows")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.get("/api/workspace/workflows")
+def workspace_workflows():
+    try:
+        logger.info("Listing workspace workflows")
+        return list_workspace_workflows()
+    except Exception as exc:
+        logger.exception("Failed to list workspace workflows")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         )

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1058,6 +1058,15 @@ class TestWorkflowEndpoints:
         assert response.status_code == 200
         mock_write.assert_called_once_with({"workflows": []})
 
+    @patch("app.list_workspace_workflows")
+    def test_workspace_workflows_success(self, mock_list):
+        mock_list.return_value = {"workflows": [{"repository": "sample", "id": "wf_1", "name": "Release", "enabled": True, "schedule": None}]}
+
+        response = client.get("/api/workspace/workflows")
+
+        assert response.status_code == 200
+        assert response.json()["workflows"][0]["repository"] == "sample"
+
     @patch("app.read_workflows")
     @patch("app._repository_path")
     def test_repository_workflows_success(self, mock_repo_path, mock_read):

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -1,4 +1,7 @@
-from workflow_service import _normalize_payload
+from pathlib import Path
+from unittest.mock import patch
+
+from workflow_service import _normalize_payload, list_workspace_workflows
 
 
 def test_normalize_payload_keeps_shell_script_path():
@@ -62,3 +65,37 @@ def test_normalize_payload_omits_empty_shell_script_path():
     result = _normalize_payload(payload)
 
     assert result["workflows"][0].get("shellScriptPath") is None
+
+
+@patch("workflow_service.read_workflows")
+@patch("workflow_service.get_workspace_home")
+def test_list_workspace_workflows_collects_repository_workflows(
+    mock_workspace_home, mock_read_workflows
+):
+    mock_workspace_home.return_value = Path("/workspace/home")
+
+    repos = [Path("/workspace/home/repo-a"), Path("/workspace/home/repo-b")]
+    file_entry = Path("/workspace/home/README.md")
+
+    with patch.object(Path, "iterdir", return_value=[*repos, file_entry]), patch.object(
+        Path, "is_dir", side_effect=[True, True, False]
+    ):
+        mock_read_workflows.side_effect = [
+            {"workflows": [{"id": "wf_a", "name": "A", "enabled": True, "schedule": "* * * * *"}]},
+            {"workflows": []},
+        ]
+
+        result = list_workspace_workflows()
+
+    assert result == {
+        "workflows": [
+            {
+                "repository": "repo-a",
+                "id": "wf_a",
+                "name": "A",
+                "enabled": True,
+                "schedule": "* * * * *",
+                "shellScriptPath": None,
+            }
+        ]
+    }

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -112,3 +112,29 @@ def write_workflows(
         encoding="utf-8",
     )
     return normalized
+
+
+def list_workspace_workflows() -> dict[str, list[dict[str, Any]]]:
+    workspace_home = get_workspace_home()
+    workflows: list[dict[str, Any]] = []
+
+    for repo_path in workspace_home.iterdir():
+        if not repo_path.is_dir():
+            continue
+
+        repo_name = repo_path.name
+        repository_workflows = read_workflows(repo_name).get("workflows", [])
+
+        for workflow in repository_workflows:
+            workflows.append(
+                {
+                    "repository": repo_name,
+                    "id": workflow.get("id"),
+                    "name": workflow.get("name"),
+                    "enabled": bool(workflow.get("enabled", False)),
+                    "schedule": workflow.get("schedule"),
+                    "shellScriptPath": workflow.get("shellScriptPath"),
+                }
+            )
+
+    return {"workflows": workflows}


### PR DESCRIPTION
### Motivation
- Provide a single overview of all repository-level workflows stored in `.made/workflows.yml` across the workspace so operators can see enabled state, schedule and jump to the corresponding repository harness. 

### Description
- Add aggregation routine `list_workspace_workflows()` that scans repositories under the workspace home and normalizes workflows, and expose it via `GET /api/workspace/workflows` in the backend. 
- Add `WorkspaceWorkflowSummary` type and `api.getWorkspaceWorkflows()` to the frontend API surface (`packages/frontend/src/hooks/useApi.ts`).
- Render a new "Workflows" panel above the Tasks panel on the Tasks page with a read-only enabled checkbox, cron schedule and workflow name, and make names link to the repository page with `?tab=harnesses` (`packages/frontend/src/pages/TasksPage.tsx`).
- Make `RepositoryPage` honor the `tab` query parameter so links jump directly to the Harnesses tab (`packages/frontend/src/pages/RepositoryPage.tsx`).
- Add and update unit tests for the backend aggregation function and endpoint as well as frontend Tasks page behavior (`packages/pybackend/tests/unit/test_workflow_service.py`, `packages/pybackend/tests/unit/test_api.py`, `packages/frontend/src/pages/TasksPage.test.tsx`).

### Testing
- Ran backend dependency sync with `cd packages/pybackend && uv sync` and executed pytest via `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_workflow_service.py packages/pybackend/tests/unit/test_api.py -k workflow`, which passed (selected tests: passed).
- Ran frontend unit tests with `npm --workspace packages/frontend run test -- src/pages/TasksPage.test.tsx`, which passed (`TasksPage` tests passed).
- Built the frontend with `npm --workspace packages/frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9dd335348833285230c1f1e530716)