### PR TITLE
Expose per-file Git details and diff view with file commenting to agent

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -215,6 +215,22 @@ export type RepositoryGitStatus = {
   diff: GitDiffEntry[];
 };
 
+export type RepositoryFileGitDetails = {
+  path: string;
+  tracked: boolean;
+  ignored: boolean;
+  lineStats: { green: number; red: number };
+  lastCommit: {
+    id: string | null;
+    message: string | null;
+    date: string | null;
+    link: string | null;
+  };
+  lastModified: string;
+  lineCount: number;
+  diffBlocks: { before: string; after: string }[];
+};
+
 export type HarnessDefinition = {
   id: string;
   name: string;
@@ -450,6 +466,10 @@ export const api = {
 
   getRepositoryGitStatus: (name: string) =>
     request<RepositoryGitStatus>(`/repositories/${name}/git`),
+  getRepositoryFileGitDetails: (name: string, filePath: string) =>
+    request<RepositoryFileGitDetails>(
+      `/repositories/${name}/git/file?path=${encodeURIComponent(filePath)}`,
+    ),
   pullRepository: (name: string) =>
     request<{ output: string }>(`/repositories/${name}/git/pull`, {
       method: "POST",
@@ -505,15 +525,19 @@ export const api = {
     request<{ workflows: WorkflowDefinition[] }>("/workflows"),
   getWorkspaceWorkflows: () =>
     request<{ workflows: WorkspaceWorkflowSummary[] }>("/workspace/workflows"),
-  getWorkflowLogs: () => request<{ logs: WorkflowLogSummary[] }>("/workflow-logs"),
+  getWorkflowLogs: () =>
+    request<{ logs: WorkflowLogSummary[] }>("/workflow-logs"),
   getWorkflowLogTail: (location: string, logName: string) =>
     request<WorkflowLogTail>(
       `/workflow-logs/${encodeURIComponent(location)}/${encodeURIComponent(logName)}`,
     ),
   terminateWorkflow: (workflowId: string) =>
-    request<{ success: boolean; message?: string }>(`/workflows/${encodeURIComponent(workflowId)}/terminate`, {
-      method: "POST",
-    }),
+    request<{ success: boolean; message?: string }>(
+      `/workflows/${encodeURIComponent(workflowId)}/terminate`,
+      {
+        method: "POST",
+      },
+    ),
   saveWorkflows: (workflows: WorkflowDefinition[]) =>
     request<{ workflows: WorkflowDefinition[] }>("/workflows", {
       method: "PUT",

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -16,7 +16,10 @@ import { ChatWindow } from "../components/ChatWindow";
 import { MentionPathTextarea } from "../components/MentionPathTextarea";
 import { WorkflowBuilderPanel } from "../components/WorkflowBuilderPanel";
 import { SessionPickerModal } from "../components/SessionPickerModal";
-import { AgentSelector, DEFAULT_AGENT_VALUE } from "../components/AgentSelector";
+import {
+  AgentSelector,
+  DEFAULT_AGENT_VALUE,
+} from "../components/AgentSelector";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { useAgentCli } from "../hooks/useAgentCli";
@@ -26,6 +29,7 @@ import {
   ChatSession,
   FileNode,
   HarnessDefinition,
+  RepositoryFileGitDetails,
   RepositorySummary,
   RepositoryGitStatus,
 } from "../hooks/useApi";
@@ -65,6 +69,12 @@ const CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
 const INLINE_CODE_PATTERN = /`[^`]*`/g;
 const normalizeMentionQuery = (value: string) =>
   value.replace(/^\.\//, "").replace(/\\/g, "/").trim();
+
+const toRelativeFilePath = (value: string) =>
+  value.replace(/\\/g, "/").replace(/^\.?\//, "");
+
+const buildFileCommentPrompt = (relativeFilePath: string, userComment: string) =>
+  `Regarding \`${relativeFilePath}\`: ${userComment}`;
 
 const splitMentionSearch = (query: string) => {
   const normalized = normalizeMentionQuery(query);
@@ -153,15 +163,15 @@ const MODEL_OPTIONS = [
   },
   {
     value: "github-copilot/gpt-5.2",
-    label: "github-copilot/gpt-5.2"
+    label: "github-copilot/gpt-5.2",
   },
   {
     value: "github-copilot/gpt-5.3",
-    label: "github-copilot/gpt-5.3"
+    label: "github-copilot/gpt-5.3",
   },
   {
     value: "github-copilot/gpt-5.4",
-    label: "github-copilot/gpt-5.4"
+    label: "github-copilot/gpt-5.4",
   },
   {
     value: "github-copilot/gpt-5.2-codex",
@@ -193,7 +203,7 @@ const MODEL_OPTIONS = [
   {
     value: "openai/gpt-5.4-codex",
     label: "openai/gpt-5.4-codex",
-  }
+  },
 ];
 
 type HarnessRun = {
@@ -245,6 +255,13 @@ const formatArgumentHint = (argumentHint?: ArgumentHint) => {
 const formatHarnessTimestamp = (value: string) => {
   const parsed = Date.parse(value);
   if (!Number.isFinite(parsed)) return "Unknown time";
+  return new Date(parsed).toLocaleString();
+};
+
+const formatDateTime = (value: string | null) => {
+  if (!value) return "Unknown";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
   return new Date(parsed).toLocaleString();
 };
 
@@ -424,7 +441,9 @@ export const RepositoryPage: React.FC = () => {
     ];
   }, [availableCommands, fileTree, repository?.path]);
   const [mentionQuery, setMentionQuery] = useState("");
-  const [recursiveMentionResults, setRecursiveMentionResults] = useState<string[]>([]);
+  const [recursiveMentionResults, setRecursiveMentionResults] = useState<
+    string[]
+  >([]);
   const [commandsError, setCommandsError] = useState<string | null>(null);
   const [commandsLoading, setCommandsLoading] = useState(false);
   const [availableHarnesses, setAvailableHarnesses] = useState<
@@ -488,9 +507,8 @@ export const RepositoryPage: React.FC = () => {
     placeholders: [],
     values: [],
   });
-  const [commandPreview, setCommandPreview] = useState<CommandDefinition | null>(
-    null,
-  );
+  const [commandPreview, setCommandPreview] =
+    useState<CommandDefinition | null>(null);
   const [harnessModal, setHarnessModal] = useState<{
     open: boolean;
     harness: HarnessDefinition | null;
@@ -548,6 +566,17 @@ export const RepositoryPage: React.FC = () => {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [editorContent, setEditorContent] = useState("");
   const [editorStatus, setEditorStatus] = useState<string | null>(null);
+  const [fileGitDetails, setFileGitDetails] =
+    useState<RepositoryFileGitDetails | null>(null);
+  const [fileGitDetailsLoading, setFileGitDetailsLoading] = useState(false);
+  const [fileGitDetailsError, setFileGitDetailsError] = useState<string | null>(
+    null,
+  );
+  const [fileCommentModal, setFileCommentModal] = useState<{
+    open: boolean;
+    source: "preview" | "diff" | null;
+  }>({ open: false, source: null });
+  const [fileCommentText, setFileCommentText] = useState("");
   const [createModal, setCreateModal] = useState(false);
   const [uploadModal, setUploadModal] = useState(false);
   const [renameModal, setRenameModal] = useState<{
@@ -727,6 +756,29 @@ export const RepositoryPage: React.FC = () => {
       .finally(() => setGitStatusLoading(false));
   }, [name, repository?.hasGit]);
 
+  const loadFileGitDetails = useCallback(
+    async (filePath: string) => {
+      if (!name || !repository?.hasGit) return;
+      setFileGitDetailsLoading(true);
+      try {
+        const response = await api.getRepositoryFileGitDetails(name, filePath);
+        setFileGitDetails(response);
+        setFileGitDetailsError(null);
+      } catch (error) {
+        console.error("Failed to load file git details", error);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load file git details";
+        setFileGitDetailsError(message);
+        setFileGitDetails(null);
+      } finally {
+        setFileGitDetailsLoading(false);
+      }
+    },
+    [name, repository?.hasGit],
+  );
+
   const refreshHarnessStatuses = useCallback(async () => {
     if (!harnessHistory.length) return;
     const updates = await Promise.all(
@@ -818,7 +870,10 @@ export const RepositoryPage: React.FC = () => {
     }
   }, [name]);
 
-  const findNodeByPath = (node: FileNode, targetPath: string): FileNode | null => {
+  const findNodeByPath = (
+    node: FileNode,
+    targetPath: string,
+  ): FileNode | null => {
     if (node.path === targetPath) {
       return node;
     }
@@ -890,6 +945,12 @@ export const RepositoryPage: React.FC = () => {
       setSelectedFile(filePath);
       setEditorContent(response.content);
       setEditorStatus(null);
+      if (repository?.hasGit) {
+        void loadFileGitDetails(filePath);
+      } else {
+        setFileGitDetails(null);
+        setFileGitDetailsError(null);
+      }
       setActiveTab("editor");
     } catch (error) {
       console.error("Failed to open file", error);
@@ -931,7 +992,10 @@ export const RepositoryPage: React.FC = () => {
     }
   };
 
-  const handleCreateWorktree = async (directoryName: string, branchName: string) => {
+  const handleCreateWorktree = async (
+    directoryName: string,
+    branchName: string,
+  ) => {
     if (!name) return;
     setCreatingWorktree(true);
     try {
@@ -1065,15 +1129,15 @@ export const RepositoryPage: React.FC = () => {
         model,
         agent,
       );
-      
+
       // No immediate message processing - polling handles everything
       if (reply.sessionId) {
         setSessionId(reply.sessionId);
       }
-      
+
       setChatError(null);
       setActiveTab("agent");
-      
+
       // Keep chatLoading=true if processing (triggers existing polling)
       if (!reply.processing) setChatLoading(false);
     } catch (error) {
@@ -1135,7 +1199,9 @@ export const RepositoryPage: React.FC = () => {
     } catch (error) {
       console.error("Failed to load session history", error);
       const message =
-        error instanceof Error ? error.message : "Failed to load session history";
+        error instanceof Error
+          ? error.message
+          : "Failed to load session history";
       setChatError(message);
     } finally {
       setChatLoading(false);
@@ -1290,10 +1356,35 @@ export const RepositoryPage: React.FC = () => {
       await api.saveRepositoryFile(name, selectedFile, editorContent);
       setEditorStatus("Saved successfully");
       refreshFiles();
+      if (repository?.hasGit) {
+        void loadGitStatus();
+        void loadFileGitDetails(selectedFile);
+      }
     } catch (error) {
       setEditorStatus("Failed to save file");
       console.error("Failed to save file", error);
     }
+  };
+
+  const openFileCommentModal = (source: "preview" | "diff") => {
+    setFileCommentModal({ open: true, source });
+    setFileCommentText("");
+  };
+
+  const closeFileCommentModal = () => {
+    setFileCommentModal({ open: false, source: null });
+    setFileCommentText("");
+  };
+
+  const submitFileComment = () => {
+    if (!selectedFile || !fileCommentText.trim()) return;
+    const prompt = buildFileCommentPrompt(
+      toRelativeFilePath(selectedFile),
+      fileCommentText.trim(),
+    );
+    handleSendMessage(prompt);
+    setActiveTab("agent");
+    closeFileCommentModal();
   };
 
   const handleCreateFile = async () => {
@@ -1404,6 +1495,8 @@ export const RepositoryPage: React.FC = () => {
       if (selectedFile === deleteModal.target) {
         setSelectedFile(null);
         setEditorContent("");
+        setFileGitDetails(null);
+        setFileGitDetailsError(null);
       }
       setDeleteModal({ open: false, target: null });
       refreshFiles();
@@ -1427,9 +1520,7 @@ export const RepositoryPage: React.FC = () => {
 
   const renderNode = (node: FileNode, depth = 0): React.ReactNode => {
     if (node.path === ".") {
-      return sortNodes(node.children).map((child) =>
-        renderNode(child, depth),
-      );
+      return sortNodes(node.children).map((child) => renderNode(child, depth));
     }
     const indent = { marginLeft: depth * 16 };
     const isFolder = node.type === "folder";
@@ -1826,7 +1917,7 @@ export const RepositoryPage: React.FC = () => {
     {
       id: "files",
       label: "File Browser",
-          content: (
+      content: (
         <>
           <div className="button-bar">
             <button className="primary" onClick={() => setCreateModal(true)}>
@@ -1859,6 +1950,118 @@ export const RepositoryPage: React.FC = () => {
       label: "File Editor",
       content: (
         <div className="editor-grid">
+          {repository?.hasGit && selectedFile && (
+            <>
+              <Panel title="Git File Info">
+                {fileGitDetailsLoading && (
+                  <div className="alert">Loading git file details...</div>
+                )}
+                {fileGitDetailsError && (
+                  <div className="alert error">{fileGitDetailsError}</div>
+                )}
+                {!fileGitDetailsLoading &&
+                  !fileGitDetailsError &&
+                  fileGitDetails && (
+                    <table className="git-table">
+                      <tbody>
+                        <tr>
+                          <th>Tracking</th>
+                          <td>
+                            {fileGitDetails.tracked ? "Tracked" : "Untracked"}
+                          </td>
+                        </tr>
+                        <tr>
+                          <th>Ignored</th>
+                          <td>{fileGitDetails.ignored ? "Yes" : "No"}</td>
+                        </tr>
+                        <tr>
+                          <th>Line diff stats</th>
+                          <td>
+                            <span className="git-stat-pair">
+                              <span className="git-added">
+                                +{fileGitDetails.lineStats.green}
+                              </span>
+                              <span className="git-removed">
+                                -{fileGitDetails.lineStats.red}
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th>Last commit</th>
+                          <td>
+                            {fileGitDetails.lastCommit.id ? (
+                              <>
+                                {fileGitDetails.lastCommit.link ? (
+                                  <a
+                                    href={fileGitDetails.lastCommit.link}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    {fileGitDetails.lastCommit.id.slice(0, 8)}
+                                  </a>
+                                ) : (
+                                  fileGitDetails.lastCommit.id.slice(0, 8)
+                                )}{" "}
+                                —{" "}
+                                {fileGitDetails.lastCommit.message ||
+                                  "No message"}
+                              </>
+                            ) : (
+                              "No commit yet"
+                            )}
+                          </td>
+                        </tr>
+                        <tr>
+                          <th>Last modified</th>
+                          <td>{formatDateTime(fileGitDetails.lastModified)}</td>
+                        </tr>
+                        <tr>
+                          <th>Line count</th>
+                          <td>{fileGitDetails.lineCount}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  )}
+              </Panel>
+              {fileGitDetails && fileGitDetails.diffBlocks.length > 0 && (
+                <Panel
+                  title="Diff View"
+                  actions={
+                    <button
+                      type="button"
+                      className="secondary"
+                      onClick={() => openFileCommentModal("diff")}
+                    >
+                      Comment
+                    </button>
+                  }
+                >
+                  <div className="editor-diff-grid">
+                    {fileGitDetails.diffBlocks.map((block, index) => (
+                      <div
+                        className="editor-diff-row"
+                        key={`${selectedFile}-${index}`}
+                      >
+                        <div className="editor-diff-column">
+                          <h4>Before</h4>
+                          <pre className="preview">
+                            {block.before || "(empty)"}
+                          </pre>
+                        </div>
+                        <div className="editor-diff-column">
+                          <h4>After</h4>
+                          <pre className="preview">
+                            {block.after || "(empty)"}
+                          </pre>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </Panel>
+              )}
+            </>
+          )}
           <Panel
             title={
               selectedFile ? `Editing ${selectedFile}` : "Select a file to edit"
@@ -1897,7 +2100,20 @@ export const RepositoryPage: React.FC = () => {
               className="editor-input"
             />
           </Panel>
-          <Panel title="Preview">
+          <Panel
+            title="Preview"
+            actions={
+              selectedFile && (
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => openFileCommentModal("preview")}
+                >
+                  Comment
+                </button>
+              )
+            }
+          >
             {selectedFile?.endsWith(".md") ? (
               <div
                 className="markdown"
@@ -1948,7 +2164,10 @@ export const RepositoryPage: React.FC = () => {
                       const argumentPlan = getCommandArgumentPlan(command);
                       const usesArguments = argumentPlan.labels.length > 0;
                       return (
-                        <div className="command-button-wrapper" key={command.id}>
+                        <div
+                          className="command-button-wrapper"
+                          key={command.id}
+                        >
                           <button
                             className="primary command-button command-button--previewable"
                             title={`${command.source} • ${command.name}`}
@@ -2127,7 +2346,10 @@ export const RepositoryPage: React.FC = () => {
           <button className="secondary" onClick={closeHarnessModal}>
             Cancel
           </button>
-          <button className="primary" onClick={() => handleHarnessRun({ dryRun: true })}>
+          <button
+            className="primary"
+            onClick={() => handleHarnessRun({ dryRun: true })}
+          >
             Dry Run
           </button>
           <button className="danger" onClick={() => handleHarnessRun()}>
@@ -2160,11 +2382,7 @@ export const RepositoryPage: React.FC = () => {
         </div>
       </Modal>
 
-      <Modal
-        open={uploadModal}
-        title="Upload File"
-        onClose={closeUploadModal}
-      >
+      <Modal open={uploadModal} title="Upload File" onClose={closeUploadModal}>
         {uploadError && <div className="alert error">{uploadError}</div>}
         <div className="form-group">
           <label htmlFor="upload-file">Select file</label>
@@ -2276,6 +2494,35 @@ export const RepositoryPage: React.FC = () => {
           </button>
           <button className="danger" onClick={handleDeleteFile}>
             Delete
+          </button>
+        </div>
+      </Modal>
+
+      <Modal
+        open={fileCommentModal.open}
+        title={`Comment on ${fileCommentModal.source === "diff" ? "Diff View" : "Preview"}`}
+        onClose={closeFileCommentModal}
+      >
+        <div className="form-group">
+          <label htmlFor="file-comment">Comment</label>
+          <textarea
+            id="file-comment"
+            rows={4}
+            value={fileCommentText}
+            onChange={(event) => setFileCommentText(event.target.value)}
+            placeholder="What should the agent do about this file?"
+          />
+        </div>
+        <div className="modal-actions">
+          <button className="secondary" onClick={closeFileCommentModal}>
+            Cancel
+          </button>
+          <button
+            className="primary"
+            onClick={submitFileComment}
+            disabled={!selectedFile || !fileCommentText.trim()}
+          >
+            Send to chat
           </button>
         </div>
       </Modal>

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -142,7 +142,9 @@ textarea {
   color: var(--muted);
   cursor: pointer;
   opacity: 0.6;
-  transition: color 0.2s ease, opacity 0.2s ease;
+  transition:
+    color 0.2s ease,
+    opacity 0.2s ease;
   background: transparent;
   background-color: transparent !important;
   border: none;
@@ -492,7 +494,9 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  transition: border-color 0.2s ease, transform 0.2s ease,
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease,
     background-color 0.2s ease;
   will-change: transform;
 }
@@ -606,7 +610,6 @@ textarea {
   }
 }
 
-
 .git-table {
   width: 100%;
   border-collapse: collapse;
@@ -628,7 +631,6 @@ textarea {
   border-bottom: 1px solid var(--border-color);
 }
 
-
 .git-added {
   color: var(--success);
   font-weight: 600;
@@ -645,9 +647,36 @@ textarea {
   white-space: nowrap;
 }
 
-
 .git-stat-pair {
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
+}
+
+.editor-diff-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.editor-diff-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.editor-diff-column {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.editor-diff-column h4 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .editor-diff-row {
+    grid-template-columns: 1fr;
+  }
 }

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -69,6 +69,7 @@ from repository_service import (
     delete_repository_file,
     create_repository_worktree,
     remove_repository_worktree,
+    get_repository_file_git_details,
     get_repository_info,
     get_repository_git_status,
     list_repositories,
@@ -534,6 +535,21 @@ def repository_git_status(name: str):
     try:
         logger.info("Retrieving git status for repository '%s'", name)
         return get_repository_git_status(name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@app.get("/api/repositories/{name}/git/file")
+def repository_git_file_details(name: str, path: str = Query(...)):
+    try:
+        logger.info(
+            "Retrieving git file details for repository '%s' and file '%s'",
+            name,
+            path,
+        )
+        return get_repository_file_git_details(name, path)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except ValueError as exc:

--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -445,6 +445,71 @@ def _untracked_files(repo_path: Path) -> list[str]:
     return [line for line in output.splitlines() if line]
 
 
+def _is_tracked_file(repo_path: Path, file_path: str) -> bool:
+    try:
+        _run_git(repo_path, ["ls-files", "--error-unmatch", "--", file_path])
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def _is_ignored_file(repo_path: Path, file_path: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", "--", file_path],
+            cwd=repo_path,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def _parse_diff_blocks(diff_text: str) -> list[dict[str, str]]:
+    blocks: list[dict[str, str]] = []
+    current_before: list[str] = []
+    current_after: list[str] = []
+    in_hunk = False
+
+    for line in diff_text.splitlines():
+        if line.startswith("@@"):
+            if in_hunk and (current_before or current_after):
+                blocks.append(
+                    {
+                        "before": "\n".join(current_before),
+                        "after": "\n".join(current_after),
+                    }
+                )
+            in_hunk = True
+            current_before = []
+            current_after = []
+            continue
+
+        if not in_hunk:
+            continue
+
+        if line.startswith("-"):
+            current_before.append(line[1:])
+        elif line.startswith("+"):
+            current_after.append(line[1:])
+        elif line.startswith(" "):
+            content = line[1:]
+            current_before.append(content)
+            current_after.append(content)
+
+    if in_hunk and (current_before or current_after):
+        blocks.append(
+            {
+                "before": "\n".join(current_before),
+                "after": "\n".join(current_after),
+            }
+        )
+
+    return blocks
+
+
 def get_repository_git_status(
     repo_name: str,
 ) -> Dict[str, Union[str, int, dict, list, None]]:
@@ -560,6 +625,94 @@ def get_repository_git_status(
         "counts": counts,
         "links": links,
         "diff": diff_files,
+    }
+
+
+def get_repository_file_git_details(
+    repo_name: str, file_path: str
+) -> Dict[str, Union[str, int, bool, dict, list, None]]:
+    workspace = get_workspace_home()
+    repo_path = workspace / repo_name
+    if not repo_path.exists() or not repo_path.is_dir():
+        raise FileNotFoundError("Repository not found")
+    if not (repo_path / ".git").exists():
+        raise ValueError("Repository is not a git repository")
+
+    target_file = repo_path / file_path
+    if not target_file.exists() or not target_file.is_file():
+        raise FileNotFoundError("File not found")
+
+    tracked = _is_tracked_file(repo_path, file_path)
+    ignored = _is_ignored_file(repo_path, file_path)
+
+    green = 0
+    red = 0
+    try:
+        numstat = _run_git(repo_path, ["diff", "--numstat", "HEAD", "--", file_path])
+        parsed = _line_stats_from_numstat(numstat)
+        green = parsed["green"]
+        red = parsed["red"]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    diff_blocks: list[dict[str, str]] = []
+    try:
+        diff_text = _run_git(repo_path, ["diff", "--unified=0", "HEAD", "--", file_path])
+        diff_blocks = _parse_diff_blocks(diff_text)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        diff_blocks = []
+
+    if not tracked:
+        file_content = target_file.read_text(encoding="utf-8", errors="ignore")
+        green = len(file_content.splitlines())
+        red = 0
+        if file_content:
+            diff_blocks = [{"before": "", "after": file_content}]
+
+    last_commit_id = None
+    last_commit_message = None
+    last_commit_date = None
+    try:
+        raw = _run_git(repo_path, ["log", "-1", "--format=%H\t%s\t%cI", "--", file_path])
+        if raw:
+            commit_id, commit_message, commit_date = raw.split("\t", 2)
+            last_commit_id = commit_id
+            last_commit_message = commit_message
+            try:
+                last_commit_date = (
+                    datetime.fromisoformat(commit_date.replace("Z", "+00:00"))
+                    .astimezone(timezone.utc)
+                    .isoformat()
+                )
+            except ValueError:
+                last_commit_date = commit_date
+    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+        pass
+
+    last_modified = datetime.fromtimestamp(
+        target_file.stat().st_mtime, tz=timezone.utc
+    ).isoformat()
+    line_count = len(target_file.read_text(encoding="utf-8", errors="ignore").splitlines())
+
+    commit_link = None
+    github_repo = _github_repo(repo_path)
+    if github_repo and last_commit_id:
+        commit_link = f"https://github.com/{github_repo}/commit/{last_commit_id}"
+
+    return {
+        "path": file_path,
+        "tracked": tracked,
+        "ignored": ignored,
+        "lineStats": {"green": green, "red": red},
+        "lastCommit": {
+            "id": last_commit_id,
+            "message": last_commit_message,
+            "date": last_commit_date,
+            "link": commit_link,
+        },
+        "lastModified": last_modified,
+        "lineCount": line_count,
+        "diffBlocks": diff_blocks,
     }
 
 

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -7,6 +7,7 @@ from repository_service import (
     apply_repository_template,
     clone_repository,
     create_repository_worktree,
+    get_repository_file_git_details,
     get_repository_git_status,
     get_repository_info,
     list_repository_templates,
@@ -185,6 +186,46 @@ def test_get_repository_git_status_includes_untracked_files(monkeypatch, tmp_pat
     result = get_repository_git_status("repo")
 
     assert any(entry["path"] == "new_file.txt" for entry in result["diff"])
+
+
+def test_get_repository_file_git_details_for_tracked_file(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_path = workspace / "repo"
+    _init_local_repo(repo_path)
+
+    readme = repo_path / "README.md"
+    readme.write_text("hello\nupdated\n", encoding="utf-8")
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    monkeypatch.setattr("repository_service._github_repo", lambda *_: "org/repo")
+
+    result = get_repository_file_git_details("repo", "README.md")
+
+    assert result["tracked"] is True
+    assert result["ignored"] is False
+    assert result["lineStats"]["green"] >= 1
+    assert result["lineCount"] == 2
+    assert result["lastCommit"]["link"] is not None
+    assert len(result["diffBlocks"]) >= 1
+
+
+def test_get_repository_file_git_details_for_untracked_file(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_path = workspace / "repo"
+    _init_local_repo(repo_path)
+    notes = repo_path / "NOTES.md"
+    notes.write_text("line one\nline two\n", encoding="utf-8")
+
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    monkeypatch.setattr("repository_service._github_repo", lambda *_: None)
+
+    result = get_repository_file_git_details("repo", "NOTES.md")
+
+    assert result["tracked"] is False
+    assert result["lineStats"] == {"green": 2, "red": 0}
+    assert result["diffBlocks"] == [{"before": "", "after": "line one\nline two\n"}]
 
 def test_pull_repository(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
### Motivation
- Provide detailed git metadata and diff blocks for individual files so the UI can show per-file history and changes.
- Allow users to send focused comments about a file preview or diff to the agent as a chat prompt.
- Add a backend API to surface file-level git information used by the frontend components.

### Description
- Added `RepositoryFileGitDetails` type and `api.getRepositoryFileGitDetails` in `useApi.ts` to request file-level git info.  
- Implemented UI changes in `RepositoryPage.tsx` to load and display file git info and diff blocks, a diff view, and a comment modal that sends a composed prompt to the agent (`openFileCommentModal`, `loadFileGitDetails`, `submitFileComment`).
- Added CSS rules for diff layout in `styles/index.css` (`.editor-diff-grid`, `.editor-diff-row`, `.editor-diff-column`).
- Backend additions include a new endpoint `GET /api/repositories/{name}/git/file` and `get_repository_file_git_details` in `repository_service.py` with helpers `_is_tracked_file`, `_is_ignored_file`, and `_parse_diff_blocks` to produce structured file details and diff blocks.
- Added unit tests in `packages/pybackend/tests/unit/test_repository_service.py` to validate tracked and untracked file behaviors for `get_repository_file_git_details`.

### Testing
- Ran backend unit tests in `packages/pybackend/tests/unit/test_repository_service.py`, including the new tests for tracked and untracked file details, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78dae6fa08332b887574f6fe767ff)