### PR TITLE
Clarify workflow harness prompt to execute bash steps as shell commands

### DIFF
--- a/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
+++ b/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
@@ -160,9 +160,13 @@ The generator MUST follow these rules.
 The script MUST NOT contain:
 
     eval
-    bash -c
     sh -c
     command strings executed via variables
+
+Exception:
+
+• `bash -lc` is allowed **only** for workflow steps with `type: bash`, and
+  only when executing the exact `run` value from the workflow YAML.
 
 ### Required Pattern
 
@@ -177,11 +181,49 @@ This prevents quoting bugs and injection risks.
 
 ------------------------------------------------------------------------
 
+# Step Type Mapping (MUST be exact)
+
+Each workflow step type maps to a different execution path:
+
+### `type: bash`
+
+Treat `run` as a shell command to execute directly in Bash,
+**not as an agent prompt**.
+
+Required structure for bash steps:
+
+``` bash
+STEP1_DESCRIPTION='git switch main && git pull --rebase --autostash'
+STEP1_RUN='git switch main && git pull --rebase --autostash'
+cmd=(bash -lc "$STEP1_RUN")
+run_step "$STEP1_DESCRIPTION" "${cmd[@]}"
+```
+
+Do NOT call `{{CURRENT_AGENT_CLI}}` for bash steps.
+
+### `type: agent`
+
+Treat `prompt` as the message to the configured agent CLI.
+
+Required structure for agent steps:
+
+``` bash
+STEP2_DESCRIPTION='Follow issue instructions'
+STEP2_PROMPT='Follow issue instructions'
+cmd=(opencode run --format json --agent build)
+RUN_STEP_PROMPT="$STEP2_PROMPT"
+run_step "$STEP2_DESCRIPTION" "${cmd[@]}"
+```
+
+------------------------------------------------------------------------
+
 # Prompt / Message Handling
 
 Some agent CLIs accept messages through **stdin**.
 
 The script MUST send prompts safely.
+
+This section applies to `type: agent` steps only.
 
 Forbidden:
 

--- a/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
@@ -30,6 +30,9 @@ describe("buildWorkflowHarnessPrompt", () => {
     expect(prompt).toContain("The script MUST be written exactly to:");
     expect(prompt).toContain("    .harness/release-workflow.sh");
     expect(prompt).toContain("The script supports **exactly one optional argument**:");
+    expect(prompt).toContain("Treat `run` as a shell command to execute directly in Bash,");
+    expect(prompt).toContain("Do NOT call `codex` for bash steps.");
+    expect(prompt).toContain("This section applies to `type: agent` steps only.");
     expect(prompt).toContain("• No arguments → execute workflow normally");
     expect(prompt).toContain(".harness/release-workflow.sh --dry-run");
   });


### PR DESCRIPTION
### Motivation
- Fix incorrect generation semantics where workflow steps with `type: bash` were being treated as agent prompts and invoked via the agent CLI instead of executed as shell commands.
- Ensure deterministic, safe harness scripts by explicitly mapping step types so the generator does not conflate shell commands and agent prompts.

### Description
- Updated `packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md` to add a `bash -lc` exception limited to `type: bash` steps and to introduce a Step Type Mapping that defines exact handling for `type: bash` and `type: agent` steps.
- Scoped prompt/stdin handling guidance so `printf '%s' "$PROMPT"` semantics apply only to `type: agent` steps and documented that `type: bash` must not call the configured agent CLI.
- Added assertions to `packages/frontend/src/utils/workflowHarnessPrompt.test.ts` to validate the new guidance appears in generated prompts.

### Testing
- Ran the targeted frontend unit tests with `npm --prefix packages/frontend test -- src/utils/workflowHarnessPrompt.test.ts`, and the test suite passed (`3 tests` passed).
- Verified the changed template and tests were syntactically valid via the project test run and local file checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55adf43f4833292824a06e38ddcfb)