### PR TITLE
Render diff line ranges in Before/After headings with monospaced style

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -2044,11 +2044,6 @@ export const RepositoryPage: React.FC = () => {
                         key={`${selectedFile}-${index}`}
                       >
                         <div className="editor-diff-block__meta">
-                          <span className="editor-diff-block__lines">
-                            Lines {block.beforeStart}-{block.beforeStart + Math.max(block.beforeCount - 1, 0)}
-                            {" → "}
-                            {block.afterStart}-{block.afterStart + Math.max(block.afterCount - 1, 0)}
-                          </span>
                           <span className="git-stat-pair">
                             <span className="git-added">
                               +{block.lineStats.green}
@@ -2060,13 +2055,23 @@ export const RepositoryPage: React.FC = () => {
                         </div>
                         <div className="editor-diff-row">
                           <div className="editor-diff-column">
-                            <h4>Before</h4>
+                            <h4>
+                              Before{" "}
+                              <span className="editor-diff-column__line-range">
+                                {block.beforeStart}-{block.beforeStart + Math.max(block.beforeCount - 1, 0)}
+                              </span>
+                            </h4>
                             <pre className="preview">
                               {block.before || "(empty)"}
                             </pre>
                           </div>
                           <div className="editor-diff-column">
-                            <h4>After</h4>
+                            <h4>
+                              After{" "}
+                              <span className="editor-diff-column__line-range">
+                                {block.afterStart}-{block.afterStart + Math.max(block.afterCount - 1, 0)}
+                              </span>
+                            </h4>
                             <pre className="preview">
                               {block.after || "(empty)"}
                             </pre>

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -679,14 +679,10 @@ textarea {
 .editor-diff-block__meta {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 0.75rem;
   font-size: 0.85rem;
   color: var(--muted);
-}
-
-.editor-diff-block__lines {
-  font-variant-numeric: tabular-nums;
 }
 
 .editor-diff-row {
@@ -704,6 +700,12 @@ textarea {
   margin: 0;
   font-size: 0.9rem;
   color: var(--muted);
+}
+
+.editor-diff-column__line-range {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-variant-numeric: tabular-nums;
+  font-weight: 400;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Improve readability of diff blocks by showing the per-block line ranges directly next to the `Before` and `After` headlines. 
- Ensure the displayed line ranges use a monospaced font and are not shown in bold to match typical diff viewers. 
- Keep the add/remove statistics visually aligned after removing the shared line-range text from the meta row.

### Description
- Move the line-range display out of the shared meta row and into each column heading in `packages/frontend/src/pages/RepositoryPage.tsx` so `Before` shows the `before` range and `After` shows the `after` range. 
- Add a new CSS rule `.editor-diff-column__line-range` in `packages/frontend/src/styles/index.css` that uses a monospaced stack (`"JetBrains Mono", "Fira Code", monospace`) and sets `font-weight: 400`. 
- Adjust `.editor-diff-block__meta` alignment to `justify-content: flex-end` to keep the `+/-` stats right-aligned after removing the shared line-range element. 
- Remove the unused `.editor-diff-block__lines` rule and clean up the meta row markup accordingly.

### Testing
- Ran `npm run lint` and the linter completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7aed1fd14833280c504ceb5b1ce40)