### PR TITLE
Terminate previous cron run before starting a new one

### DIFF
--- a/packages/pybackend/cron_service.py
+++ b/packages/pybackend/cron_service.py
@@ -22,6 +22,22 @@ _configured_jobs = 0
 _invalid_jobs = 0
 _started_at: datetime | None = None
 _last_run_by_job: dict[str, datetime] = {}
+_running_process_by_job: dict[str, subprocess.Popen[str]] = {}
+
+
+def _terminate_running_job(workflow_id: str) -> None:
+    running_process = _running_process_by_job.get(workflow_id)
+    if running_process is None or running_process.poll() is not None:
+        return
+
+    logger.info("Stopping previous cron workflow run for '%s'", workflow_id)
+    running_process.terminate()
+    try:
+        running_process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        logger.warning("Force killing previous cron workflow run for '%s'", workflow_id)
+        running_process.kill()
+        running_process.wait(timeout=5)
 
 
 def _resolve_script_path(repo_path: Path, shell_script_path: str) -> Path:
@@ -35,33 +51,39 @@ def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -
     global _started_jobs, _successful_jobs
 
     with _state_lock:
+        _terminate_running_job(workflow_id)
         _started_jobs += 1
         _last_run_by_job[workflow_id] = datetime.now(timezone.utc)
