### PR TITLE
Add backend cron clock and surface cron status in dashboard

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -241,6 +241,16 @@ export type WorkspaceWorkflowSummary = {
   shellScriptPath?: string;
 };
 
+export type CronClockSummary = {
+  running: boolean;
+  trafficLight: "ok" | "warning" | "error";
+  message: string;
+  startedAt: string | null;
+  configuredJobs: number;
+  invalidSchedules: number;
+  startedJobsSinceStartup: number;
+};
+
 export type WorkflowDefinition = {
   id: string;
   name: string;
@@ -259,6 +269,7 @@ export const api = {
       madeHome: string;
       workspaceHome: string;
       madeDirectory: string;
+      cronClock: CronClockSummary;
     }>("/dashboard"),
   listRepositories: () =>
     request<{ repositories: RepositorySummary[] }>("/repositories"),

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { api } from "../hooks/useApi";
+import { api, type CronClockSummary } from "../hooks/useApi";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import "../styles/page.css";
@@ -10,6 +10,7 @@ type DashboardData = {
   madeHome: string;
   workspaceHome: string;
   madeDirectory: string;
+  cronClock: CronClockSummary;
 };
 
 export const DashboardPage: React.FC = () => {
@@ -26,10 +27,13 @@ export const DashboardPage: React.FC = () => {
           madeHome: res.madeHome,
           workspaceHome: res.workspaceHome,
           madeDirectory: res.madeDirectory,
+          cronClock: res.cronClock,
         }),
       )
       .catch((error) => console.error("Failed to load dashboard", error));
   }, []);
