### PR TITLE
Group @ mention suggestions into Commands and Files sections

### DIFF
--- a/packages/frontend/src/components/MentionPathTextarea.tsx
+++ b/packages/frontend/src/components/MentionPathTextarea.tsx
@@ -4,6 +4,10 @@ type MentionPathTextareaProps = {
   value: string;
   onChange: (nextValue: string) => void;
   suggestions: string[];
+  sections?: Array<{
+    label: string;
+    suggestions: string[];
+  }>;
   placeholder?: string;
   rows?: number;
   id?: string;
@@ -95,6 +99,7 @@ export const MentionPathTextarea: React.FC<MentionPathTextareaProps> = ({
   value,
   onChange,
   suggestions,
+  sections,
   placeholder,
   rows = 4,
   id,
@@ -110,8 +115,29 @@ export const MentionPathTextarea: React.FC<MentionPathTextareaProps> = ({
   const filteredSuggestions = useMemo(() => {
     if (!activeMention) return [];
     const query = activeMention.query.toLowerCase();
+
+    if (sections?.length) {
+      return sections.flatMap((section) =>
+        section.suggestions.filter((item) => item.toLowerCase().includes(query)),
+      );
+    }
+
     return suggestions.filter((item) => item.toLowerCase().includes(query));
-  }, [activeMention, suggestions]);
+  }, [activeMention, sections, suggestions]);
+
+  const filteredSections = useMemo(() => {
+    if (!activeMention || !sections?.length) return [];
+    const query = activeMention.query.toLowerCase();
+
+    return sections
+      .map((section) => ({
+        label: section.label,
+        suggestions: section.suggestions.filter((item) =>
+          item.toLowerCase().includes(query),
+        ),
+      }))
+      .filter((section) => section.suggestions.length > 0);
+  }, [activeMention, sections]);
 
   useEffect(() => {
     if (!filteredSuggestions.length) {
@@ -221,19 +247,47 @@ export const MentionPathTextarea: React.FC<MentionPathTextareaProps> = ({
           className="mention-textarea__menu"
           style={{ top: menuPosition.top, left: menuPosition.left }}
         >
-          {filteredSuggestions.slice(0, 50).map((item, index) => (
-            <button
-              key={item}
-              type="button"
-              className={`mention-textarea__item${selectedIndex === index ? " is-active" : ""}`}
-              onMouseDown={(event) => {
-                event.preventDefault();
-                applySuggestion(item);
-              }}
-            >
-              {item}
-            </button>
-          ))}
+          {filteredSections.length > 0
+            ? (() => {
+                let globalIndex = 0;
+                return filteredSections.map((section) => (
+                  <div key={section.label}>
+                    <div className="mention-textarea__section-label">
+                      {section.label}
+                    </div>
+                    {section.suggestions.slice(0, 50).map((item) => {
+                      const itemIndex = globalIndex;
+                      globalIndex += 1;
+                      return (
+                        <button
+                          key={`${section.label}-${item}`}
+                          type="button"
+                          className={`mention-textarea__item${selectedIndex === itemIndex ? " is-active" : ""}`}
+                          onMouseDown={(event) => {
+                            event.preventDefault();
+                            applySuggestion(item);
+                          }}
+                        >
+                          {item}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ));
+              })()
+            : filteredSuggestions.slice(0, 50).map((item, index) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={`mention-textarea__item${selectedIndex === index ? " is-active" : ""}`}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    applySuggestion(item);
+                  }}
+                >
+                  {item}
+                </button>
+              ))}
         </div>
       )}
     </div>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -45,7 +45,11 @@ import { EditIcon } from "../components/icons/EditIcon";
 import { MoveIcon } from "../components/icons/MoveIcon";
 import { TagIcon } from "../components/icons/TagIcon";
 import { TrashIcon } from "../components/icons/TrashIcon";
-import { buildMentionPathCandidates, commandPathsFromDefinitions } from "../utils/pathMentions";
+import {
+  buildMentionPathCandidates,
+  buildMentionPathSections,
+  commandPathsFromDefinitions,
+} from "../utils/pathMentions";
 
 const stripCommandFrontmatter = (content: string) => {
   const delimiterPattern =
@@ -356,6 +360,23 @@ export const RepositoryPage: React.FC = () => {
     () => buildMentionPathCandidates(commandPathsFromDefinitions(availableCommands), fileTree),
     [availableCommands, fileTree],
   );
+  const mentionPathSections = useMemo(() => {
+    const sections = buildMentionPathSections(
+      commandPathsFromDefinitions(availableCommands),
+      fileTree,
+    );
+
+    return [
+      {
+        label: "Commands",
+        suggestions: sections.commands,
+      },
+      {
+        label: "Files",
+        suggestions: sections.files,
+      },
+    ];
+  }, [availableCommands, fileTree]);
   const [commandsError, setCommandsError] = useState<string | null>(null);
   const [commandsLoading, setCommandsLoading] = useState(false);
   const [availableHarnesses, setAvailableHarnesses] = useState<
@@ -1471,6 +1492,7 @@ export const RepositoryPage: React.FC = () => {
             onChange={setPendingPrompt}
             placeholder="Describe the change or ask the agent..."
             suggestions={mentionPathSuggestions}
+            sections={mentionPathSections}
           />
           <div className="button-bar chat-controls">
             <div className="chat-controls__left">

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -327,6 +327,21 @@ textarea {
   cursor: pointer;
 }
 
+.mention-textarea__section-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  padding: 0.45rem 0.6rem 0.2rem;
+  border-top: 1px solid var(--border);
+  margin-top: 0.2rem;
+}
+
+.mention-textarea__menu > div:first-child .mention-textarea__section-label {
+  border-top: 0;
+  margin-top: 0;
+}
+
 .mention-textarea__item:hover,
 .mention-textarea__item.is-active {
   background: rgba(59, 130, 246, 0.16);

--- a/packages/frontend/src/utils/pathMentions.test.ts
+++ b/packages/frontend/src/utils/pathMentions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildMentionPathCandidates, commandPathsFromDefinitions, flattenRepositoryTreePaths } from "./pathMentions";
+import {
+  buildMentionPathCandidates,
+  buildMentionPathSections,
+  commandPathsFromDefinitions,
+  flattenRepositoryTreePaths,
+} from "./pathMentions";
 
 describe("pathMentions", () => {
   it("prioritizes command paths and deduplicates tree paths", () => {
@@ -18,13 +23,31 @@ describe("pathMentions", () => {
       ],
     });
 
-    expect(treePaths).toEqual([
-      "commands/run.md",
-      "commands/build.md",
-      "commands",
-      "src",
-      "src/main.ts",
+    expect(treePaths).toEqual(["commands/run.md", "commands/build.md", "src/main.ts"]);
+  });
+
+  it("keeps command files even when hidden and separates command and file sections", () => {
+    const commandPaths = commandPathsFromDefinitions([
+      { id: "1", name: "c1", description: "", path: ".claude/commands/myCommand.md", source: "user", content: "" },
+      { id: "2", name: "c2", description: "", path: "../.made/commands/centralCommand.md", source: "user", content: "" },
     ]);
+
+    const sections = buildMentionPathSections(commandPaths, {
+      name: ".",
+      path: ".",
+      type: "folder",
+      children: [
+        { name: "src", path: "src", type: "folder", children: [{ name: "main.py", path: "src/main.py", type: "file" }] },
+        { name: "README.md", path: "README.md", type: "file" },
+        { name: ".claude", path: ".claude", type: "folder", children: [{ name: "commands", path: ".claude/commands", type: "folder" }] },
+      ],
+    });
+
+    expect(sections.commands).toEqual([
+      ".claude/commands/myCommand.md",
+      "../.made/commands/centralCommand.md",
+    ]);
+    expect(sections.files).toEqual(["src/main.py", "README.md"]);
   });
 
   it("filters dot and special folders", () => {
@@ -40,6 +63,6 @@ describe("pathMentions", () => {
       ],
     });
 
-    expect(flattened).toEqual(["docs", "docs/README.md"]);
+    expect(flattened).toEqual(["docs/README.md"]);
   });
 });

--- a/packages/frontend/src/utils/pathMentions.ts
+++ b/packages/frontend/src/utils/pathMentions.ts
@@ -7,7 +7,7 @@ const SPECIAL_FOLDER_NAMES = new Set([
   "coverage",
 ]);
 
-const hasIgnoredSegment = (path: string) =>
+const hasIgnoredFileSegment = (path: string) =>
   path
     .split("/")
     .some(
@@ -21,10 +21,27 @@ const hasIgnoredSegment = (path: string) =>
 
 const normalizePath = (value: string) => value.replace(/^\.\//, "").trim();
 
+const dedupePaths = (paths: string[], shouldIgnore: (path: string) => boolean) => {
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+
+  paths.forEach((value) => {
+    const normalized = normalizePath(value);
+    if (!normalized || shouldIgnore(normalized) || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    deduped.push(normalized);
+  });
+
+  return deduped;
+};
+
 export const commandPathsFromDefinitions = (commands: CommandDefinition[]) =>
-  commands
-    .map((command) => normalizePath(command.path || ""))
-    .filter((path) => path && !hasIgnoredSegment(path));
+  dedupePaths(
+    commands.map((command) => normalizePath(command.path || "")),
+    () => false,
+  );
 
 export const flattenRepositoryTreePaths = (tree?: FileNode | null): string[] => {
   if (!tree?.children?.length) return [];
@@ -34,8 +51,10 @@ export const flattenRepositoryTreePaths = (tree?: FileNode | null): string[] => 
   const walk = (nodes: FileNode[]) => {
     nodes.forEach((node) => {
       const path = normalizePath(node.path || "");
-      if (!path || hasIgnoredSegment(path)) return;
-      collected.push(path);
+      if (!path || hasIgnoredFileSegment(path)) return;
+      if (node.type === "file") {
+        collected.push(path);
+      }
       if (node.type === "folder" && node.children?.length) {
         walk(node.children);
       }
@@ -46,22 +65,23 @@ export const flattenRepositoryTreePaths = (tree?: FileNode | null): string[] => 
   return collected;
 };
 
+export type MentionPathSections = {
+  commands: string[];
+  files: string[];
+};
+
+export const buildMentionPathSections = (
+  commandPaths: string[],
+  tree?: FileNode | null,
+): MentionPathSections => ({
+  commands: dedupePaths(commandPaths, () => false),
+  files: dedupePaths(flattenRepositoryTreePaths(tree), hasIgnoredFileSegment),
+});
+
 export const buildMentionPathCandidates = (
   commandPaths: string[],
   tree?: FileNode | null,
 ) => {
-  const ordered = [...commandPaths, ...flattenRepositoryTreePaths(tree)];
-  const deduped: string[] = [];
-  const seen = new Set<string>();
-
-  ordered.forEach((value) => {
-    const normalized = normalizePath(value);
-    if (!normalized || hasIgnoredSegment(normalized) || seen.has(normalized)) {
-      return;
-    }
-    seen.add(normalized);
-    deduped.push(normalized);
-  });
-
-  return deduped;
+  const sections = buildMentionPathSections(commandPaths, tree);
+  return dedupePaths([...sections.commands, ...sections.files], () => false);
 };


### PR DESCRIPTION
### Motivation
- Make the `@` mention suggestion menu surface both relative repository filepaths and command filepaths (including command files stored under hidden segments like `.claude/...` or `../.made/...`) and present them as distinct sections so users can find commands and files more easily.

### Description
- Add `MentionPathSections` and helpers in `packages/frontend/src/utils/pathMentions.ts` to keep command paths (not filtered out for hidden segments), produce a file-only flattening of the repo tree, and deduplicate lists via a shared `dedupePaths` helper.
- Update `RepositoryPage` to build `mentionPathSections` (two sections: `Commands` and `Files`) from available commands and the repository tree and pass them to the mention textarea.
- Extend `MentionPathTextarea` to accept a `sections` prop and render section headers with the items while preserving the existing combined suggestion list, keyboard navigation, and insertion behavior.
- Add styling for section headers in `packages/frontend/src/styles/index.css` and expand tests in `packages/frontend/src/utils/pathMentions.test.ts` to cover hidden command paths and sectioning.

### Testing
- Ran the unit tests with `npm --prefix packages/frontend test -- src/utils/pathMentions.test.ts`, and all tests passed (`3 passed`).
- Ran linter with `npm --prefix packages/frontend run lint`, which succeeded with no errors.
- Built the frontend with `npm --prefix packages/frontend run build`, which completed successfully.
- Started the dev server and verified the UI (screenshot captured) with the updated mention menu showing `Commands` and `Files` sections.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3b1c86f88332acf2793e261a8163)