### PR TITLE
Add compact workflow diagnostics column to Tasks workflows table

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -139,10 +139,10 @@ async function requestForm<T>(
 export type AgentReply = {
   messageId: string;
   sent: string;
-  response: string;                 // Status message only
+  response: string; // Status message only
   prompt?: string;
   sessionId?: string;
-  processing?: boolean;             // NEW: indicates polling needed
+  processing?: boolean; // NEW: indicates polling needed
 };
 
 type AgentStatus = {
@@ -188,7 +188,6 @@ export type AvailableAgent = {
   source?: string;
 };
 
-
 export type GitDiffEntry = {
   path: string;
   green: number;
@@ -223,7 +222,6 @@ export type HarnessDefinition = {
   source: string;
 };
 
-
 export type WorkflowStep = {
   type: "agent" | "bash";
   agent?: string;
@@ -240,6 +238,14 @@ export type WorkspaceWorkflowSummary = {
   schedule: string | null;
   shellScriptPath?: string;
   lastRun?: string | null;
+  diagnostics?: {
+    lastStartedAt?: string | null;
+    lastFinishedAt?: string | null;
+    lastDurationMs?: number | null;
+    lastExitCode?: number | null;
+    lastError?: string | null;
+    running?: boolean;
+  } | null;
 };
 
 export type CronClockSummary = {
@@ -424,10 +430,13 @@ export const api = {
     directoryName: string,
     branchName: string,
   ) =>
-    request<{ path: string; branch: string }>(`/repositories/${name}/git/worktree`, {
-      method: "POST",
-      body: JSON.stringify({ directoryName, branchName }),
-    }),
+    request<{ path: string; branch: string }>(
+      `/repositories/${name}/git/worktree`,
+      {
+        method: "POST",
+        body: JSON.stringify({ directoryName, branchName }),
+      },
+    ),
   removeRepositoryWorktree: (name: string) =>
     request<{ removed: string }>(`/repositories/${name}/git/worktree`, {
       method: "DELETE",
@@ -442,12 +451,17 @@ export const api = {
     ),
 
   getRepositoryWorkflows: (name: string) =>
-    request<{ workflows: WorkflowDefinition[] }>(`/repositories/${name}/workflows`),
+    request<{ workflows: WorkflowDefinition[] }>(
+      `/repositories/${name}/workflows`,
+    ),
   saveRepositoryWorkflows: (name: string, workflows: WorkflowDefinition[]) =>
-    request<{ workflows: WorkflowDefinition[] }>(`/repositories/${name}/workflows`, {
-      method: "PUT",
-      body: JSON.stringify({ workflows }),
-    }),
+    request<{ workflows: WorkflowDefinition[] }>(
+      `/repositories/${name}/workflows`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ workflows }),
+      },
+    ),
   getCommands: () => request<{ commands: CommandDefinition[] }>("/commands"),
   getHarnesses: () => request<{ harnesses: HarnessDefinition[] }>("/harnesses"),
   runHarness: (path: string, args?: string) =>
@@ -458,7 +472,8 @@ export const api = {
   getHarnessStatus: (pid: number) =>
     request<{ pid: number; running: boolean }>(`/harnesses/${pid}/status`),
 
-  getWorkflows: () => request<{ workflows: WorkflowDefinition[] }>("/workflows"),
+  getWorkflows: () =>
+    request<{ workflows: WorkflowDefinition[] }>("/workflows"),
   getWorkspaceWorkflows: () =>
     request<{ workflows: WorkspaceWorkflowSummary[] }>("/workspace/workflows"),
   saveWorkflows: (workflows: WorkflowDefinition[]) =>

--- a/packages/frontend/src/pages/TasksPage.test.tsx
+++ b/packages/frontend/src/pages/TasksPage.test.tsx
@@ -8,9 +8,8 @@ import { TasksPage } from "./TasksPage";
 import { api } from "../hooks/useApi";
 
 vi.mock("../hooks/useApi", async () => {
-  const actual = await vi.importActual<typeof import("../hooks/useApi")>(
-    "../hooks/useApi",
-  );
+  const actual =
+    await vi.importActual<typeof import("../hooks/useApi")>("../hooks/useApi");
   return {
     ...actual,
     api: {
@@ -59,6 +58,14 @@ describe("TasksPage", () => {
           enabled: true,
           schedule: "0 8 * * 1",
           lastRun: "2026-01-02T03:04:05Z",
+          diagnostics: {
+            lastStartedAt: "2026-01-02T03:00:00Z",
+            lastFinishedAt: "2026-01-02T03:04:05Z",
+            lastDurationMs: 245000,
+            lastExitCode: 0,
+            lastError: null,
+            running: false,
+          },
         },
       ],
     });
@@ -78,9 +85,13 @@ describe("TasksPage", () => {
     expect(screen.getByLabelText("Release enabled")).toBeChecked();
     expect(screen.getByText("sample-repo")).toBeInTheDocument();
     expect(screen.getByText("Last run")).toBeInTheDocument();
-    expect(screen.getByText(/2026|1\/2\/2026|2\/1\/2026/)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/2026|1\/2\/2026|2\/1\/2026/).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Diagnostics")).toBeInTheDocument();
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText("Exit 0")).toBeInTheDocument();
   });
-
 
   it("shows fallback last-run labels for non-cron and never-run workflows", async () => {
     vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
@@ -115,6 +126,31 @@ describe("TasksPage", () => {
     expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 
+  it("shows fallback diagnostics label when no diagnostics exist", async () => {
+    vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
+    vi.mocked(api.getWorkspaceWorkflows).mockResolvedValue({
+      workflows: [
+        {
+          repository: "repo-a",
+          id: "wf_no_diagnostics",
+          name: "No Diagnostics",
+          enabled: true,
+          schedule: "0 8 * * 1",
+          lastRun: null,
+          diagnostics: null,
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("No diagnostics yet")).toBeInTheDocument();
+  });
+
   it("creates tasks with schedule metadata", async () => {
     vi.mocked(api.listTasks).mockResolvedValue({ tasks: [] });
     vi.mocked(api.saveTask).mockResolvedValue({});
@@ -125,7 +161,9 @@ describe("TasksPage", () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: /create task/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /create task/i }),
+    );
     fireEvent.change(screen.getByLabelText(/file name/i), {
       target: { value: "new-task" },
     });

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -10,10 +10,102 @@ import { TabView } from "../components/TabView";
 import { Modal } from "../components/Modal";
 import "../styles/page.css";
 
+type WorkflowDiagnostics = WorkspaceWorkflowSummary["diagnostics"];
+
+const formatDateTime = (value?: string | null, fallback = "-") => {
+  if (!value) {
+    return fallback;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+  return date.toLocaleString();
+};
+
+const formatDuration = (durationMs?: number | null) => {
+  if (typeof durationMs !== "number" || Number.isNaN(durationMs)) {
+    return "-";
+  }
+  if (durationMs < 1000) {
+    return `${durationMs}ms`;
+  }
+  const seconds = durationMs / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+};
+
+const formatExitCode = (value?: number | null) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "-";
+  }
+  return String(value);
+};
+
+const formatErrorText = (value?: string | null) => {
+  if (!value || !value.trim()) {
+    return "-";
+  }
+  const normalized = value.trim();
+  if (normalized.length <= 80) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 77)}...`;
+};
+
+const formatWorkflowLastRun = (workflow: WorkspaceWorkflowSummary) => {
+  if (!workflow.schedule || !workflow.schedule.trim()) {
+    return "n.a.";
+  }
+
+  if (!workflow.lastRun) {
+    return "-";
+  }
+
+  return formatDateTime(workflow.lastRun);
+};
+
+const renderWorkflowDiagnosticsSummary = (diagnostics: WorkflowDiagnostics) => {
+  if (!diagnostics) {
+    return <span className="meta-secondary">No diagnostics yet</span>;
+  }
+
+  return (
+    <details className="workflow-diagnostics">
+      <summary className="workflow-diagnostics__summary">
+        <span
+          className={`badge ${diagnostics.running ? "success" : ""}`.trim()}
+        >
+          {diagnostics.running ? "Running" : "Idle"}
+        </span>
+        <span className="badge">
+          Exit {formatExitCode(diagnostics.lastExitCode)}
+        </span>
+        <span className="badge">
+          {formatDuration(diagnostics.lastDurationMs)}
+        </span>
+      </summary>
+      <div className="meta-secondary">
+        <span>Started: {formatDateTime(diagnostics.lastStartedAt)}</span>
+        <span>Finished: {formatDateTime(diagnostics.lastFinishedAt)}</span>
+      </div>
+      <div className="meta-secondary">
+        Error: {formatErrorText(diagnostics.lastError)}
+      </div>
+    </details>
+  );
+};
+
 export const TasksPage: React.FC = () => {
   const [tasks, setTasks] = useState<ArtefactSummary[]>([]);
   const [activeTab, setActiveTab] = useState("tasks");
-  const [workspaceWorkflows, setWorkspaceWorkflows] = useState<WorkspaceWorkflowSummary[]>([]);
+  const [workspaceWorkflows, setWorkspaceWorkflows] = useState<
+    WorkspaceWorkflowSummary[]
+  >([]);
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const navigate = useNavigate();
@@ -22,29 +114,12 @@ export const TasksPage: React.FC = () => {
       return task.type === "template";
     }
     const frontmatterType = task.frontmatter?.type;
-    return typeof frontmatterType === "string" && frontmatterType === "template";
+    return (
+      typeof frontmatterType === "string" && frontmatterType === "template"
+    );
   };
   const templateTasks = tasks.filter(isTemplate);
-  const documentTasks = tasks.filter(
-    (task) => !isTemplate(task),
-  );
-  const formatWorkflowLastRun = (workflow: WorkspaceWorkflowSummary) => {
-    if (!workflow.schedule || !workflow.schedule.trim()) {
-      return "n.a.";
-    }
-
-    if (!workflow.lastRun) {
-      return "-";
-    }
-
-    const lastRunDate = new Date(workflow.lastRun);
-    if (Number.isNaN(lastRunDate.getTime())) {
-      return "-";
-    }
-
-    return lastRunDate.toLocaleString();
-  };
-
+  const documentTasks = tasks.filter((task) => !isTemplate(task));
   const getRepositoryName = (repository: string) => {
     const segments = repository.split(/[\\/]/).filter(Boolean);
     return segments[segments.length - 1] || repository;
@@ -95,7 +170,8 @@ export const TasksPage: React.FC = () => {
                 <Panel title="Workflows">
                   {workspaceWorkflows.length === 0 ? (
                     <div className="empty">
-                      No workflows found in repository .made/workflows.yml files.
+                      No workflows found in repository .made/workflows.yml
+                      files.
                     </div>
                   ) : (
                     <table className="git-table">
@@ -106,11 +182,14 @@ export const TasksPage: React.FC = () => {
                           <th>Name</th>
                           <th>Repository</th>
                           <th>Last run</th>
+                          <th>Diagnostics</th>
                         </tr>
                       </thead>
                       <tbody>
                         {workspaceWorkflows.map((workflow) => {
-                          const repositoryName = getRepositoryName(workflow.repository);
+                          const repositoryName = getRepositoryName(
+                            workflow.repository,
+                          );
                           return (
                             <tr key={`${workflow.repository}:${workflow.id}`}>
                               <td>
@@ -131,6 +210,11 @@ export const TasksPage: React.FC = () => {
                               </td>
                               <td>{repositoryName}</td>
                               <td>{formatWorkflowLastRun(workflow)}</td>
+                              <td>
+                                {renderWorkflowDiagnosticsSummary(
+                                  workflow.diagnostics,
+                                )}
+                              </td>
                             </tr>
                           );
                         })}
@@ -164,8 +248,7 @@ export const TasksPage: React.FC = () => {
                                     {String(task.frontmatter.schedule)}
                                   </span>
                                 )}
-                              {typeof task.frontmatter?.type ===
-                                "string" && (
+                              {typeof task.frontmatter?.type === "string" && (
                                 <span className="badge">
                                   {String(task.frontmatter.type)}
                                 </span>
@@ -192,8 +275,7 @@ export const TasksPage: React.FC = () => {
                                     {String(task.frontmatter.schedule)}
                                   </span>
                                 )}
-                              {typeof task.frontmatter?.type ===
-                                "string" && (
+                              {typeof task.frontmatter?.type === "string" && (
                                 <span className="badge">
                                   {String(task.frontmatter.type)}
                                 </span>

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -352,12 +352,10 @@
   gap: 1rem;
 }
 
-
 .workflow-builder__actions {
   display: flex;
   gap: 0.5rem;
 }
-
 
 .workflow-icon-button {
   width: 30px;
@@ -456,4 +454,17 @@
   border-radius: 6px;
   background: transparent;
   padding: 0.3rem 0.45rem;
+}
+
+.workflow-diagnostics {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.workflow-diagnostics__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
 }


### PR DESCRIPTION
### Motivation
- Surface the new per-job runtime diagnostics (start/finish times, duration, exit code, error text, running state) on the Tasks workflows list so operators can quickly inspect recent job health.  
- Keep the table readable by default by presenting a compact summary and expandable details rather than adding many separate columns.

### Description
- Extended the frontend workflow summary type to include diagnostics fields in `packages/frontend/src/hooks/useApi.ts` (`diagnostics` with `lastStartedAt`, `lastFinishedAt`, `lastDurationMs`, `lastExitCode`, `lastError`, `running`).
- Added compact diagnostics rendering to the Tasks page in `packages/frontend/src/pages/TasksPage.tsx` including formatter helpers (`formatDateTime`, `formatDuration`, `formatExitCode`, `formatErrorText`), a single `Diagnostics` table column with always-visible summary badges and an expandable `<details>` for timestamps and error text.  
- Updated unit tests in `packages/frontend/src/pages/TasksPage.test.tsx` to verify diagnostics rendering and fallback behavior when diagnostics are absent.  
- Added minimal styles for the diagnostics summary to `packages/frontend/src/styles/page.css`.

### Testing
- Ran the frontend unit tests for the Tasks page with `npm --workspace packages/frontend run test -- src/pages/TasksPage.test.tsx`, and all tests passed (`5 passed`).
- Ran linting via `npm --workspace packages/frontend run lint` for the modified files and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ffef62d48332bfc56ed94967c39d)