### PR TITLE
Add workflow last-run column to Tasks page

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -239,6 +239,7 @@ export type WorkspaceWorkflowSummary = {
   enabled: boolean;
   schedule: string | null;
   shellScriptPath?: string;
+  lastRun?: string | null;
 };
 
 export type CronClockSummary = {

--- a/packages/frontend/src/pages/TasksPage.test.tsx
+++ b/packages/frontend/src/pages/TasksPage.test.tsx
@@ -58,6 +58,7 @@ describe("TasksPage", () => {
           name: "Release",
           enabled: true,
           schedule: "0 8 * * 1",
+          lastRun: "2026-01-02T03:04:05Z",
         },
       ],
     });
@@ -76,6 +77,42 @@ describe("TasksPage", () => {
     );
     expect(screen.getByLabelText("Release enabled")).toBeChecked();
     expect(screen.getByText("sample-repo")).toBeInTheDocument();
+    expect(screen.getByText("Last run")).toBeInTheDocument();
+    expect(screen.getByText(/2026|1\/2\/2026|2\/1\/2026/)).toBeInTheDocument();
+  });
+
+
+  it("shows fallback last-run labels for non-cron and never-run workflows", async () => {
+    vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
+    vi.mocked(api.getWorkspaceWorkflows).mockResolvedValue({
+      workflows: [
+        {
+          repository: "repo-a",
+          id: "wf_no_cron",
+          name: "No Cron",
+          enabled: true,
+          schedule: null,
+          lastRun: null,
+        },
+        {
+          repository: "repo-b",
+          id: "wf_never",
+          name: "Never Run",
+          enabled: true,
+          schedule: "0 8 * * 1",
+          lastRun: null,
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("n.a.")).toBeInTheDocument();
+    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 
   it("creates tasks with schedule metadata", async () => {

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -28,6 +28,23 @@ export const TasksPage: React.FC = () => {
   const documentTasks = tasks.filter(
     (task) => !isTemplate(task),
   );
+  const formatWorkflowLastRun = (workflow: WorkspaceWorkflowSummary) => {
+    if (!workflow.schedule || !workflow.schedule.trim()) {
+      return "n.a.";
+    }
+
+    if (!workflow.lastRun) {
+      return "-";
+    }
+
+    const lastRunDate = new Date(workflow.lastRun);
+    if (Number.isNaN(lastRunDate.getTime())) {
+      return "-";
+    }
+
+    return lastRunDate.toLocaleString();
+  };
+
   const getRepositoryName = (repository: string) => {
     const segments = repository.split(/[\\/]/).filter(Boolean);
     return segments[segments.length - 1] || repository;
@@ -88,6 +105,7 @@ export const TasksPage: React.FC = () => {
                           <th>Schedule</th>
                           <th>Name</th>
                           <th>Repository</th>
+                          <th>Last run</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -112,6 +130,7 @@ export const TasksPage: React.FC = () => {
                                 </Link>
                               </td>
                               <td>{repositoryName}</td>
+                              <td>{formatWorkflowLastRun(workflow)}</td>
                             </tr>
                           );
                         })}

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -51,7 +51,12 @@ from knowledge_service import (
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
 from workflow_service import list_workspace_workflows, read_workflows, write_workflows
-from cron_service import refresh_cron_clock, start_cron_clock, stop_cron_clock
+from cron_service import (
+    get_cron_job_last_runs,
+    refresh_cron_clock,
+    start_cron_clock,
+    stop_cron_clock,
+)
 from repository_service import (
     create_repository,
     create_repository_file,
@@ -596,7 +601,7 @@ def save_global_workflows(payload: dict = Body(...)):
 def workspace_workflows():
     try:
         logger.info("Listing workspace workflows")
-        return list_workspace_workflows()
+        return list_workspace_workflows(get_cron_job_last_runs())
     except Exception as exc:
         logger.exception("Failed to list workspace workflows")
         raise HTTPException(

--- a/packages/pybackend/cron_service.py
+++ b/packages/pybackend/cron_service.py
@@ -21,6 +21,7 @@ _successful_jobs = 0
 _configured_jobs = 0
 _invalid_jobs = 0
 _started_at: datetime | None = None
+_last_run_by_job: dict[str, datetime] = {}
 
 
 def _resolve_script_path(repo_path: Path, shell_script_path: str) -> Path:
@@ -35,6 +36,7 @@ def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -
 
     with _state_lock:
         _started_jobs += 1
+        _last_run_by_job[workflow_id] = datetime.now(timezone.utc)
 
     logger.info("Running cron workflow '%s' in '%s'", workflow_id, repo_path)
     result = subprocess.run(
@@ -124,6 +126,7 @@ def start_cron_clock() -> None:
         _configured_jobs = configured_jobs
         _invalid_jobs = invalid_jobs
         _started_at = datetime.now(timezone.utc)
+        _last_run_by_job.clear()
 
     logger.info(
         "Cron clock started with %s configured jobs (%s invalid schedules)",
@@ -182,3 +185,20 @@ def get_cron_clock_status() -> dict[str, object]:
         "startedJobsSinceStartup": started_jobs,
         "successfulJobsSinceStartup": successful_jobs,
     }
+
+
+def get_cron_job_last_runs() -> dict[str, str | None]:
+    if _scheduler is None:
+        return {}
+
+    with _state_lock:
+        last_runs = {
+            workflow_id: timestamp.isoformat()
+            for workflow_id, timestamp in _last_run_by_job.items()
+        }
+
+    job_last_runs: dict[str, str | None] = {}
+    for job in _scheduler.get_jobs():
+        job_last_runs[job.id] = last_runs.get(job.id)
+
+    return job_last_runs

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1095,14 +1095,18 @@ class TestWorkflowEndpoints:
         mock_write.assert_called_once_with({"workflows": []}, None)
         mock_refresh.assert_called_once_with()
 
+    @patch("app.get_cron_job_last_runs")
     @patch("app.list_workspace_workflows")
-    def test_workspace_workflows_success(self, mock_list):
+    def test_workspace_workflows_success(self, mock_list, mock_last_runs):
+        mock_last_runs.return_value = {"sample:wf_1": "2026-01-02T03:04:05+00:00"}
         mock_list.return_value = {"workflows": [{"repository": "sample", "id": "wf_1", "name": "Release", "enabled": True, "schedule": None}]}
 
         response = client.get("/api/workspace/workflows")
 
         assert response.status_code == 200
         assert response.json()["workflows"][0]["repository"] == "sample"
+        mock_last_runs.assert_called_once_with()
+        mock_list.assert_called_once_with({"sample:wf_1": "2026-01-02T03:04:05+00:00"})
 
     @patch("app.read_workflows")
     @patch("app._repository_path")

--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -168,3 +168,21 @@ def test_refresh_cron_clock_reloads_scheduler(
     mock_start.assert_called_once_with()
     mock_status.assert_called_once_with()
     assert status == {"running": True}
+
+
+def test_get_cron_job_last_runs_includes_only_registered_jobs():
+    cron_service._scheduler = MagicMock()
+    cron_service._scheduler.get_jobs.return_value = [
+        MagicMock(id="repo-a:wf-1"),
+        MagicMock(id="repo-a:wf-2"),
+    ]
+    cron_service._last_run_by_job = {
+        "repo-a:wf-1": cron_service.datetime(2026, 1, 2, 3, 4, 5, tzinfo=cron_service.timezone.utc),
+        "repo-a:other": cron_service.datetime(2026, 1, 3, 3, 4, 5, tzinfo=cron_service.timezone.utc),
+    }
+
+    result = cron_service.get_cron_job_last_runs()
+
+    assert result["repo-a:wf-1"] == "2026-01-02T03:04:05+00:00"
+    assert result["repo-a:wf-2"] is None
+    assert "repo-a:other" not in result

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -85,7 +85,7 @@ def test_list_workspace_workflows_collects_repository_workflows(
             {"workflows": []},
         ]
 
-        result = list_workspace_workflows()
+        result = list_workspace_workflows({"repo-a:wf_a": "2026-01-02T03:04:05+00:00"})
 
     assert result == {
         "workflows": [
@@ -96,6 +96,7 @@ def test_list_workspace_workflows_collects_repository_workflows(
                 "enabled": True,
                 "schedule": "* * * * *",
                 "shellScriptPath": None,
+                "lastRun": "2026-01-02T03:04:05+00:00",
             }
         ]
     }

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -114,7 +114,9 @@ def write_workflows(
     return normalized
 
 
-def list_workspace_workflows() -> dict[str, list[dict[str, Any]]]:
+def list_workspace_workflows(
+    last_runs_by_job: dict[str, str | None] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
     workspace_home = get_workspace_home()
     workflows: list[dict[str, Any]] = []
 
@@ -126,6 +128,7 @@ def list_workspace_workflows() -> dict[str, list[dict[str, Any]]]:
         repository_workflows = read_workflows(repo_name).get("workflows", [])
 
         for workflow in repository_workflows:
+            job_id = f"{repo_name}:{workflow.get('id') or 'workflow'}"
             workflows.append(
                 {
                     "repository": repo_name,
@@ -134,6 +137,7 @@ def list_workspace_workflows() -> dict[str, list[dict[str, Any]]]:
                     "enabled": bool(workflow.get("enabled", False)),
                     "schedule": workflow.get("schedule"),
                     "shellScriptPath": workflow.get("shellScriptPath"),
+                    "lastRun": (last_runs_by_job or {}).get(job_id),
                 }
             )
 


### PR DESCRIPTION
### Motivation
- Surface the last execution time of scheduled workspace workflows in the Tasks UI so users can see when a cron job last ran.
- Backend must record and expose run timestamps only for registered cron jobs to avoid guessing from workflow files.

### Description
- Record run start timestamps per job id in `cron_service` by adding `_last_run_by_job` and updating it in `_run_workflow_script`, clearing on start, and exposing `get_cron_job_last_runs()` which returns a `{jobId -> ISO timestamp | null}` map.
- Wire `get_cron_job_last_runs()` into the workspace listing by passing it to `list_workspace_workflows()` and augmenting `list_workspace_workflows()` to attach a `lastRun` field to each workflow entry.
- Add `lastRun?: string | null` to the frontend `WorkspaceWorkflowSummary` type and add a new "Last run" column in the Tasks page table with rendering rules: `n.a.` when no schedule, `-` when scheduled but never run, and a localized date/time when `lastRun` is present (implemented in `formatWorkflowLastRun`).
- Add and update unit tests for the backend and frontend to cover the new `lastRun` behavior and API wiring.

### Testing
- Ran the frontend tests: `npm --workspace packages/frontend run test -- src/pages/TasksPage.test.tsx`, all tests passed (4/4).
- Ran selected backend tests: `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_workflow_service.py packages/pybackend/tests/unit/test_cron_service.py packages/pybackend/tests/unit/test_api.py -k "workspace_workflows_success or list_workspace_workflows_collects_repository_workflows or get_cron_job_last_runs"`, all selected tests passed (3/3).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42452a4688332b3112c4a88bedb06)