+
+  const cronLight = data?.cronClock.trafficLight ?? "warning";
 
   return (
     <div className="page">
@@ -52,6 +56,17 @@ export const DashboardPage: React.FC = () => {
                     {data?.agentConnection
                       ? "Connection established"
                       : "Connection lost"}
+                  </div>
+                </Panel>
+                <Panel title="Cron Clock Status">
+                  <div className={`status-indicator ${cronLight}`}>
+                    <span className="light" />
+                    {data?.cronClock.message ?? "Cron status unknown"}
+                  </div>
+                </Panel>
+                <Panel title="Cron Jobs Started Since Startup">
+                  <div className="metric">
+                    {data?.cronClock.startedJobsSinceStartup ?? "—"}
                   </div>
                 </Panel>
                 <Panel title="MADE Home">

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -47,6 +47,11 @@
   box-shadow: 0 0 12px rgba(52, 211, 153, 0.6);
 }
 
+.status-indicator.warning .light {
+  background: #f59e0b;
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.6);
+}
+
 .path-info {
   font-family: monospace;
   font-size: 0.9rem;

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -51,6 +51,7 @@ from knowledge_service import (
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
 from workflow_service import list_workspace_workflows, read_workflows, write_workflows
+from cron_service import start_cron_clock, stop_cron_clock
 from repository_service import (
     create_repository,
     create_repository_file,
@@ -92,7 +93,16 @@ logging.basicConfig(
 )
 logger = logging.getLogger("made.pybackend")
 
-app = FastAPI(title="MADE Python Backend")
+@contextlib.asynccontextmanager
+async def lifespan(_: FastAPI):
+    start_cron_clock()
+    try:
+        yield
+    finally:
+        stop_cron_clock()
+
+
+app = FastAPI(title="MADE Python Backend", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/packages/pybackend/cron_service.py
+++ b/packages/pybackend/cron_service.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from config import get_workspace_home
+from workflow_service import read_workflows
+
+logger = logging.getLogger("made.pybackend.cron")
+
+_scheduler: BackgroundScheduler | None = None
+_state_lock = Lock()
+_started_jobs = 0
+_configured_jobs = 0
+_invalid_jobs = 0
+_started_at: datetime | None = None
+
+
+def _resolve_script_path(repo_path: Path, shell_script_path: str) -> Path:
+    script_path = Path(shell_script_path)
+    if script_path.is_absolute():
+        return script_path
+    return repo_path / script_path
+
+
+def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -> None:
+    global _started_jobs
+
+    with _state_lock:
+        _started_jobs += 1
+
+    logger.info("Running cron workflow '%s' in '%s'", workflow_id, repo_path)
+    result = subprocess.run(
+        ["bash", str(script_path)],
+        cwd=str(repo_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode == 0:
+        logger.info("Cron workflow '%s' completed", workflow_id)
+        if result.stdout.strip():
+            logger.info("Cron workflow '%s' stdout: %s", workflow_id, result.stdout.strip())
+        return
+
+    logger.warning(
+        "Cron workflow '%s' failed with exit code %s", workflow_id, result.returncode
+    )
+    if result.stdout.strip():
+        logger.warning("Cron workflow '%s' stdout: %s", workflow_id, result.stdout.strip())
+    if result.stderr.strip():
+        logger.warning("Cron workflow '%s' stderr: %s", workflow_id, result.stderr.strip())
+
+
+def start_cron_clock() -> None:
+    global _scheduler, _started_jobs, _configured_jobs, _invalid_jobs, _started_at
+
+    if _scheduler is not None:
+        return
+
+    scheduler = BackgroundScheduler()
+    configured_jobs = 0
+    invalid_jobs = 0
+
+    for repo_path in get_workspace_home().iterdir():
+        if not repo_path.is_dir():
+            continue
+
+        repo_name = repo_path.name
+        workflows = read_workflows(repo_name).get("workflows", [])
+        for workflow in workflows:
+            if not workflow.get("enabled"):
+                continue
+
+            schedule = workflow.get("schedule")
+            shell_script_path = workflow.get("shellScriptPath")
+            workflow_id = workflow.get("id") or "workflow"
+            if not isinstance(schedule, str) or not schedule.strip():
+                continue
+            if not isinstance(shell_script_path, str) or not shell_script_path.strip():
+                continue
+
+            script_path = _resolve_script_path(repo_path, shell_script_path)
+            if not script_path.exists() or not script_path.is_file():
+                continue
+
+            job_id = f"{repo_name}:{workflow_id}"
+            try:
+                scheduler.add_job(
+                    _run_workflow_script,
+                    CronTrigger.from_crontab(schedule),
+                    id=job_id,
+                    replace_existing=True,
+                    max_instances=1,
+                    coalesce=True,
+                    args=[repo_path, job_id, script_path],
+                )
+                configured_jobs += 1
+            except ValueError:
+                invalid_jobs += 1
+                logger.warning(
+                    "Skipping workflow '%s' in '%s': invalid cron '%s'",
+                    workflow_id,
+                    repo_name,
+                    schedule,
+                )
+
+    scheduler.start()
+    _scheduler = scheduler
+
+    with _state_lock:
+        _started_jobs = 0
+        _configured_jobs = configured_jobs
+        _invalid_jobs = invalid_jobs
+        _started_at = datetime.now(timezone.utc)
+
+    logger.info(
+        "Cron clock started with %s configured jobs (%s invalid schedules)",
+        configured_jobs,
+        invalid_jobs,
+    )
+
+
+def stop_cron_clock() -> None:
+    global _scheduler
+
+    if _scheduler is None:
+        return
+
+    _scheduler.shutdown(wait=False)
+    _scheduler = None
+    logger.info("Cron clock stopped")
+
+
+def get_cron_clock_status() -> dict[str, object]:
+    with _state_lock:
+        started_jobs = _started_jobs
+        configured_jobs = _configured_jobs
+        invalid_jobs = _invalid_jobs
+        started_at = _started_at
+
+    running = _scheduler is not None
+    if not running:
+        traffic_light = "error"
+        message = "Cron clock stopped"
+    elif configured_jobs == 0:
+        traffic_light = "warning"
+        message = "No cron jobs configured"
+    elif invalid_jobs > 0:
+        traffic_light = "warning"
+        message = "Cron clock running with invalid schedules"
+    else:
+        traffic_light = "ok"
+        message = "Cron clock running"
+
+    return {
+        "running": running,
+        "trafficLight": traffic_light,
+        "message": message,
+        "startedAt": started_at.isoformat() if started_at else None,
+        "configuredJobs": configured_jobs,
+        "invalidSchedules": invalid_jobs,
+        "startedJobsSinceStartup": started_jobs,
+    }

--- a/packages/pybackend/dashboard_service.py
+++ b/packages/pybackend/dashboard_service.py
@@ -1,5 +1,6 @@
 from repository_service import list_repositories
 from config import get_made_directory, get_made_home, get_workspace_home
+from cron_service import get_cron_clock_status
 
 
 def get_dashboard_summary():
@@ -11,4 +12,5 @@ def get_dashboard_summary():
         "madeHome": str(get_made_home()),
         "workspaceHome": str(get_workspace_home()),
         "madeDirectory": str(get_made_directory()),
+        "cronClock": get_cron_clock_status(),
     }

--- a/packages/pybackend/pyproject.toml
+++ b/packages/pybackend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "pytest-cov>=4.0.0",
   "httpx>=0.24.0",
   "PyYAML>=6.0.1",
+  "apscheduler>=3.11.2",
 ]
 
 [project.scripts]

--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock, patch
+
+import cron_service
+
+
+def teardown_function():
+    cron_service.stop_cron_clock()
+
+
+@patch("cron_service.CronTrigger.from_crontab")
+@patch("cron_service.BackgroundScheduler")
+@patch("cron_service.read_workflows")
+@patch("cron_service.get_workspace_home")
+def test_start_cron_clock_registers_only_enabled_workflows_with_existing_scripts(
+    mock_workspace_home,
+    mock_read_workflows,
+    mock_scheduler_cls,
+    mock_from_crontab,
+    tmp_path,
+):
+    repo = tmp_path / "repo-a"
+    repo.mkdir()
+    script = repo / ".made" / "build.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("echo hi", encoding="utf-8")
+
+    mock_workspace_home.return_value = tmp_path
+    mock_read_workflows.return_value = {
+        "workflows": [
+            {
+                "id": "enabled",
+                "enabled": True,
+                "schedule": "*/5 * * * *",
+                "shellScriptPath": ".made/build.sh",
+            },
+            {
+                "id": "disabled",
+                "enabled": False,
+                "schedule": "*/5 * * * *",
+                "shellScriptPath": ".made/build.sh",
+            },
+            {
+                "id": "missing-script",
+                "enabled": True,
+                "schedule": "*/5 * * * *",
+                "shellScriptPath": ".made/missing.sh",
+            },
+        ]
+    }
+
+    mock_scheduler = MagicMock()
+    mock_scheduler_cls.return_value = mock_scheduler
+    mock_from_crontab.return_value = object()
+
+    cron_service.start_cron_clock()
+
+    assert mock_scheduler.add_job.call_count == 1
+    _, kwargs = mock_scheduler.add_job.call_args
+    assert kwargs["id"] == "repo-a:enabled"
+    assert kwargs["args"][0] == repo
+    assert kwargs["args"][2] == script
+
+    status = cron_service.get_cron_clock_status()
+    assert status["running"] is True
+    assert status["configuredJobs"] == 1
+    assert status["trafficLight"] == "ok"
+
+
+@patch("cron_service.BackgroundScheduler")
+@patch("cron_service.read_workflows")
+@patch("cron_service.get_workspace_home")
+def test_start_cron_clock_marks_invalid_cron_as_warning(
+    mock_workspace_home,
+    mock_read_workflows,
+    mock_scheduler_cls,
+    tmp_path,
+):
+    repo = tmp_path / "repo-a"
+    repo.mkdir()
+    script = repo / "run.sh"
+    script.write_text("echo hi", encoding="utf-8")
+
+    mock_workspace_home.return_value = tmp_path
+    mock_read_workflows.return_value = {
+        "workflows": [
+            {
+                "id": "bad",
+                "enabled": True,
+                "schedule": "not-a-cron",
+                "shellScriptPath": "run.sh",
+            }
+        ]
+    }
+
+    mock_scheduler = MagicMock()
+    mock_scheduler.add_job.side_effect = ValueError("bad cron")
+    mock_scheduler_cls.return_value = mock_scheduler
+
+    cron_service.start_cron_clock()
+
+    status = cron_service.get_cron_clock_status()
+    assert status["running"] is True
+    assert status["configuredJobs"] == 0
+    assert status["invalidSchedules"] == 1
+    assert status["trafficLight"] == "warning"

--- a/packages/pybackend/uv.lock
+++ b/packages/pybackend/uv.lock
@@ -27,6 +27,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +358,7 @@ name = "made-pybackend"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "apscheduler" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pytest" },
@@ -358,6 +371,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "apscheduler", specifier = ">=3.11.2" },
     { name = "fastapi", specifier = "==0.111.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "pytest", specifier = ">=7.0.0" },
@@ -1007,6 +1021,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation

- Run enabled workflows on a schedule defined in repository `workflows.yml` and ensure generated shell scripts are executed in their repository directories. 
- Expose a simple traffic-light status and a runtime counter to the frontend so operators can see cron health and activity. 

### Description

- Added an APScheduler-backed cron clock service in `packages/pybackend/cron_service.py` that scans workspace repositories at startup, registers only enabled workflows with a valid cron schedule and an existing `shellScriptPath`, executes shell scripts with the repository as `cwd`, and tracks counters and status.
- Wired the scheduler lifecycle into FastAPI startup/shutdown via an async lifespan in `packages/pybackend/app.py` with `start_cron_clock()` and `stop_cron_clock()`.
- Extended the dashboard payload in `packages/pybackend/dashboard_service.py` to include `cronClock` (status, traffic light, configured/invalid job counts, started-jobs counter and start time).
- Updated frontend API typings and UI in `packages/frontend/src/hooks/useApi.ts` and `packages/frontend/src/pages/DashboardPage.tsx` to show a Cron Clock Status panel and a "Cron Jobs Started Since Startup" metric, and added warning styling in `packages/frontend/src/styles/page.css`.
- Added unit tests in `packages/pybackend/tests/unit/test_cron_service.py` to verify scheduling selection and invalid-cron handling, and added `apscheduler` to the backend dependencies (`packages/pybackend/pyproject.toml` and `uv.lock`).

### Testing

- Ran backend unit tests: `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_cron_service.py packages/pybackend/tests/unit/test_workflow_service.py packages/pybackend/tests/unit/test_api.py`; all tests passed.
- Linted backend files with `uv run ruff check app.py cron_service.py dashboard_service.py tests/unit/test_cron_service.py`; checks passed.
- Built frontend with `npm run build:frontend` to validate type and UI changes; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6527d1f0833284a27f0768053c3e)