### PR TITLE
Add repository-scoped agent listing endpoint and frontend usage

### DIFF
--- a/packages/frontend/src/components/AgentSelector.tsx
+++ b/packages/frontend/src/components/AgentSelector.tsx
@@ -6,6 +6,7 @@ type AgentSelectorProps = {
   onChange: (value: string) => void;
   disabled?: boolean;
   selectId: string;
+  repositoryName?: string;
 };
 
 const DEFAULT_AGENT_VALUE = "default";
@@ -15,6 +16,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({
   onChange,
   disabled = false,
   selectId,
+  repositoryName,
 }) => {
   const [agents, setAgents] = useState<AvailableAgent[]>([]);
   const [loading, setLoading] = useState(false);
@@ -25,7 +27,9 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({
     const loadAgents = async () => {
       setLoading(true);
       try {
-        const response = await api.getAgents();
+        const response = repositoryName
+          ? await api.getRepositoryAgents(repositoryName)
+          : await api.getAgents();
         if (!active) return;
         setAgents(response.agents || []);
         setError(null);
@@ -44,7 +48,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({
     return () => {
       active = false;
     };
-  }, []);
+  }, [repositoryName]);
 
   const groupedAgents = useMemo(() => {
     const primary = agents.filter((agent) => agent.type === "primary");

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -466,6 +466,8 @@ export const api = {
       body: JSON.stringify({ workflows }),
     }),
   getAgents: () => request<{ agents: AvailableAgent[] }>("/agents"),
+  getRepositoryAgents: (name: string) =>
+    request<{ agents: AvailableAgent[] }>(`/repositories/${name}/agents`),
   listKnowledge: () => request<{ artefacts: ArtefactSummary[] }>("/knowledge"),
   getKnowledge: (name: string) => request<MatterFile>(`/knowledge/${name}`),
   saveKnowledge: (name: string, payload: MatterFile) =>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1603,6 +1603,7 @@ export const RepositoryPage: React.FC = () => {
                 selectedAgent={normalizedSelectedAgent}
                 onChange={setSelectedAgent}
                 disabled={chatLoading}
+                repositoryName={name || undefined}
               />
               <label className="model-select" htmlFor="agent-model-select">
                 <select
@@ -1675,7 +1676,7 @@ export const RepositoryPage: React.FC = () => {
               saveWorkflows={(payload) =>
                 api.saveRepositoryWorkflows(name || "", payload.workflows)
               }
-              listAgents={() => api.getAgents()}
+              listAgents={() => api.getRepositoryAgents(name || "")}
               onRunWorkflow={(message) => {
                 void handleSendMessage(message);
                 setActiveTab("agent");

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -317,13 +317,25 @@ def list_chat_sessions(
     return [session.to_frontend_format() for session in limited_sessions]
 
 
-def list_agents() -> list[dict[str, object]]:
-    logger.info("Listing available %s agents", AGENT_CLI.cli_name)
+def list_agents(repository_name: str | None = None) -> list[dict[str, object]]:
+    logger.info(
+        "Listing available %s agents (repository: %s)",
+        AGENT_CLI.cli_name,
+        repository_name or "<workspace>",
+    )
 
     workspace_home = get_workspace_home()
-    list_cwd = (
-        workspace_home if workspace_home.exists() and workspace_home.is_dir() else None
-    )
+    if repository_name:
+        repository_path = workspace_home / repository_name
+        if not repository_path.exists() or not repository_path.is_dir():
+            raise FileNotFoundError(f"Repository '{repository_name}' not found")
+        list_cwd = repository_path
+    else:
+        list_cwd = (
+            workspace_home
+            if workspace_home.exists() and workspace_home.is_dir()
+            else None
+        )
 
     agent_cli = get_agent_cli()
     start_time = time.monotonic()

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -198,6 +198,21 @@ def list_available_agents():
         )
 
 
+@app.get("/api/repositories/{name}/agents")
+def list_repository_agents(name: str):
+    try:
+        logger.info("Listing available agents for repository '%s'", name)
+        return {"agents": list_agents(name)}
+    except FileNotFoundError as exc:
+        logger.warning("Repository not found for agent list '%s': %s", name, exc)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Failed to list agents for repository '%s'", name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
 @app.get("/api/repositories")
 def repositories():
     try:

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -82,6 +82,40 @@ class TestAgentsEndpoint:
         assert "Agent error" in response.json()["detail"]
 
 
+class TestRepositoryAgentsEndpoint:
+    """Test repository-scoped agents endpoint."""
+
+    @patch("app.list_agents")
+    def test_list_repository_agents_success(self, mock_list):
+        mock_list.return_value = [
+            {"name": "repo-agent", "type": "primary", "details": []}
+        ]
+
+        response = client.get("/api/repositories/sample/agents")
+
+        assert response.status_code == 200
+        assert response.json() == {"agents": mock_list.return_value}
+        mock_list.assert_called_once_with("sample")
+
+    @patch("app.list_agents")
+    def test_list_repository_agents_not_found(self, mock_list):
+        mock_list.side_effect = FileNotFoundError("Repository 'missing' not found")
+
+        response = client.get("/api/repositories/missing/agents")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"]
+
+    @patch("app.list_agents")
+    def test_list_repository_agents_error(self, mock_list):
+        mock_list.side_effect = Exception("Agent error")
+
+        response = client.get("/api/repositories/sample/agents")
+
+        assert response.status_code == 500
+        assert "Agent error" in response.json()["detail"]
+
+
 class TestChatHistoryEndpoint:
     @patch("app.export_chat_history")
     def test_repository_history_success(self, mock_export):

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -193,6 +193,48 @@ class TestAgentService:
         assert result == [{"name": "test", "type": "primary", "details": []}]
 
     @patch("agent_service.get_agent_cli")
+    @patch("agent_service.get_workspace_home")
+    def test_list_agents_uses_repository_cwd(
+        self, mock_get_workspace_home, mock_get_cli
+    ):
+        """Test agent listing executes with repository cwd when provided."""
+        from agent_service import list_agents
+        from agent_results import AgentListResult, AgentInfo
+
+        workspace = Path("/workspace")
+        repository = workspace / "sample"
+
+        mock_get_workspace_home.return_value = workspace
+        mock_cli = Mock()
+        mock_get_cli.return_value = mock_cli
+        mock_cli.list_agents.return_value = AgentListResult(
+            success=True,
+            agents=[AgentInfo(name="test", agent_type="primary", details=[])],
+        )
+
+        with patch.object(Path, "exists", return_value=True), patch.object(
+            Path, "is_dir", return_value=True
+        ):
+            result = list_agents("sample")
+
+        mock_cli.list_agents.assert_called_once_with(cwd=repository)
+        assert result == [{"name": "test", "type": "primary", "details": []}]
+
+    @patch("agent_service.get_workspace_home")
+    def test_list_agents_repository_not_found(self, mock_get_workspace_home):
+        """Test repository-specific agent listing fails for missing repository."""
+        from agent_service import list_agents
+
+        workspace = Path("/workspace")
+        mock_get_workspace_home.return_value = workspace
+
+        with patch.object(Path, "exists", return_value=False), patch.object(
+            Path, "is_dir", return_value=False
+        ):
+            with pytest.raises(FileNotFoundError):
+                list_agents("missing")
+
+    @patch("agent_service.get_agent_cli")
     def test_send_agent_message_success(self, mock_get_cli):
         """Test successful agent message sending."""
         from agent_service import send_agent_message


### PR DESCRIPTION
### Motivation
- Provide a way to list agents in the context of a specific repository so `opencode agent list` runs inside `MADE_WORKSPACE_HOME/{repo}` instead of only the global workspace.
- Keep existing global `/api/agents` behavior while enabling project-scoped agent discovery for repository UI flows.

### Description
- Added `GET /api/repositories/{name}/agents` endpoint which returns agents for the named repository and returns `404` when the repository path does not exist (`packages/pybackend/app.py`).
- Extended `agent_service.list_agents()` to accept an optional `repository_name` parameter, resolve and validate the repository path, and run the agent CLI in that directory when provided (`packages/pybackend/agent_service.py`).
- Updated frontend API client with `getRepositoryAgents(name)` and updated repository UI components to use the repository-scoped endpoint where appropriate (`packages/frontend/src/hooks/useApi.ts`, `packages/frontend/src/components/AgentSelector.tsx`, `packages/frontend/src/pages/RepositoryPage.tsx`).
- Added unit tests that cover the new repository agents API endpoint and repository-aware `list_agents()` behavior including missing-repo handling (`packages/pybackend/tests/unit/test_api.py`, `packages/pybackend/tests/unit/test_unit.py`).

### Testing
- Ran backend unit tests: `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py packages/pybackend/tests/unit/test_unit.py` which completed successfully (all tests passed: 117 passed, 1 warning).
- Built the frontend: `npm --prefix packages/frontend run build` which succeeded.
- Ran a targeted frontend test with Vitest: `npm --prefix packages/frontend run test -- --run src/components/MentionPathTextarea.test.tsx` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf7373c108332938968b6cb6f50bd)