### PR TITLE
Make @ mention path suggestions repo-relative (relativize absolute paths)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -357,13 +357,19 @@ export const RepositoryPage: React.FC = () => {
     CommandDefinition[]
   >([]);
   const mentionPathSuggestions = useMemo(
-    () => buildMentionPathCandidates(commandPathsFromDefinitions(availableCommands), fileTree),
-    [availableCommands, fileTree],
+    () =>
+      buildMentionPathCandidates(
+        commandPathsFromDefinitions(availableCommands, repository?.path),
+        fileTree,
+        repository?.path,
+      ),
+    [availableCommands, fileTree, repository?.path],
   );
   const mentionPathSections = useMemo(() => {
     const sections = buildMentionPathSections(
-      commandPathsFromDefinitions(availableCommands),
+      commandPathsFromDefinitions(availableCommands, repository?.path),
       fileTree,
+      repository?.path,
     );
 
     return [
@@ -376,7 +382,7 @@ export const RepositoryPage: React.FC = () => {
         suggestions: sections.files,
       },
     ];
-  }, [availableCommands, fileTree]);
+  }, [availableCommands, fileTree, repository?.path]);
   const [commandsError, setCommandsError] = useState<string | null>(null);
   const [commandsLoading, setCommandsLoading] = useState(false);
   const [availableHarnesses, setAvailableHarnesses] = useState<

--- a/packages/frontend/src/utils/pathMentions.test.ts
+++ b/packages/frontend/src/utils/pathMentions.test.ts
@@ -50,6 +50,50 @@ describe("pathMentions", () => {
     expect(sections.files).toEqual(["src/main.py", "README.md"]);
   });
 
