### PR TITLE
Show workflow repository names in Tasks workflows table

### DIFF
--- a/packages/frontend/src/pages/TasksPage.test.tsx
+++ b/packages/frontend/src/pages/TasksPage.test.tsx
@@ -48,12 +48,12 @@ describe("TasksPage", () => {
     expect(screen.getByText("0 9 * * 1-5")).toHaveClass("success");
   });
 
-  it("shows workspace workflows and links to the repository harness tab", async () => {
+  it("shows workspace workflows with repository names and links to harness tab", async () => {
     vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
     vi.mocked(api.getWorkspaceWorkflows).mockResolvedValue({
       workflows: [
         {
-          repository: "sample-repo",
+          repository: "/workspace/sample-repo",
           id: "wf_release",
           name: "Release",
           enabled: true,
@@ -75,6 +75,7 @@ describe("TasksPage", () => {
       "/repositories/sample-repo?tab=harnesses",
     );
     expect(screen.getByLabelText("Release enabled")).toBeChecked();
+    expect(screen.getByText("sample-repo")).toBeInTheDocument();
   });
 
   it("creates tasks with schedule metadata", async () => {

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -28,6 +28,10 @@ export const TasksPage: React.FC = () => {
   const documentTasks = tasks.filter(
     (task) => !isTemplate(task),
   );
+  const getRepositoryName = (repository: string) => {
+    const segments = repository.split(/[\\/]/).filter(Boolean);
+    return segments[segments.length - 1] || repository;
+  };
 
   const loadTasks = () => {
     api
@@ -83,29 +87,34 @@ export const TasksPage: React.FC = () => {
                           <th>Enabled</th>
                           <th>Schedule</th>
                           <th>Name</th>
+                          <th>Repository</th>
                         </tr>
                       </thead>
                       <tbody>
-                        {workspaceWorkflows.map((workflow) => (
-                          <tr key={`${workflow.repository}:${workflow.id}`}>
-                            <td>
-                              <input
-                                type="checkbox"
-                                checked={workflow.enabled}
-                                readOnly
-                                aria-label={`${workflow.name} enabled`}
-                              />
-                            </td>
-                            <td>{workflow.schedule || "-"}</td>
-                            <td>
-                              <Link
-                                to={`/repositories/${encodeURIComponent(workflow.repository)}?tab=harnesses`}
-                              >
-                                {workflow.name}
-                              </Link>
-                            </td>
-                          </tr>
-                        ))}
+                        {workspaceWorkflows.map((workflow) => {
+                          const repositoryName = getRepositoryName(workflow.repository);
+                          return (
+                            <tr key={`${workflow.repository}:${workflow.id}`}>
+                              <td>
+                                <input
+                                  type="checkbox"
+                                  checked={workflow.enabled}
+                                  readOnly
+                                  aria-label={`${workflow.name} enabled`}
+                                />
+                              </td>
+                              <td>{workflow.schedule || "-"}</td>
+                              <td>
+                                <Link
+                                  to={`/repositories/${encodeURIComponent(repositoryName)}?tab=harnesses`}
+                                >
+                                  {workflow.name}
+                                </Link>
+                              </td>
+                              <td>{repositoryName}</td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
                     </table>
                   )}


### PR DESCRIPTION
### Motivation
- The Tasks page workflows table displayed repository values as absolute paths which is noisy and exposes implementation details. The UI should show only the workspace folder (repo) name. 
- Links from the workflows table should continue to navigate to the repository harness tab using the normalized repository name.

### Description
- Added `getRepositoryName(repository: string)` to extract the last path segment from a repository path and fall back to the original value when needed. 
- Added a new `Repository` column to the workflows table and render the normalized repository folder name there. 
- Use the normalized repository name when building the harness link target (`/repositories/{repoName}?tab=harnesses`) so links remain correct for path-like repository values. 
- Updated `TasksPage` tests to assert repository name normalization and rendering.

### Testing
- Ran the frontend unit tests for the modified page with `npm --prefix packages/frontend test -- src/pages/TasksPage.test.tsx`, which executed 3 tests and all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab9ca5fbd483328deaaafd9640137d)