+        process = subprocess.Popen(
+            ["bash", str(script_path)],
+            cwd=str(repo_path),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        _running_process_by_job[workflow_id] = process
 
     logger.info("Running cron workflow '%s' in '%s'", workflow_id, repo_path)
-    result = subprocess.run(
-        ["bash", str(script_path)],
-        cwd=str(repo_path),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    stdout, stderr = process.communicate()
+    returncode = process.returncode
 
-    if result.returncode == 0:
+    with _state_lock:
+        if _running_process_by_job.get(workflow_id) is process:
+            _running_process_by_job.pop(workflow_id, None)
+
+    if returncode == 0:
         with _state_lock:
             _successful_jobs += 1
         logger.info("Cron workflow '%s' completed", workflow_id)
-        if result.stdout.strip():
-            logger.info("Cron workflow '%s' stdout: %s", workflow_id, result.stdout.strip())
+        if stdout.strip():
+            logger.info("Cron workflow '%s' stdout: %s", workflow_id, stdout.strip())
         return
 
-    logger.warning(
-        "Cron workflow '%s' failed with exit code %s", workflow_id, result.returncode
-    )
-    if result.stdout.strip():
-        logger.warning("Cron workflow '%s' stdout: %s", workflow_id, result.stdout.strip())
-    if result.stderr.strip():
-        logger.warning("Cron workflow '%s' stderr: %s", workflow_id, result.stderr.strip())
+    logger.warning("Cron workflow '%s' failed with exit code %s", workflow_id, returncode)
+    if stdout.strip():
+        logger.warning("Cron workflow '%s' stdout: %s", workflow_id, stdout.strip())
+    if stderr.strip():
+        logger.warning("Cron workflow '%s' stderr: %s", workflow_id, stderr.strip())
 
 
 def start_cron_clock() -> None:
@@ -103,7 +125,7 @@ def start_cron_clock() -> None:
                     CronTrigger.from_crontab(schedule),
                     id=job_id,
                     replace_existing=True,
-                    max_instances=1,
+                    max_instances=2,
                     coalesce=True,
                     args=[repo_path, job_id, script_path],
                 )
@@ -127,6 +149,7 @@ def start_cron_clock() -> None:
         _invalid_jobs = invalid_jobs
         _started_at = datetime.now(timezone.utc)
         _last_run_by_job.clear()
+        _running_process_by_job.clear()
 
     logger.info(
         "Cron clock started with %s configured jobs (%s invalid schedules)",
@@ -142,6 +165,12 @@ def stop_cron_clock() -> None:
         return
 
     _scheduler.shutdown(wait=False)
+
+    with _state_lock:
+        for workflow_id in list(_running_process_by_job):
+            _terminate_running_job(workflow_id)
+            _running_process_by_job.pop(workflow_id, None)
+
     _scheduler = None
     logger.info("Cron clock stopped")
 

--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -5,6 +5,7 @@ import cron_service
 
 def teardown_function():
     cron_service.stop_cron_clock()
+    cron_service._running_process_by_job = {}
 
 
 @patch("cron_service.CronTrigger.from_crontab")
@@ -105,29 +106,33 @@ def test_start_cron_clock_marks_invalid_cron_as_warning(
     assert status["trafficLight"] == "warning"
 
 
-@patch("cron_service.subprocess.run")
-def test_run_workflow_script_executes_from_repository_directory(mock_run, tmp_path):
+@patch("cron_service.subprocess.Popen")
+def test_run_workflow_script_executes_from_repository_directory(mock_popen, tmp_path):
     repo = tmp_path / "repo-a"
     repo.mkdir()
     script = repo / ".harness" / "news.sh"
     script.parent.mkdir(parents=True)
     script.write_text("echo hi", encoding="utf-8")
 
-    mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+    process = MagicMock()
+    process.communicate.return_value = ("ok", "")
+    process.returncode = 0
+    process.poll.return_value = None
+    mock_popen.return_value = process
 
     cron_service._run_workflow_script(repo, "repo-a:news", script)
 
-    mock_run.assert_called_once_with(
+    mock_popen.assert_called_once_with(
         ["bash", str(script)],
         cwd=str(repo),
-        capture_output=True,
+        stdout=cron_service.subprocess.PIPE,
+        stderr=cron_service.subprocess.PIPE,
         text=True,
-        check=False,
     )
 
 
-@patch("cron_service.subprocess.run")
-def test_cron_status_tracks_successful_vs_started_jobs(mock_run, tmp_path):
+@patch("cron_service.subprocess.Popen")
+def test_cron_status_tracks_successful_vs_started_jobs(mock_popen, tmp_path):
     repo = tmp_path / "repo-a"
     repo.mkdir()
     script = repo / ".harness" / "news.sh"
@@ -137,10 +142,22 @@ def test_cron_status_tracks_successful_vs_started_jobs(mock_run, tmp_path):
     cron_service._started_jobs = 0
     cron_service._successful_jobs = 0
 
-    mock_run.side_effect = [
-        MagicMock(returncode=0, stdout="ok", stderr=""),
-        MagicMock(returncode=1, stdout="", stderr="boom"),
-        MagicMock(returncode=127, stdout="", stderr="missing"),
+    mock_popen.side_effect = [
+        MagicMock(
+            communicate=MagicMock(return_value=("ok", "")),
+            returncode=0,
+            poll=MagicMock(return_value=None),
+        ),
+        MagicMock(
+            communicate=MagicMock(return_value=("", "boom")),
+            returncode=1,
+            poll=MagicMock(return_value=None),
+        ),
+        MagicMock(
+            communicate=MagicMock(return_value=("", "missing")),
+            returncode=127,
+            poll=MagicMock(return_value=None),
+        ),
     ]
 
     cron_service._run_workflow_script(repo, "repo-a:news", script)
@@ -150,6 +167,30 @@ def test_cron_status_tracks_successful_vs_started_jobs(mock_run, tmp_path):
     status = cron_service.get_cron_clock_status()
     assert status["startedJobsSinceStartup"] == 3
     assert status["successfulJobsSinceStartup"] == 1
+
+
+@patch("cron_service.subprocess.Popen")
+def test_new_run_terminates_previous_process_for_same_job(mock_popen, tmp_path):
+    repo = tmp_path / "repo-a"
+    repo.mkdir()
+    script = repo / "run.sh"
+    script.write_text("echo hi", encoding="utf-8")
+
+    previous_process = MagicMock()
+    previous_process.poll.return_value = None
+
+    next_process = MagicMock()
+    next_process.communicate.return_value = ("ok", "")
+    next_process.returncode = 0
+    next_process.poll.return_value = None
+
+    cron_service._running_process_by_job = {"repo-a:wf": previous_process}
+    mock_popen.return_value = next_process
+
+    cron_service._run_workflow_script(repo, "repo-a:wf", script)
+
+    previous_process.terminate.assert_called_once_with()
+    previous_process.wait.assert_called_once_with(timeout=5)
 
 
 @patch("cron_service.get_cron_clock_status")


### PR DESCRIPTION
### Motivation
- Prevent overlapping runs of the same scheduled task so stale/long-running processes are stopped before a new invocation begins.

### Description
- Track live workflow processes in `_running_process_by_job` and add `_terminate_running_job` to gracefully terminate (then kill) any previous process for the same job before starting a new one.
- Switch execution from `subprocess.run` to `subprocess.Popen` with `communicate()` so runs can be preempted and their output captured.
- Allow APScheduler to launch the replacement run by setting `max_instances=2` and explicitly clear/terminate tracked processes during `stop_cron_clock()` and when starting the scheduler (`_running_process_by_job.clear()`).
- Update unit tests to mock `subprocess.Popen` instead of `subprocess.run` and add a regression test that asserts the previous process is terminated when a new run for the same job starts.

### Testing
- Ran unit tests with `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_cron_service.py`, and all tests passed (`7 passed`).
- A direct `python -m pytest` run outside the `uv` environment failed due to missing `apscheduler` (expected if environment deps are not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44f1618588332bdccf2215514736c)