+  it("relativizes absolute command and file paths to the repository scope", () => {
+    const scopeRoot = "/workspace/made/repo";
+    const commandPaths = commandPathsFromDefinitions(
+      [
+        {
+          id: "1",
+          name: "c1",
+          description: "",
+          path: "/workspace/made/repo/.claude/commands/my-command.md",
+          source: "repository",
+          content: "",
+        },
+      ],
+      scopeRoot,
+    );
+
+    const sections = buildMentionPathSections(
+      commandPaths,
+      {
+        name: ".",
+        path: ".",
+        type: "folder",
+        children: [
+          {
+            name: "src",
+            path: "/workspace/made/repo/src",
+            type: "folder",
+            children: [
+              {
+                name: "index.ts",
+                path: "/workspace/made/repo/src/index.ts",
+                type: "file",
+              },
+            ],
+          },
+        ],
+      },
+      scopeRoot,
+    );
+
+    expect(sections.commands).toEqual([".claude/commands/my-command.md"]);
+    expect(sections.files).toEqual(["src/index.ts"]);
+  });
+
   it("filters dot and special folders", () => {
     const flattened = flattenRepositoryTreePaths({
       name: ".",

--- a/packages/frontend/src/utils/pathMentions.ts
+++ b/packages/frontend/src/utils/pathMentions.ts
@@ -21,12 +21,61 @@ const hasIgnoredFileSegment = (path: string) =>
 
 const normalizePath = (value: string) => value.replace(/^\.\//, "").trim();
 
-const dedupePaths = (paths: string[], shouldIgnore: (path: string) => boolean) => {
+const normalizeAbsolutePath = (value: string) => {
+  const normalized = normalizePath(value).replace(/\\/g, "/");
+  const withoutTrailingSlash = normalized.replace(/\/+$/, "");
+  if (/^[A-Za-z]:\//.test(withoutTrailingSlash)) {
+    return withoutTrailingSlash.toLowerCase();
+  }
+  return withoutTrailingSlash;
+};
+
+const isAbsolutePath = (value: string) =>
+  value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+
+const relativizePath = (value: string, scopeRoot?: string) => {
+  const normalizedValue = normalizePath(value);
+  if (!scopeRoot || !isAbsolutePath(normalizedValue)) {
+    return normalizedValue;
+  }
+
+  const base = normalizeAbsolutePath(scopeRoot);
+  const target = normalizeAbsolutePath(normalizedValue);
+  if (!base || !target || !isAbsolutePath(base) || !isAbsolutePath(target)) {
+    return normalizedValue;
+  }
+
+  const baseParts = base.split("/").filter(Boolean);
+  const targetParts = target.split("/").filter(Boolean);
+  let commonLength = 0;
+
+  while (
+    commonLength < baseParts.length &&
+    commonLength < targetParts.length &&
+    baseParts[commonLength] === targetParts[commonLength]
+  ) {
+    commonLength += 1;
+  }
+
+  const upSegments = Array.from(
+    { length: baseParts.length - commonLength },
+    () => "..",
+  );
+  const downSegments = targetParts.slice(commonLength);
+  const relativePath = [...upSegments, ...downSegments].join("/");
+  return relativePath || ".";
+};
+
+const dedupePaths = (
+  paths: string[],
+  shouldIgnore: (path: string) => boolean,
+  scopeRoot?: string,
+) => {
   const deduped: string[] = [];
   const seen = new Set<string>();
 
   paths.forEach((value) => {
-    const normalized = normalizePath(value);
+    const normalized = relativizePath(value, scopeRoot);
     if (!normalized || shouldIgnore(normalized) || seen.has(normalized)) {
       return;
     }
@@ -37,20 +86,27 @@ const dedupePaths = (paths: string[], shouldIgnore: (path: string) => boolean) =
   return deduped;
 };
 
-export const commandPathsFromDefinitions = (commands: CommandDefinition[]) =>
+export const commandPathsFromDefinitions = (
+  commands: CommandDefinition[],
+  scopeRoot?: string,
+) =>
   dedupePaths(
     commands.map((command) => normalizePath(command.path || "")),
     () => false,
+    scopeRoot,
   );
 
-export const flattenRepositoryTreePaths = (tree?: FileNode | null): string[] => {
+export const flattenRepositoryTreePaths = (
+  tree?: FileNode | null,
+  scopeRoot?: string,
+): string[] => {
   if (!tree?.children?.length) return [];
 
   const collected: string[] = [];
 
   const walk = (nodes: FileNode[]) => {
     nodes.forEach((node) => {
-      const path = normalizePath(node.path || "");
+      const path = relativizePath(node.path || "", scopeRoot);
       if (!path || hasIgnoredFileSegment(path)) return;
       if (node.type === "file") {
         collected.push(path);
@@ -73,15 +129,25 @@ export type MentionPathSections = {
 export const buildMentionPathSections = (
   commandPaths: string[],
   tree?: FileNode | null,
+  scopeRoot?: string,
 ): MentionPathSections => ({
-  commands: dedupePaths(commandPaths, () => false),
-  files: dedupePaths(flattenRepositoryTreePaths(tree), hasIgnoredFileSegment),
+  commands: dedupePaths(commandPaths, () => false, scopeRoot),
+  files: dedupePaths(
+    flattenRepositoryTreePaths(tree, scopeRoot),
+    hasIgnoredFileSegment,
+    scopeRoot,
+  ),
 });
 
 export const buildMentionPathCandidates = (
   commandPaths: string[],
   tree?: FileNode | null,
+  scopeRoot?: string,
 ) => {
-  const sections = buildMentionPathSections(commandPaths, tree);
-  return dedupePaths([...sections.commands, ...sections.files], () => false);
+  const sections = buildMentionPathSections(commandPaths, tree, scopeRoot);
+  return dedupePaths(
+    [...sections.commands, ...sections.files],
+    () => false,
+    scopeRoot,
+  );
 };


### PR DESCRIPTION
### Motivation
- Ensure the `@` path suggestion menu always shows paths relative to the repository in scope rather than exposing absolute filesystem paths. 
- This is needed so command files and file suggestions are consistent and portable across environments (including Windows-style absolute paths).

### Description
- Add utilities to detect/normalize absolute paths and a `relativizePath(value, scopeRoot?)` helper that converts absolute paths into repo-relative paths when a `scopeRoot` is provided. 
- Apply relativization when building command path lists and when flattening the repository file tree so both `Commands` and `Files` suggestions are repo-relative. 
- Extend `dedupePaths`, `commandPathsFromDefinitions`, `flattenRepositoryTreePaths`, `buildMentionPathSections` and `buildMentionPathCandidates` to accept an optional `scopeRoot` parameter and thread `repository?.path` from `RepositoryPage` into suggestion builders. 
- Add a unit test to cover relativizing absolute command and file-tree paths, and keep existing dedupe/filter behavior intact (updated `packages/frontend/src/utils/pathMentions.test.ts`).

### Testing
- Ran the frontend unit test for the updated module with `npm --workspace packages/frontend run test -- src/utils/pathMentions.test.ts`, which passed (1 test file, 4 tests passed). 
- Ran the frontend linter with `npm --workspace packages/frontend run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab40191cf48332b10202bfa5eaa967)