### PR TITLE
Track cron workflow success ratio and validate repo cwd execution

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -249,6 +249,7 @@ export type CronClockSummary = {
   configuredJobs: number;
   invalidSchedules: number;
   startedJobsSinceStartup: number;
+  successfulJobsSinceStartup: number;
 };
 
 export type WorkflowDefinition = {

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -64,9 +64,11 @@ export const DashboardPage: React.FC = () => {
                     {data?.cronClock.message ?? "Cron status unknown"}
                   </div>
                 </Panel>
-                <Panel title="Cron Jobs Started Since Startup">
+                <Panel title="Cron Job Success Rate Since Startup">
                   <div className="metric">
-                    {data?.cronClock.startedJobsSinceStartup ?? "—"}
+                    {data
+                      ? `${data.cronClock.successfulJobsSinceStartup}/${data.cronClock.startedJobsSinceStartup}`
+                      : "—"}
                   </div>
                 </Panel>
                 <Panel title="MADE Home">

--- a/packages/pybackend/cron_service.py
+++ b/packages/pybackend/cron_service.py
@@ -17,6 +17,7 @@ logger = logging.getLogger("made.pybackend.cron")
 _scheduler: BackgroundScheduler | None = None
 _state_lock = Lock()
 _started_jobs = 0
+_successful_jobs = 0
 _configured_jobs = 0
 _invalid_jobs = 0
 _started_at: datetime | None = None
@@ -30,7 +31,7 @@ def _resolve_script_path(repo_path: Path, shell_script_path: str) -> Path:
 
 
 def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -> None:
-    global _started_jobs
+    global _started_jobs, _successful_jobs
 
     with _state_lock:
         _started_jobs += 1
@@ -45,6 +46,8 @@ def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -
     )
 
     if result.returncode == 0:
+        with _state_lock:
+            _successful_jobs += 1
         logger.info("Cron workflow '%s' completed", workflow_id)
         if result.stdout.strip():
             logger.info("Cron workflow '%s' stdout: %s", workflow_id, result.stdout.strip())
@@ -60,7 +63,7 @@ def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -
 
 
 def start_cron_clock() -> None:
-    global _scheduler, _started_jobs, _configured_jobs, _invalid_jobs, _started_at
+    global _scheduler, _started_jobs, _successful_jobs, _configured_jobs, _invalid_jobs, _started_at
 
     if _scheduler is not None:
         return
@@ -117,6 +120,7 @@ def start_cron_clock() -> None:
 
     with _state_lock:
         _started_jobs = 0
+        _successful_jobs = 0
         _configured_jobs = configured_jobs
         _invalid_jobs = invalid_jobs
         _started_at = datetime.now(timezone.utc)
@@ -142,6 +146,7 @@ def stop_cron_clock() -> None:
 def get_cron_clock_status() -> dict[str, object]:
     with _state_lock:
         started_jobs = _started_jobs
+        successful_jobs = _successful_jobs
         configured_jobs = _configured_jobs
         invalid_jobs = _invalid_jobs
         started_at = _started_at
@@ -168,4 +173,5 @@ def get_cron_clock_status() -> dict[str, object]:
         "configuredJobs": configured_jobs,
         "invalidSchedules": invalid_jobs,
         "startedJobsSinceStartup": started_jobs,
+        "successfulJobsSinceStartup": successful_jobs,
     }

--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -103,3 +103,50 @@ def test_start_cron_clock_marks_invalid_cron_as_warning(
     assert status["configuredJobs"] == 0
     assert status["invalidSchedules"] == 1
     assert status["trafficLight"] == "warning"
+
+
+@patch("cron_service.subprocess.run")
+def test_run_workflow_script_executes_from_repository_directory(mock_run, tmp_path):
+    repo = tmp_path / "repo-a"
+    repo.mkdir()
+    script = repo / ".harness" / "news.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("echo hi", encoding="utf-8")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+
+    cron_service._run_workflow_script(repo, "repo-a:news", script)
+
+    mock_run.assert_called_once_with(
+        ["bash", str(script)],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@patch("cron_service.subprocess.run")
+def test_cron_status_tracks_successful_vs_started_jobs(mock_run, tmp_path):
+    repo = tmp_path / "repo-a"
+    repo.mkdir()
+    script = repo / ".harness" / "news.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("echo hi", encoding="utf-8")
+
+    cron_service._started_jobs = 0
+    cron_service._successful_jobs = 0
+
+    mock_run.side_effect = [
+        MagicMock(returncode=0, stdout="ok", stderr=""),
+        MagicMock(returncode=1, stdout="", stderr="boom"),
+        MagicMock(returncode=127, stdout="", stderr="missing"),
+    ]
+
+    cron_service._run_workflow_script(repo, "repo-a:news", script)
+    cron_service._run_workflow_script(repo, "repo-a:news", script)
+    cron_service._run_workflow_script(repo, "repo-a:news", script)
+
+    status = cron_service.get_cron_clock_status()
+    assert status["startedJobsSinceStartup"] == 3
+    assert status["successfulJobsSinceStartup"] == 1


### PR DESCRIPTION
### Motivation
- Ensure cron job scripts defined with relative `shellScriptPath` are executed from the repository directory so scripts like `.harness/news.sh` are found and run.
- Provide visibility into successful cron executions versus total attempts so the dashboard can show a success ratio (e.g. `0/3`) for cron jobs.

### Description
- Added a backend counter `_successful_jobs` that is incremented under lock when a cron subprocess returns exit code `0` and reset when the cron clock starts.  
- Included `successfulJobsSinceStartup` in the `get_cron_clock_status()` payload.  
- Kept execution `cwd` as the repository path when invoking subprocesses (so relative `shellScriptPath` resolves relative to the repo).  
- Updated frontend API typing (`CronClockSummary`) and the Dashboard card to display a success ratio `successful/started`, and added unit tests validating cwd usage and success counting.

### Testing
- `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_cron_service.py` ran the unit tests inside the backend virtualenv and all tests passed (`4 passed`).
- Running `python -m pytest packages/pybackend/tests/unit/test_cron_service.py` without the `uv` environment failed during collection due to missing `apscheduler` (expected if backend deps are not installed). 
- `npm run build:frontend` completed successfully and produced a production build of the frontend. 
- An automated Playwright attempt to capture `/dashboard` failed with `net::ERR_EMPTY_RESPONSE`, so no browser screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6f03fd9483329bbfddd66b09571f)