### PR TITLE
Recursive @path mention search and live mention-query callback

### DIFF
--- a/packages/frontend/src/components/MentionPathTextarea.test.tsx
+++ b/packages/frontend/src/components/MentionPathTextarea.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MentionPathTextarea } from "./MentionPathTextarea";
+
+describe("MentionPathTextarea", () => {
+  it("notifies mention query changes while typing", async () => {
+    const onMentionQueryChange = vi.fn();
+
+    const Wrapper = () => {
+      const [value, setValue] = useState("");
+      return (
+        <MentionPathTextarea
+          value={value}
+          onChange={setValue}
+          suggestions={["src/components/Button.tsx"]}
+          onMentionQueryChange={onMentionQueryChange}
+        />
+      );
+    };
+
+    render(<Wrapper />);
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "@src/comp" } });
+    fireEvent.keyUp(textarea);
+
+    await waitFor(() => {
+      expect(onMentionQueryChange).toHaveBeenCalledWith("src/comp");
+    });
+  });
+});

--- a/packages/frontend/src/components/MentionPathTextarea.tsx
+++ b/packages/frontend/src/components/MentionPathTextarea.tsx
@@ -13,6 +13,7 @@ type MentionPathTextareaProps = {
   id?: string;
   className?: string;
   disabled?: boolean;
+  onMentionQueryChange?: (query: string) => void;
 };
 
 type ActiveMention = {
@@ -105,6 +106,7 @@ export const MentionPathTextarea: React.FC<MentionPathTextareaProps> = ({
   id,
   className,
   disabled,
+  onMentionQueryChange,
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -150,7 +152,12 @@ export const MentionPathTextarea: React.FC<MentionPathTextareaProps> = ({
   const closeMenu = () => {
     setActiveMention(null);
     setSelectedIndex(0);
+    onMentionQueryChange?.("");
   };
+
+  useEffect(() => {
+    onMentionQueryChange?.(activeMention?.query || "");
+  }, [activeMention, onMentionQueryChange]);
 
   useEffect(() => {
     const handleMouseDown = (event: MouseEvent) => {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -63,6 +63,22 @@ const ARGUMENT_SPECIFIER_PATTERN = /\[([^\]]+)\]|<([^>]+)>/g;
 const PARENTHETICAL_COMMENT_PATTERN = /\s*\([^()]*\)\s*$/g;
 const CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
 const INLINE_CODE_PATTERN = /`[^`]*`/g;
+const normalizeMentionQuery = (value: string) =>
+  value.replace(/^\.\//, "").replace(/\\/g, "/").trim();
+
+const splitMentionSearch = (query: string) => {
+  const normalized = normalizeMentionQuery(query);
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash <= 0) {
+    return null;
+  }
+
+  return {
+    directory: normalized.slice(0, lastSlash),
+    searchTerm: normalized.slice(lastSlash + 1).toLowerCase(),
+  };
+};
+
 const MODEL_OPTIONS = [
   { value: "default", label: "default" },
   { value: "", label: "------ kiro ------", disabled: true },
@@ -383,6 +399,8 @@ export const RepositoryPage: React.FC = () => {
       },
     ];
   }, [availableCommands, fileTree, repository?.path]);
+  const [mentionQuery, setMentionQuery] = useState("");
+  const [recursiveMentionResults, setRecursiveMentionResults] = useState<string[]>([]);
   const [commandsError, setCommandsError] = useState<string | null>(null);
   const [commandsLoading, setCommandsLoading] = useState(false);
   const [availableHarnesses, setAvailableHarnesses] = useState<
@@ -529,6 +547,83 @@ export const RepositoryPage: React.FC = () => {
   const [movePath, setMovePath] = useState("");
   const [loadingFile, setLoadingFile] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
+
+  useEffect(() => {
+    const search = splitMentionSearch(mentionQuery);
+    if (!name || !search?.directory) {
+      setRecursiveMentionResults([]);
+      return;
+    }
+
+    let cancelled = false;
+    const timeout = window.setTimeout(() => {
+      const loadRecursiveMatches = async () => {
+        const folderQueue = [search.directory];
+        const collected: string[] = [];
+        const seen = new Set<string>();
+
+        while (folderQueue.length > 0) {
+          const currentPath = folderQueue.shift();
+          if (!currentPath || seen.has(currentPath)) {
+            continue;
+          }
+          seen.add(currentPath);
+
+          try {
+            const node = await api.getRepositoryFiles(name, currentPath);
+            const children = node.children || [];
+            children.forEach((child) => {
+              if (child.path) {
+                collected.push(child.path);
+              }
+              if (child.type === "folder") {
+                folderQueue.push(child.path);
+              }
+            });
+          } catch {
+            // Ignore invalid or inaccessible directories.
+          }
+        }
+
+        const filtered = search.searchTerm
+          ? collected.filter((path) =>
+              path.toLowerCase().includes(search.searchTerm),
+            )
+          : collected;
+
+        if (!cancelled) {
+          setRecursiveMentionResults(Array.from(new Set(filtered)).sort());
+        }
+      };
+
+      void loadRecursiveMatches();
+    }, 180);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
+  }, [mentionQuery, name]);
+
+  const displayedMentionSuggestions = useMemo(() => {
+    if (!recursiveMentionResults.length) {
+      return mentionPathSuggestions;
+    }
+    return recursiveMentionResults;
+  }, [mentionPathSuggestions, recursiveMentionResults]);
+
+  const displayedMentionSections = useMemo(() => {
+    if (!recursiveMentionResults.length) {
+      return mentionPathSections;
+    }
+
+    return [
+      {
+        label: "Recursive matches",
+        suggestions: recursiveMentionResults,
+      },
+    ];
+  }, [mentionPathSections, recursiveMentionResults]);
 
   useEffect(() => {
     if (!name) {
@@ -1497,8 +1592,9 @@ export const RepositoryPage: React.FC = () => {
             value={pendingPrompt}
             onChange={setPendingPrompt}
             placeholder="Describe the change or ask the agent..."
-            suggestions={mentionPathSuggestions}
-            sections={mentionPathSections}
+            suggestions={displayedMentionSuggestions}
+            sections={displayedMentionSections}
+            onMentionQueryChange={setMentionQuery}
           />
           <div className="button-bar chat-controls">
             <div className="chat-controls__left">


### PR DESCRIPTION
### Motivation
- Improve the `@` mention UX so typing a slash-qualified path (e.g. `@src/com`) triggers a recursive search inside that directory instead of only showing root-level candidates.
- Allow parent components to observe the active mention query so they can switch suggestion sources dynamically as the user types.

### Description
- Added an optional `onMentionQueryChange` prop to `MentionPathTextarea` and emit the live mention query (and an empty string when the menu closes) so parents can react to `@...` input in real time.
- Implemented `normalizeMentionQuery` and `splitMentionSearch` plus a `mentionQuery` state in `RepositoryPage` to detect slash-qualified queries and drive recursive searching.
- Added a recursive directory walker that uses the existing `api.getRepositoryFiles` to traverse descendants and produce `recursiveMentionResults`, exposed as a new "Recursive matches" suggestions section and used to drive `displayedMentionSuggestions`/`displayedMentionSections`.
- Wired the repository agent prompt to pass `onMentionQueryChange={setMentionQuery}` and to use `displayedMentionSuggestions`/`displayedMentionSections` instead of the static lists; added a component test `MentionPathTextarea.test.tsx` that verifies mention-query notifications.

### Testing
- Ran the focused component test with `npm --prefix packages/frontend test -- MentionPathTextarea.test.tsx`, which passed.
- Built the frontend with `npm --prefix packages/frontend run build`, which completed successfully.
- Ran ESLint from the frontend package context (`npm exec eslint ...` in `packages/frontend`) after a minor test import tweak, which completed without errors.
- Performed an end-to-end smoke run (`make run`) and exercised the UI via a Playwright script that navigated to the repository page and captured a screenshot of the recursive mention menu, confirming runtime behavior (screenshot saved as an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd1b977c083328ed8ca46ed9e9704)