### PR TITLE
Show per-diff-block line stats and align diff block spacing

### DIFF
--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -228,7 +228,15 @@ export type RepositoryFileGitDetails = {
   };
   lastModified: string;
   lineCount: number;
-  diffBlocks: { before: string; after: string }[];
+  diffBlocks: {
+    before: string;
+    after: string;
+    beforeStart: number;
+    beforeCount: number;
+    afterStart: number;
+    afterCount: number;
+    lineStats: { green: number; red: number };
+  }[];
 };
 
 export type HarnessDefinition = {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -2040,20 +2040,37 @@ export const RepositoryPage: React.FC = () => {
                   <div className="editor-diff-grid">
                     {fileGitDetails.diffBlocks.map((block, index) => (
                       <div
-                        className="editor-diff-row"
+                        className="editor-diff-block"
                         key={`${selectedFile}-${index}`}
                       >
-                        <div className="editor-diff-column">
-                          <h4>Before</h4>
-                          <pre className="preview">
-                            {block.before || "(empty)"}
-                          </pre>
+                        <div className="editor-diff-block__meta">
+                          <span className="editor-diff-block__lines">
+                            Lines {block.beforeStart}-{block.beforeStart + Math.max(block.beforeCount - 1, 0)}
+                            {" → "}
+                            {block.afterStart}-{block.afterStart + Math.max(block.afterCount - 1, 0)}
+                          </span>
+                          <span className="git-stat-pair">
+                            <span className="git-added">
+                              +{block.lineStats.green}
+                            </span>
+                            <span className="git-removed">
+                              -{block.lineStats.red}
+                            </span>
+                          </span>
                         </div>
-                        <div className="editor-diff-column">
-                          <h4>After</h4>
-                          <pre className="preview">
-                            {block.after || "(empty)"}
-                          </pre>
+                        <div className="editor-diff-row">
+                          <div className="editor-diff-column">
+                            <h4>Before</h4>
+                            <pre className="preview">
+                              {block.before || "(empty)"}
+                            </pre>
+                          </div>
+                          <div className="editor-diff-column">
+                            <h4>After</h4>
+                            <pre className="preview">
+                              {block.after || "(empty)"}
+                            </pre>
+                          </div>
                         </div>
                       </div>
                     ))}

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -668,13 +668,31 @@ textarea {
 
 .editor-diff-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.5rem;
+}
+
+.editor-diff-block {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.editor-diff-block__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.editor-diff-block__lines {
+  font-variant-numeric: tabular-nums;
 }
 
 .editor-diff-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .editor-diff-column {

--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import logging
 import shutil
+import re
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -467,10 +468,16 @@ def _is_ignored_file(repo_path: Path, file_path: str) -> bool:
         return False
 
 
-def _parse_diff_blocks(diff_text: str) -> list[dict[str, str]]:
-    blocks: list[dict[str, str]] = []
+def _parse_diff_blocks(diff_text: str) -> list[dict[str, object]]:
+    blocks: list[dict[str, object]] = []
     current_before: list[str] = []
     current_after: list[str] = []
+    before_start = 0
+    before_count = 0
+    after_start = 0
+    after_count = 0
+    green = 0
+    red = 0
     in_hunk = False
 
     for line in diff_text.splitlines():
@@ -480,11 +487,33 @@ def _parse_diff_blocks(diff_text: str) -> list[dict[str, str]]:
                     {
                         "before": "\n".join(current_before),
                         "after": "\n".join(current_after),
+                        "beforeStart": before_start,
+                        "beforeCount": before_count,
+                        "afterStart": after_start,
+                        "afterCount": after_count,
+                        "lineStats": {"green": green, "red": red},
                     }
                 )
+            match = re.match(
+                r"^@@ -(?P<before_start>\d+)(?:,(?P<before_count>\d+))? "
+                r"\+(?P<after_start>\d+)(?:,(?P<after_count>\d+))? @@",
+                line,
+            )
+            if match:
+                before_start = int(match.group("before_start"))
+                before_count = int(match.group("before_count") or "1")
+                after_start = int(match.group("after_start"))
+                after_count = int(match.group("after_count") or "1")
+            else:
+                before_start = 0
+                before_count = 0
+                after_start = 0
+                after_count = 0
             in_hunk = True
             current_before = []
             current_after = []
+            green = 0
+            red = 0
             continue
 
         if not in_hunk:
@@ -492,8 +521,10 @@ def _parse_diff_blocks(diff_text: str) -> list[dict[str, str]]:
 
         if line.startswith("-"):
             current_before.append(line[1:])
+            red += 1
         elif line.startswith("+"):
             current_after.append(line[1:])
+            green += 1
         elif line.startswith(" "):
             content = line[1:]
             current_before.append(content)
@@ -504,6 +535,11 @@ def _parse_diff_blocks(diff_text: str) -> list[dict[str, str]]:
             {
                 "before": "\n".join(current_before),
                 "after": "\n".join(current_after),
+                "beforeStart": before_start,
+                "beforeCount": before_count,
+                "afterStart": after_start,
+                "afterCount": after_count,
+                "lineStats": {"green": green, "red": red},
             }
         )
 
@@ -655,7 +691,7 @@ def get_repository_file_git_details(
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
 
-    diff_blocks: list[dict[str, str]] = []
+    diff_blocks: list[dict[str, object]] = []
     try:
         diff_text = _run_git(repo_path, ["diff", "--unified=0", "HEAD", "--", file_path])
         diff_blocks = _parse_diff_blocks(diff_text)
@@ -667,7 +703,17 @@ def get_repository_file_git_details(
         green = len(file_content.splitlines())
         red = 0
         if file_content:
-            diff_blocks = [{"before": "", "after": file_content}]
+            diff_blocks = [
+                {
+                    "before": "",
+                    "after": file_content,
+                    "beforeStart": 0,
+                    "beforeCount": 0,
+                    "afterStart": 1,
+                    "afterCount": green,
+                    "lineStats": {"green": green, "red": 0},
+                }
+            ]
 
     last_commit_id = None
     last_commit_message = None

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -208,6 +208,8 @@ def test_get_repository_file_git_details_for_tracked_file(monkeypatch, tmp_path)
     assert result["lineCount"] == 2
     assert result["lastCommit"]["link"] is not None
     assert len(result["diffBlocks"]) >= 1
+    assert "lineStats" in result["diffBlocks"][0]
+    assert "beforeStart" in result["diffBlocks"][0]
 
 
 def test_get_repository_file_git_details_for_untracked_file(monkeypatch, tmp_path):
@@ -225,7 +227,17 @@ def test_get_repository_file_git_details_for_untracked_file(monkeypatch, tmp_pat
 
     assert result["tracked"] is False
     assert result["lineStats"] == {"green": 2, "red": 0}
-    assert result["diffBlocks"] == [{"before": "", "after": "line one\nline two\n"}]
+    assert result["diffBlocks"] == [
+        {
+            "before": "",
+            "after": "line one\nline two\n",
+            "beforeStart": 0,
+            "beforeCount": 0,
+            "afterStart": 1,
+            "afterCount": 2,
+            "lineStats": {"green": 2, "red": 0},
+        }
+    ]
 
 def test_pull_repository(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
### Motivation
- Improve the Diff View so each diff block has the same metadata shape and shows per-block line impacts (+/−) like other pages, and make the block spacing match the app's standard panel rhythm.

### Description
- Backend: extended `_parse_diff_blocks` to parse hunk headers (`@@ -a,b +c,d @@`) and return per-block metadata (`beforeStart`, `beforeCount`, `afterStart`, `afterCount`, `lineStats`) and updated untracked-file handling to produce the same block shape.
- Frontend types: updated `RepositoryFileGitDetails.diffBlocks` in `useApi.ts` to include the new numeric range fields and `lineStats` object so consumers have a stable shape.
- Frontend UI: added a per-block header above each Before/After pair in `RepositoryPage.tsx` that displays affected line ranges and `+green / -red` counts, and adjusted markup to group the header with the columns.
- Styles: increased spacing in `.editor-diff-grid` and `.editor-diff-row` and added `.editor-diff-block` and metadata styles in `index.css` to align diff block spacing with other panels.

### Testing
- Ran backend unit tests with `python -m pytest packages/pybackend/tests/unit/test_repository_service.py`, all tests passed (`19 passed`).
- Built the frontend with `npm run build:frontend`, the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a4a046348332b24666fd1d39d575)