### PR TITLE
Render Modal via portal to fix harness builder edit-step overlay

### DIFF
--- a/packages/frontend/src/components/Modal.tsx
+++ b/packages/frontend/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import "../styles/modal.css";
 
 interface ModalProps {
@@ -17,7 +18,9 @@ export const Modal: React.FC<ModalProps> = ({
   className,
 }) => {
   if (!open) return null;
-  return (
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
     <div className="modal-backdrop" role="dialog" aria-modal="true">
       <div className={`modal${className ? ` ${className}` : ""}`}>
         <header className="modal-header">
@@ -32,6 +35,7 @@ export const Modal: React.FC<ModalProps> = ({
         </header>
         <div className="modal-body">{children}</div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };


### PR DESCRIPTION
### Motivation
- The edit-step dialog in the workflow/harness builder could be visually obscured by adjacent panel content because the shared `Modal` was mounted inline inside panel containers rather than at the document root.

### Description
- Updated `packages/frontend/src/components/Modal.tsx` to render the modal with `createPortal(..., document.body)` and added a `document` existence guard to avoid non-DOM runtime issues.

### Testing
- Ran the frontend unit test suite with `npm --workspace packages/frontend run test` (which executes `vitest run`) and all tests passed (29 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08960dfec83328d1264a7c911a4b9)