### PR TITLE
Leave Bash agent column empty in workflow builder

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -315,7 +315,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                               )}
                             </select>
                           ) : (
-                            <span className="workflow-step-target__label">Bash</span>
+                            <span className="workflow-step-target__label" />
                           )}
                         </div>
                         <button


### PR DESCRIPTION
### Motivation
- Ensure the workflow/harness builder UI leaves the second column empty for `bash` step rows instead of repeating a `Bash` label, matching the requested UX.

### Description
- Update `packages/frontend/src/components/WorkflowBuilderPanel.tsx` to render an empty `<span className="workflow-step-target__label" />` for steps with `type === "bash"` so the agent/target column is visually blank for Bash steps.

### Testing
- `npm --prefix packages/frontend test -- --runInBand` failed because `vitest` does not accept the `--runInBand` flag.
- `npm --prefix packages/frontend test` succeeded and reported all tests passing (9 test files, 31 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5597fd250833299827b81bd29efe7)