### PR TITLE
Adjust file editor layout and make Comment buttons blue

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1949,8 +1949,8 @@ export const RepositoryPage: React.FC = () => {
       id: "editor",
       label: "File Editor",
       content: (
-        <div className="editor-grid">
-          {repository?.hasGit && selectedFile && (
+        <div className="editor-layout">
+          {repository?.hasGit && selectedFile ? (
             <>
               <Panel title="Git File Info">
                 {fileGitDetailsLoading && (
@@ -2030,7 +2030,7 @@ export const RepositoryPage: React.FC = () => {
                   actions={
                     <button
                       type="button"
-                      className="secondary"
+                      className="secondary comment-action"
                       onClick={() => openFileCommentModal("diff")}
                     >
                       Comment
@@ -2061,70 +2061,72 @@ export const RepositoryPage: React.FC = () => {
                 </Panel>
               )}
             </>
-          )}
-          <Panel
-            title={
-              selectedFile ? `Editing ${selectedFile}` : "Select a file to edit"
-            }
-            actions={
-              selectedFile && (
-                <button
-                  className="primary"
-                  onClick={handleSaveFile}
-                  disabled={loadingFile}
+          ) : null}
+          <div className="editor-grid">
+            <Panel
+              title={
+                selectedFile ? `Editing ${selectedFile}` : "Select a file to edit"
+              }
+              actions={
+                selectedFile && (
+                  <button
+                    className="primary"
+                    onClick={handleSaveFile}
+                    disabled={loadingFile}
+                  >
+                    Save File
+                  </button>
+                )
+              }
+            >
+              {loadingFile && <div className="alert">Loading file...</div>}
+              {editorStatus && (
+                <div
+                  className={`alert ${
+                    editorStatus.includes("successfully")
+                      ? "success"
+                      : editorStatus.includes("Failed") ||
+                          editorStatus.includes("failed")
+                        ? "error"
+                        : ""
+                  }`}
                 >
-                  Save File
-                </button>
-              )
-            }
-          >
-            {loadingFile && <div className="alert">Loading file...</div>}
-            {editorStatus && (
-              <div
-                className={`alert ${
-                  editorStatus.includes("successfully")
-                    ? "success"
-                    : editorStatus.includes("Failed") ||
-                        editorStatus.includes("failed")
-                      ? "error"
-                      : ""
-                }`}
-              >
-                {editorStatus}
-              </div>
-            )}
-            <textarea
-              value={editorContent}
-              onChange={(event) => setEditorContent(event.target.value)}
-              disabled={!selectedFile}
-              className="editor-input"
-            />
-          </Panel>
-          <Panel
-            title="Preview"
-            actions={
-              selectedFile && (
-                <button
-                  type="button"
-                  className="secondary"
-                  onClick={() => openFileCommentModal("preview")}
-                >
-                  Comment
-                </button>
-              )
-            }
-          >
-            {selectedFile?.endsWith(".md") ? (
-              <div
-                className="markdown"
-                dangerouslySetInnerHTML={{
-                  __html: marked(editorContent || ""),
-                }}
+                  {editorStatus}
+                </div>
+              )}
+              <textarea
+                value={editorContent}
+                onChange={(event) => setEditorContent(event.target.value)}
+                disabled={!selectedFile}
+                className="editor-input"
               />
-            ) : (
-              <pre className="preview">{editorContent}</pre>
-            )}
-          </Panel>
+            </Panel>
+            <Panel
+              title="Preview"
+              actions={
+                selectedFile && (
+                  <button
+                    type="button"
+                    className="secondary comment-action"
+                    onClick={() => openFileCommentModal("preview")}
+                  >
+                    Comment
+                  </button>
+                )
+              }
+            >
+              {selectedFile?.endsWith(".md") ? (
+                <div
+                  className="markdown"
+                  dangerouslySetInnerHTML={{
+                    __html: marked(editorContent || ""),
+                  }}
+                />
+              ) : (
+                <pre className="preview">{editorContent}</pre>
+              )}
+            </Panel>
+          </div>
         </div>
       ),
     },

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -216,6 +216,19 @@ textarea {
   color: var(--muted);
 }
 
+.comment-action {
+  border-color: rgba(63, 116, 255, 0.45);
+  background: rgba(63, 116, 255, 0.16);
+  color: #c8dcff;
+}
+
+.comment-action:hover:not(:disabled),
+.comment-action:focus-visible:not(:disabled) {
+  border-color: rgba(98, 144, 255, 0.65);
+  background: rgba(63, 116, 255, 0.24);
+  color: #e2edff;
+}
+
 .danger {
   padding: 0.75rem 1.25rem;
   border-radius: 0.9rem;

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -151,6 +151,11 @@
   height: 16px;
 }
 
+.editor-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .editor-grid,
 .artefact-grid {
   display: grid;
@@ -158,7 +163,7 @@
 }
 
 .editor-grid {
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 }
 
 .artefact-grid {


### PR DESCRIPTION
### Motivation
- Ensure Git file metadata appears above the editor/preview area instead of being side-by-side with the editor to improve clarity and match layout expectations. 
- Make file-level "Comment" actions visually distinct and blue-tinted so they are clearly identifiable as comment controls.
- Improve editor spacing for better readability on typical viewport widths.

### Description
- Moved `Git File Info` and `Diff View` panels into a top section (`.editor-layout`) so they render above the editing and preview panels in `RepositoryPage.tsx`.
- Kept the editing and preview panels in a dedicated two-column grid (`.editor-grid`) and adjusted the minimum column width from `320px` to `360px` for improved spacing.
- Added a new `.comment-action` CSS class in `packages/frontend/src/styles/index.css` and applied it to the "Comment" buttons in the Diff View and Preview to give them a blue-tinted appearance.
- Added `.editor-layout` to `packages/frontend/src/styles/page.css` and updated related layout styles to support the new structure.

### Testing
- Built the frontend with `npm run build:frontend` (runs `tsc` and `vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a3346520833284f78a2d6f3fe343)