### PR TITLE
Include untracked files in Git status diff

### DIFF
--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -397,6 +397,15 @@ def _line_stats_from_numstat(numstat_output: str) -> dict[str, int]:
     return {"green": green, "red": red}
 
 
+def _untracked_files(repo_path: Path) -> list[str]:
+    try:
+        output = _run_git(repo_path, ["ls-files", "--others", "--exclude-standard"])
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    return [line for line in output.splitlines() if line]
+
+
 def get_repository_git_status(
     repo_name: str,
 ) -> Dict[str, Union[str, int, dict, list, None]]:
@@ -420,11 +429,13 @@ def get_repository_git_status(
     line_stats = _remote_line_stats(repo_path)
 
     diff_files = []
+    seen_paths: set[str] = set()
     for line in diff_numstat.splitlines():
         parts = line.split("\t")
         if len(parts) < 3:
             continue
         added, deleted, path = parts[0], parts[1], parts[2]
+        seen_paths.add(path)
         diff_files.append(
             {
                 "path": path,
@@ -432,6 +443,11 @@ def get_repository_git_status(
                 "red": int(deleted) if deleted.isdigit() else 0,
             }
         )
+
+    for path in _untracked_files(repo_path):
+        if path in seen_paths:
+            continue
+        diff_files.append({"path": path, "green": 0, "red": 0})
 
     last_commit_id = None
     last_commit_date = None

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -168,6 +168,22 @@ def test_get_repository_git_status(monkeypatch, tmp_path):
     assert "lineStats" in result
 
 
+
+
+def test_get_repository_git_status_includes_untracked_files(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_path = workspace / "repo"
+    _init_local_repo(repo_path)
+    (repo_path / "new_file.txt").write_text("new", encoding="utf-8")
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    monkeypatch.setattr("repository_service._github_repo", lambda *_: None)
+
+    result = get_repository_git_status("repo")
+
+    assert any(entry["path"] == "new_file.txt" for entry in result["diff"])
+
 def test_pull_repository(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -284,6 +300,8 @@ def test_get_repository_git_status_uses_remote_line_stats(monkeypatch, tmp_path)
             return "4\t1\tsrc/main.py"
         if command == ["diff", "--numstat", "HEAD"]:
             return "10\t8\tsrc/local.py"
+        if command == ["ls-files", "--others", "--exclude-standard"]:
+            return ""
         if command == ["log", "-1", "--format=%H\t%cI"]:
             return "abc123\t2024-01-01T00:00:00Z"
         if command == ["worktree", "list", "--porcelain"]:


### PR DESCRIPTION
### Motivation
- Ensure the Git tab shows untracked files in addition to modified tracked files so the repository diff view reflects all local changes.

### Description
- Added a new helper `def _untracked_files(repo_path: Path) -> list[str]` that calls `git ls-files --others --exclude-standard` in `packages/pybackend/repository_service.py`.
- Updated `get_repository_git_status` to track seen paths and append untracked file entries (`green: 0, red: 0`) to the `diff` payload.
- Added `test_get_repository_git_status_includes_untracked_files` to `packages/pybackend/tests/unit/test_repository_service.py` to verify untracked files appear in `diff`.
- Updated the existing unit test's fake `_run_git` mock to account for the `ls-files --others --exclude-standard` call.

### Testing
- Ran `python -m pytest packages/pybackend/tests/unit/test_repository_service.py`; after updating the mock the suite passed with `15 passed`.
- Initial test run failed due to the new git command not being handled by the mock, then the mock was updated and tests were re-run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af0e4da180833284adeecc3cafb27a)