### PR TITLE
Run harness scripts from repository root for .harness and .opencode/harness layouts and add unit test

### DIFF
--- a/packages/pybackend/harness_service.py
+++ b/packages/pybackend/harness_service.py
@@ -79,9 +79,18 @@ def run_harness(
         raise FileNotFoundError("Harness script not found")
 
     command = ["bash", str(resolved_path), *(_parse_harness_args(args))]
+    execution_cwd = resolved_path.parent
+    for ancestor in resolved_path.parents:
+        if ancestor.name == ".harness":
+            execution_cwd = ancestor.parent
+            break
+        if ancestor.name == "harness" and ancestor.parent.name == ".opencode":
+            execution_cwd = ancestor.parent.parent
+            break
+
     process = subprocess.Popen(
         command,
-        cwd=str(resolved_path.parent),
+        cwd=str(execution_cwd),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,

--- a/packages/pybackend/tests/unit/test_harness_service.py
+++ b/packages/pybackend/tests/unit/test_harness_service.py
@@ -102,5 +102,19 @@ def test_run_harness_accepts_multiline_argument(temp_env):
     assert output_path.read_text(encoding="utf-8") == multiline_value
 
 
+def test_run_harness_uses_repository_root_as_working_directory(temp_env):
+    workspace, _, _ = temp_env
+    repo_path = workspace / "runner"
+    harness_path = repo_path / ".harness" / "pwd.sh"
+    output_path = repo_path / "pwd.txt"
+    harness_path.parent.mkdir(parents=True, exist_ok=True)
+    write_harness_file(harness_path, f'pwd > "{output_path}"')
+
+    result = run_harness("runner", str(harness_path))
+
+    os.waitpid(result["pid"], 0)
+    assert output_path.read_text(encoding="utf-8").strip() == str(repo_path)
+
+
 def test_is_process_running_handles_invalid_pid():
     assert is_process_running(-1) is False


### PR DESCRIPTION
### Motivation
- Ensure harness scripts that live under `.harness` or under `.opencode/harness` are executed with the repository root as the current working directory so relative paths inside those scripts resolve correctly.

### Description
- Modify `run_harness` in `packages/pybackend/harness_service.py` to walk `resolved_path.parents` and set `cwd` to the parent of a found `.harness` directory or to the grandparent when the harness is `harness` under `.opencode`, falling back to the harness parent otherwise.
- Keep command invocation as `bash` with parsed arguments and return the launched process metadata (`pid`, `name`, `path`).
- Add `test_run_harness_uses_repository_root_as_working_directory` to `packages/pybackend/tests/unit/test_harness_service.py` to verify the working directory is the repository root for a `.harness` script.

### Testing
- Ran the unit test file `packages/pybackend/tests/unit/test_harness_service.py`, including the new `test_run_harness_uses_repository_root_as_working_directory`, and the tests passed.
- Existing harness tests for argument handling and process checks were also executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e9e761e08332aa22782ca035fbef)