### PR TITLE
Use slug-safe workflow names for log filenames and update harness template

### DIFF
--- a/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
+++ b/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
@@ -106,8 +106,8 @@ Example format:
 
 Log destination preference:
 
-1.  `/var/log/made-<workflow-name>-<timestamp>-<PID>.log`
-2.  `/tmp/made-harness-logs/made-<workflow-name>-<timestamp>-<PID>.log`
+1.  `/var/log/made-[workflow-name]-[timestamp]-[PID].log`
+2.  `/tmp/made-harness-logs/made-[workflow-name]-[timestamp]-[PID].log`
 
 Required filename format:
 
@@ -443,6 +443,12 @@ Adapt {{AGENT_PARAMETER_FORMAT}} when provided and supported by CLI.
 set -euo pipefail
 
 SCRIPT_NAME="{{WORKFLOW_FILE_NAME}}"
+WORKFLOW_NAME="${SCRIPT_NAME%.sh}"
+WORKFLOW_SLUG=$(printf '%s' "$WORKFLOW_NAME" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+LOG_TIMESTAMP="$(date -u +'%Y%m%dT%H%M%SZ')"
+LOG_BASENAME="made-${WORKFLOW_SLUG}-${LOG_TIMESTAMP}-$$.log"
 
 # Argument handling
 DRY_RUN=false
@@ -455,11 +461,11 @@ fi
 
 # Try /var/log first, fallback to /tmp/made-harness-logs
 if [[ -w "/var/log" ]]; then
-  LOG_FILE="/var/log/${SCRIPT_NAME%.sh}.log"
+  LOG_FILE="/var/log/${LOG_BASENAME}"
 else
   LOG_DIR="/tmp/made-harness-logs"
   mkdir -p "$LOG_DIR"
-  LOG_FILE="$LOG_DIR/${SCRIPT_NAME%.sh}.log"
+  LOG_FILE="$LOG_DIR/${LOG_BASENAME}"
 fi
 
 log() {


### PR DESCRIPTION
### Motivation

- Ensure log filenames are slug-safe, deterministic, and include UTC timestamp and PID to avoid collisions and permission issues.
- Make the prompt/template documentation consistent about the required filename format using bracketed placeholders.

### Description

- Add `WORKFLOW_NAME`, `WORKFLOW_SLUG`, `LOG_TIMESTAMP`, and `LOG_BASENAME` variables to the Bash harness template to build a `made-[workflow-name]-[timestamp]-[PID].log` filename safely using `tr` and `sed` for slugification and `date -u` for UTC timestamps.
- Use `LOG_BASENAME` when selecting the log file path for `/var/log` or the fallback `/tmp/made-harness-logs`, and ensure the fallback directory is created with `mkdir -p`.
- Update the template documentation examples to use bracketed placeholder notation (e.g. `/var/log/made-[workflow-name]-[timestamp]-[PID].log`).
- Preserve existing logging behavior of emitting ISO-8601 UTC timestamps, writing to `stderr`, and appending to the log file when writable.

### Testing

- Ran the repository linters and the frontend test suite against the modified templates and harness script; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42b8f6cd083328d652ed4d3c759e9)