### PR TITLE
Refresh backend cron schedule when workflows change

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -157,6 +157,14 @@ def _start_shell(repo_path: Path) -> tuple[int, subprocess.Popen, str]:
     return master_fd, process, shell
 
 
+def _save_workflows_and_refresh_cron(
+    payload: dict, repo_name: str | None = None
+) -> dict[str, object]:
+    saved_workflows = write_workflows(payload, repo_name)
+    refresh_cron_clock()
+    return saved_workflows
+
+
 @app.get("/api/health")
 def health_check():
     return {
@@ -535,7 +543,7 @@ def save_repository_workflows(name: str, payload: dict = Body(...)):
     try:
         logger.info("Saving workflows for repository '%s'", name)
         _repository_path(name)
-        return write_workflows(payload, name)
+        return _save_workflows_and_refresh_cron(payload, name)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except Exception as exc:
@@ -561,7 +569,7 @@ def global_workflows():
 def save_global_workflows(payload: dict = Body(...)):
     try:
         logger.info("Saving global workflows")
-        return write_workflows(payload)
+        return _save_workflows_and_refresh_cron(payload)
     except Exception as exc:
         logger.exception("Failed to save global workflows")
         raise HTTPException(

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1049,14 +1049,17 @@ class TestWorkflowEndpoints:
         assert response.status_code == 200
         assert response.json() == {"workflows": []}
 
+    @patch("app.refresh_cron_clock")
     @patch("app.write_workflows")
-    def test_save_global_workflows_success(self, mock_write):
+    def test_save_global_workflows_success(self, mock_write, mock_refresh):
         mock_write.return_value = {"workflows": [{"id": "wf_1", "name": "x", "schedule": None, "steps": []}]}
+        mock_refresh.return_value = {"running": True}
 
         response = client.put("/api/workflows", json={"workflows": []})
 
         assert response.status_code == 200
-        mock_write.assert_called_once_with({"workflows": []})
+        mock_write.assert_called_once_with({"workflows": []}, None)
+        mock_refresh.assert_called_once_with()
 
     @patch("app.list_workspace_workflows")
     def test_workspace_workflows_success(self, mock_list):
@@ -1078,16 +1081,21 @@ class TestWorkflowEndpoints:
         assert response.status_code == 200
         mock_read.assert_called_once_with("sample")
 
+    @patch("app.refresh_cron_clock")
     @patch("app.write_workflows")
     @patch("app._repository_path")
-    def test_save_repository_workflows_success(self, mock_repo_path, mock_write):
+    def test_save_repository_workflows_success(
+        self, mock_repo_path, mock_write, mock_refresh
+    ):
         mock_repo_path.return_value = "/workspace/repo"
         mock_write.return_value = {"workflows": []}
+        mock_refresh.return_value = {"running": True}
 
         response = client.put("/api/repositories/sample/workflows", json={"workflows": []})
 
         assert response.status_code == 200
         mock_write.assert_called_once_with({"workflows": []}, "sample")
+        mock_refresh.assert_called_once_with()
 
     @patch("app.refresh_cron_clock")
     def test_update_cron_jobs_success(self, mock_refresh):


### PR DESCRIPTION
### Motivation
- Ensure the backend cron scheduler is updated automatically when workflows are changed (enabled/disabled or schedule edited) so frontend workflow mutations take effect immediately.
- Avoid requiring manual cron refresh calls after saving workflows from the UI.

### Description
- Add `_save_workflows_and_refresh_cron` which calls `write_workflows` and then `refresh_cron_clock` in `packages/pybackend/app.py`.
- Use the new helper for the `PUT /api/workflows` and `PUT /api/repositories/{name}/workflows` endpoints so saving workflows persists them and refreshes the scheduler.
- Update unit tests in `packages/pybackend/tests/unit/test_api.py` to mock and assert `refresh_cron_clock` is invoked when workflows are saved.

### Testing
- An initial `python -m pytest packages/pybackend/tests/unit/test_api.py -k "workflow or cron"` run failed due to missing `fastapi` when not using the package virtualenv.
- After running `cd packages/pybackend && uv sync` and executing `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py -k "workflow or cron"`, the selected tests passed with the new assertions (`7 passed, 86 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abcbda6da08332b425d46c0be046b9)