### PR TITLE
Skip workflow cron discovery for git worktree directories

### DIFF
--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -104,3 +104,41 @@ def test_list_workspace_workflows_collects_repository_workflows(
             }
         ]
     }
+
+
+@patch("workflow_service.read_workflows")
+@patch("workflow_service.get_workspace_home")
+def test_list_workspace_workflows_skips_git_worktrees(
+    mock_workspace_home, mock_read_workflows
+):
+    mock_workspace_home.return_value = Path("/workspace/home")
+
+    repo = Path("/workspace/home/repo-a")
+    worktree = Path("/workspace/home/repo-a-feature")
+
+    with patch.object(Path, "iterdir", return_value=[repo, worktree]), patch.object(
+        Path, "is_dir", return_value=True
+    ), patch.object(Path, "is_file", side_effect=[False, True]):
+        mock_read_workflows.return_value = {
+            "workflows": [
+                {"id": "wf_a", "name": "A", "enabled": True, "schedule": "* * * * *"}
+            ]
+        }
+
+        result = list_workspace_workflows()
+
+    assert result == {
+        "workflows": [
+            {
+                "repository": "repo-a",
+                "id": "wf_a",
+                "name": "A",
+                "enabled": True,
+                "schedule": "* * * * *",
+                "shellScriptPath": None,
+                "lastRun": None,
+                "diagnostics": None,
+            }
+        ]
+    }
+    mock_read_workflows.assert_called_once_with("repo-a")

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -124,6 +124,8 @@ def list_workspace_workflows(
     for repo_path in workspace_home.iterdir():
         if not repo_path.is_dir():
             continue
+        if (repo_path / ".git").is_file():
+            continue
 
         repo_name = repo_path.name
         repository_workflows = read_workflows(repo_name).get("workflows", [])


### PR DESCRIPTION
### Motivation
- Avoid collecting workflow YAMLs from git worktree checkouts so cron/workflow discovery does not register workflows from worktree child directories.

### Description
- Update `list_workspace_workflows` to skip workspace entries where `(.git)` is a file, which indicates a git worktree checkout.
- Add a unit test `test_list_workspace_workflows_skips_git_worktrees` to verify worktree directories are excluded from workspace workflow aggregation.

### Testing
- Running `python -m pytest packages/pybackend/tests/unit/test_workflow_service.py` in the plain environment initially failed due to a missing `yaml` dependency. 
- Installed backend dependencies with `cd packages/pybackend && uv sync` and ran `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_workflow_service.py`. 
- Final test run succeeded with all tests passing: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50a14d1e083328decccd977937c8a)