### PR TITLE
Add backend endpoint to refresh cron schedules

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -51,7 +51,7 @@ from knowledge_service import (
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
 from workflow_service import list_workspace_workflows, read_workflows, write_workflows
-from cron_service import start_cron_clock, stop_cron_clock
+from cron_service import refresh_cron_clock, start_cron_clock, stop_cron_clock
 from repository_service import (
     create_repository,
     create_repository_file,
@@ -576,6 +576,17 @@ def workspace_workflows():
         return list_workspace_workflows()
     except Exception as exc:
         logger.exception("Failed to list workspace workflows")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+@app.post("/api/cron/update")
+def update_cron_jobs():
+    try:
+        logger.info("Refreshing cron clock from workflows")
+        return refresh_cron_clock()
+    except Exception as exc:
+        logger.exception("Failed to refresh cron clock")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         )

--- a/packages/pybackend/cron_service.py
+++ b/packages/pybackend/cron_service.py
@@ -143,6 +143,13 @@ def stop_cron_clock() -> None:
     logger.info("Cron clock stopped")
 
 
+def refresh_cron_clock() -> dict[str, object]:
+    """Reload cron jobs from workflow definitions and return current status."""
+    stop_cron_clock()
+    start_cron_clock()
+    return get_cron_clock_status()
+
+
 def get_cron_clock_status() -> dict[str, object]:
     with _state_lock:
         started_jobs = _started_jobs

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1088,3 +1088,22 @@ class TestWorkflowEndpoints:
 
         assert response.status_code == 200
         mock_write.assert_called_once_with({"workflows": []}, "sample")
+
+    @patch("app.refresh_cron_clock")
+    def test_update_cron_jobs_success(self, mock_refresh):
+        mock_refresh.return_value = {"running": True, "configuredJobs": 2}
+
+        response = client.post("/api/cron/update")
+
+        assert response.status_code == 200
+        assert response.json()["running"] is True
+        mock_refresh.assert_called_once_with()
+
+    @patch("app.refresh_cron_clock")
+    def test_update_cron_jobs_error(self, mock_refresh):
+        mock_refresh.side_effect = Exception("Cron refresh failed")
+
+        response = client.post("/api/cron/update")
+
+        assert response.status_code == 500
+        assert "Cron refresh failed" in response.json()["detail"]

--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -150,3 +150,21 @@ def test_cron_status_tracks_successful_vs_started_jobs(mock_run, tmp_path):
     status = cron_service.get_cron_clock_status()
     assert status["startedJobsSinceStartup"] == 3
     assert status["successfulJobsSinceStartup"] == 1
+
+
+@patch("cron_service.get_cron_clock_status")
+@patch("cron_service.start_cron_clock")
+@patch("cron_service.stop_cron_clock")
+def test_refresh_cron_clock_reloads_scheduler(
+    mock_stop,
+    mock_start,
+    mock_status,
+):
+    mock_status.return_value = {"running": True}
+
+    status = cron_service.refresh_cron_clock()
+
+    mock_stop.assert_called_once_with()
+    mock_start.assert_called_once_with()
+    mock_status.assert_called_once_with()
+    assert status == {"running": True}


### PR DESCRIPTION
### Motivation
- Allow the frontend to trigger a reload of cron jobs when a workflow's cron string or shell script path is edited and saved.
- Provide a single, safe operation that stops and restarts the scheduler to pick up updated workflow definitions.
- Surface the scheduler status payload to callers so the UI can reflect current cron health immediately.

### Description
- Introduced `refresh_cron_clock()` in `packages/pybackend/cron_service.py` which stops and restarts the scheduler and returns `get_cron_clock_status()`.
- Added a new API endpoint `POST /api/cron/update` in `packages/pybackend/app.py` implemented as `update_cron_jobs()` that calls `refresh_cron_clock()` and returns the status or a 500 on error.
- Added unit tests covering the new service orchestration and the API endpoint success and error cases in `packages/pybackend/tests/unit/test_cron_service.py` and `packages/pybackend/tests/unit/test_api.py`.

### Testing
- Ran backend unit tests with `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py packages/pybackend/tests/unit/test_cron_service.py`.
- All executed tests passed: `98 passed, 1 warning` (the two target test files and related suite assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7252826c8332ad8b4e17804b7b0f)