### PR TITLE
Improve workflow diagnostics readability on Tasks page

### DIFF
--- a/packages/frontend/src/pages/TasksPage.test.tsx
+++ b/packages/frontend/src/pages/TasksPage.test.tsx
@@ -158,8 +158,10 @@ describe("TasksPage", () => {
     );
 
     expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText(/Error: captured stderr/)).toBeInTheDocument();
-    expect(screen.getByText(/Stdout: line-11/)).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("captured stderr")).toBeInTheDocument();
+    expect(screen.getByText("Stdout")).toBeInTheDocument();
+    expect(screen.getByText(/line-11/)).toBeInTheDocument();
   });
 
   it("shows fallback diagnostics label when no diagnostics exist", async () => {

--- a/packages/frontend/src/pages/TasksPage.tsx
+++ b/packages/frontend/src/pages/TasksPage.tsx
@@ -50,11 +50,7 @@ const formatErrorText = (value?: string | null) => {
   if (!value || !value.trim()) {
     return "-";
   }
-  const normalized = value.trim();
-  if (normalized.length <= 80) {
-    return normalized;
-  }
-  return `${normalized.slice(0, 77)}...`;
+  return value.trim();
 };
 
 const formatWorkflowLastRun = (workflow: WorkspaceWorkflowSummary) => {
@@ -93,12 +89,14 @@ const renderWorkflowDiagnosticsSummary = (diagnostics: WorkflowDiagnostics) => {
         <span>Started: {formatDateTime(diagnostics.lastStartedAt)}</span>
         <span>Finished: {formatDateTime(diagnostics.lastFinishedAt)}</span>
       </div>
-      <div className="meta-secondary">
-        Error: {formatErrorText(diagnostics.lastStderr ?? diagnostics.lastError)}
-      </div>
-      <div className="meta-secondary">
-        Stdout: {formatErrorText(diagnostics.lastStdout)}
-      </div>
+      <div className="meta-secondary">Error</div>
+      <pre className="workflow-diagnostics__output">
+        {formatErrorText(diagnostics.lastStderr ?? diagnostics.lastError)}
+      </pre>
+      <div className="meta-secondary">Stdout</div>
+      <pre className="workflow-diagnostics__output">
+        {formatErrorText(diagnostics.lastStdout)}
+      </pre>
     </details>
   );
 };

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -483,3 +483,17 @@
   gap: 0.35rem;
   cursor: pointer;
 }
+
+.workflow-diagnostics__output {
+  margin: 0;
+  max-height: 12rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--panel-border);
+  background: var(--surface-strong);
+  color: var(--text);
+  font-size: 0.82rem;
+}


### PR DESCRIPTION
### Motivation
- Workflow diagnostics shown on the Tasks page were aggressively truncated and presented inline, making failures like `Exit 1` hard to investigate.
- The goal is to make captured stderr/stdout tails directly visible and preserve multiline output so users can analyze errors without leaving the overview.

### Description
- Stop truncating diagnostics text by simplifying `formatErrorText` to return the full trimmed string instead of slicing it.  
- Render `Error` and `Stdout` sections as `<pre>` blocks inside the diagnostics details so multiline logs and traces are preserved.  
- Add `.workflow-diagnostics__output` CSS to make diagnostics blocks scrollable, wrapped, and visually distinct.  
- Update the Tasks page unit test (`TasksPage.test.tsx`) to assert the new `Error`/`Stdout` presentation and sample content.

### Testing
- Ran the frontend unit test file with `npm --workspace packages/frontend run test -- src/pages/TasksPage.test.tsx`, and all tests passed (`1 file, 6 tests`).
- No backend tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2bbe1e9f483329e0a28a9e34960ec)