### PR TITLE
cron: resolve agent CLI executable, robust stdin handling, and record CLI resolution failures

### DIFF
--- a/packages/pybackend/cron_service.py
+++ b/packages/pybackend/cron_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -9,8 +10,8 @@ from threading import Lock, Thread
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from agent_service import get_agent_cli
 from config import get_workspace_home
-from settings_service import read_settings
 from task_service import get_tasks_directory, list_scheduled_tasks, read_task
 from workflow_service import read_workflows
 
@@ -82,26 +83,38 @@ def _resolve_script_path(repo_path: Path, shell_script_path: str) -> Path:
 
 
 def _build_agent_cli_command(prompt: str) -> list[str]:
-    settings = read_settings()
-    selected_cli = str(settings.get("agentCli", "opencode")).strip()
+    agent_cli = get_agent_cli()
+    executable = agent_cli.main_executable_name()
+    selected_cli = agent_cli.cli_name
 
-    if selected_cli == "kiro":
-        return ["kiro-cli", "chat", "--no-interactive", "--trust-all-tools"]
+    if selected_cli == "kiro-cli":
+        return [executable, "chat", "--no-interactive", "--trust-all-tools"]
     if selected_cli == "copilot":
-        return ["copilot", "-p", prompt, "--allow-all-tools", "--silent"]
+        return [executable, "-p", prompt, "--allow-all-tools", "--silent"]
     if selected_cli == "codex":
-        return ["codex", "exec", "--json"]
+        return [executable, "exec", "--json"]
     if selected_cli == "ob1":
-        return ["ob1", "--output-format", "json", "--prompt", prompt]
+        return [executable, "--output-format", "json", "--prompt", prompt]
 
     # Defaults for both "opencode" and "opencode-legacy".
-    return ["opencode", "run", "--format", "json"]
+    return [executable, "run", "--format", "json"]
 
 
 def _uses_stdin_prompt(command: list[str]) -> bool:
     if len(command) < 2:
         return False
     return command[0] in {"opencode", "kiro-cli", "codex"}
+
+
+def _resolve_executable(command: list[str]) -> list[str]:
+    if not command:
+        raise ValueError("Empty command")
+
+    executable = command[0]
+    resolved = shutil.which(executable)
+    if resolved is None:
+        raise FileNotFoundError(f"Executable not found: {executable}")
+    return [resolved, *command[1:]]
 
 
 def _tail_output(value: str, max_lines: int = 20) -> str:
@@ -202,10 +215,22 @@ def _wait_for_workflow_process(
     workflow_id: str,
     process: subprocess.Popen[str],
     started_at: datetime,
+    stdin_input: str | None = None,
 ) -> None:
     global _successful_jobs, _failed_jobs
 
-    stdout, stderr = process.communicate()
+    try:
+        stdout, stderr = process.communicate(input=stdin_input)
+    except ValueError:
+        # Defensive fallback: stdin may already be closed by another thread/process
+        # which makes communicate() attempt to flush a closed stream.
+        logger.warning(
+            "Cron workflow '%s' had closed stdin before communicate(); falling back to wait/read",
+            workflow_id,
+        )
+        process.wait()
+        stdout = process.stdout.read() if process.stdout is not None else ""
+        stderr = process.stderr.read() if process.stderr is not None else ""
     stdout_tail = _tail_output(stdout)
     stderr_tail = _tail_output(stderr)
     returncode = process.returncode
@@ -282,7 +307,7 @@ def _run_workflow_script(repo_path: Path, workflow_id: str, script_path: Path) -
 
 
 def _run_scheduled_task(task_id: str, task_file_name: str) -> None:
-    global _started_jobs
+    global _started_jobs, _failed_jobs
 
     started_at = datetime.now(timezone.utc)
     tasks_directory = get_tasks_directory()
@@ -291,6 +316,18 @@ def _run_scheduled_task(task_id: str, task_file_name: str) -> None:
     if not prompt:
         prompt = f"Follow the instructions in `{task_file_name}`"
     command = _build_agent_cli_command(prompt)
+    use_stdin_prompt = _uses_stdin_prompt(command)
+    try:
+        command = _resolve_executable(command)
+    except (ValueError, FileNotFoundError) as exc:
+        with _state_lock:
+            _started_jobs += 1
+            _failed_jobs += 1
+            _last_run_by_job[task_id] = datetime.now(timezone.utc)
+            _last_finished_by_job[task_id] = datetime.now(timezone.utc)
+            _last_error_by_job[task_id] = str(exc)
+        logger.warning("Skipping scheduled task '%s': %s", task_id, exc)
+        return
 
     popen_kwargs: dict[str, object] = {
         "cwd": str(tasks_directory),
@@ -298,7 +335,7 @@ def _run_scheduled_task(task_id: str, task_file_name: str) -> None:
         "stderr": subprocess.PIPE,
         "text": True,
     }
-    if _uses_stdin_prompt(command):
+    if use_stdin_prompt:
         popen_kwargs["stdin"] = subprocess.PIPE
 
     with _state_lock:
@@ -309,14 +346,11 @@ def _run_scheduled_task(task_id: str, task_file_name: str) -> None:
         _running_process_by_job[task_id] = process
         _job_start_times[task_id] = started_at
 
-    if _uses_stdin_prompt(command) and process.stdin is not None:
-        process.stdin.write(prompt)
-        process.stdin.close()
-
     logger.info("Running scheduled task '%s' in '%s'", task_id, tasks_directory)
+    stdin_input = prompt if use_stdin_prompt else None
     Thread(
         target=_wait_for_workflow_process,
-        args=(task_id, process, started_at),
+        args=(task_id, process, started_at, stdin_input),
         daemon=True,
     ).start()
 

--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -365,13 +365,15 @@ def test_start_cron_clock_registers_scheduled_tasks(
 
 @patch("cron_service.get_tasks_directory")
 @patch("cron_service.read_task")
-@patch("cron_service.read_settings")
+@patch("cron_service.get_agent_cli")
+@patch("cron_service.shutil.which")
 @patch("cron_service.Thread")
 @patch("cron_service.subprocess.Popen")
 def test_run_scheduled_task_uses_configured_agent_cli(
     mock_popen,
     mock_thread,
-    mock_read_settings,
+    mock_which,
+    mock_get_agent_cli,
     mock_read_task,
     mock_get_tasks_directory,
     tmp_path,
@@ -379,8 +381,12 @@ def test_run_scheduled_task_uses_configured_agent_cli(
     tasks_dir = tmp_path / ".made" / "tasks"
     tasks_dir.mkdir(parents=True)
     mock_get_tasks_directory.return_value = tasks_dir
-    mock_read_settings.return_value = {"agentCli": "opencode"}
+    mock_cli = MagicMock()
+    mock_cli.cli_name = "opencode"
+    mock_cli.main_executable_name.return_value = "opencode"
+    mock_get_agent_cli.return_value = mock_cli
     mock_read_task.return_value = {"content": "# check things\n- task body"}
+    mock_which.return_value = "/usr/bin/opencode"
 
     process = MagicMock()
     process.stdin = MagicMock()
@@ -393,26 +399,30 @@ def test_run_scheduled_task_uses_configured_agent_cli(
     cron_service._run_scheduled_task("task:daily-report.md", "daily-report.md")
 
     mock_popen.assert_called_once_with(
-        ["opencode", "run", "--format", "json"],
+        ["/usr/bin/opencode", "run", "--format", "json"],
         cwd=str(tasks_dir),
         stdout=cron_service.subprocess.PIPE,
         stderr=cron_service.subprocess.PIPE,
         text=True,
         stdin=cron_service.subprocess.PIPE,
     )
-    process.stdin.write.assert_called_once_with("# check things\n- task body")
-    process.stdin.close.assert_called_once_with()
+    mock_thread.assert_called_once()
+    assert (
+        mock_thread.call_args.kwargs["args"][3] == "# check things\n- task body"
+    )
 
 
 @patch("cron_service.get_tasks_directory")
 @patch("cron_service.read_task")
-@patch("cron_service.read_settings")
+@patch("cron_service.get_agent_cli")
+@patch("cron_service.shutil.which")
 @patch("cron_service.Thread")
 @patch("cron_service.subprocess.Popen")
 def test_run_scheduled_task_falls_back_to_filename_prompt_when_content_empty(
     mock_popen,
     mock_thread,
-    mock_read_settings,
+    mock_which,
+    mock_get_agent_cli,
     mock_read_task,
     mock_get_tasks_directory,
     tmp_path,
@@ -420,8 +430,12 @@ def test_run_scheduled_task_falls_back_to_filename_prompt_when_content_empty(
     tasks_dir = tmp_path / ".made" / "tasks"
     tasks_dir.mkdir(parents=True)
     mock_get_tasks_directory.return_value = tasks_dir
-    mock_read_settings.return_value = {"agentCli": "opencode"}
+    mock_cli = MagicMock()
+    mock_cli.cli_name = "opencode"
+    mock_cli.main_executable_name.return_value = "opencode"
+    mock_get_agent_cli.return_value = mock_cli
     mock_read_task.return_value = {"content": "   "}
+    mock_which.return_value = "/usr/bin/opencode"
 
     process = MagicMock()
     process.stdin = MagicMock()
@@ -433,8 +447,47 @@ def test_run_scheduled_task_falls_back_to_filename_prompt_when_content_empty(
 
     cron_service._run_scheduled_task("task:daily-report.md", "daily-report.md")
 
-    process.stdin.write.assert_called_once_with(
-        "Follow the instructions in `daily-report.md`"
+    mock_thread.assert_called_once()
+    assert (
+        mock_thread.call_args.kwargs["args"][3]
+        == "Follow the instructions in `daily-report.md`"
+    )
+
+
+@patch("cron_service.get_tasks_directory")
+@patch("cron_service.read_task")
+@patch("cron_service.get_agent_cli")
+@patch("cron_service.shutil.which")
+@patch("cron_service.Thread")
+@patch("cron_service.subprocess.Popen")
+def test_run_scheduled_task_records_failure_when_cli_not_found(
+    mock_popen,
+    mock_thread,
+    mock_which,
+    mock_get_agent_cli,
+    mock_read_task,
+    mock_get_tasks_directory,
+    tmp_path,
+):
+    tasks_dir = tmp_path / ".made" / "tasks"
+    tasks_dir.mkdir(parents=True)
+    mock_get_tasks_directory.return_value = tasks_dir
+    mock_cli = MagicMock()
+    mock_cli.cli_name = "opencode"
+    mock_cli.main_executable_name.return_value = "opencode"
+    mock_get_agent_cli.return_value = mock_cli
+    mock_read_task.return_value = {"content": "run report"}
+    mock_which.return_value = None
+    cron_service._failed_jobs = 0
+
+    cron_service._run_scheduled_task("task:daily-report.md", "daily-report.md")
+
+    mock_popen.assert_not_called()
+    mock_thread.assert_not_called()
+    assert cron_service._failed_jobs == 1
+    assert (
+        cron_service._last_error_by_job["task:daily-report.md"]
+        == "Executable not found: opencode"
     )
 
 
@@ -454,6 +507,27 @@ def test_wait_for_workflow_process_keeps_last_stdout_lines_only():
     assert stored_stdout.startswith("line-11")
     assert stored_stdout.endswith("line-30")
     assert "line-10" not in stored_stdout
+
+
+def test_wait_for_workflow_process_handles_closed_stdin_during_communicate():
+    process = MagicMock()
+    process.communicate.side_effect = ValueError("I/O operation on closed file")
+    process.wait.return_value = 0
+    process.stdout.read.return_value = "stdout line"
+    process.stderr.read.return_value = ""
+    process.returncode = 0
+    process.poll.return_value = 0
+
+    started_at = cron_service.datetime(
+        2026, 1, 2, 3, 4, 5, tzinfo=cron_service.timezone.utc
+    )
+    cron_service._wait_for_workflow_process(
+        "task:daily-report.md", process, started_at, "prompt text"
+    )
+
+    process.wait.assert_called_once_with()
+    process.stdout.read.assert_called_once_with()
+    assert cron_service._last_stdout_by_job["task:daily-report.md"] == "stdout line"
 
 
 def test_get_cron_job_diagnostics_returns_empty_when_scheduler_not_running():


### PR DESCRIPTION
### Motivation

- Replace legacy settings-based CLI selection with the `agent_service` abstraction and ensure the actual CLI executable is resolved before running scheduled tasks.
- Make subprocess communication robust to closed stdin and avoid writing to closed pipes from other threads.
- Surface and record failures when the configured CLI executable is not found so scheduled tasks fail fast and are diagnosable.

### Description

- Replaced `read_settings` usage with `get_agent_cli()` and use the agent object's `cli_name` and `main_executable_name()` in `_build_agent_cli_command`.
- Added `_resolve_executable` which uses `shutil.which` to resolve the CLI executable path and raises when missing, and integrated it into `_run_scheduled_task`.
- Added defensive handling when `subprocess.communicate()` raises `ValueError` (closed stdin) by falling back to `wait()` and reading from `stdout`/`stderr` in `_wait_for_workflow_process`.
- Stopped writing to `process.stdin` directly; instead pass the prompt as `stdin_input` into the worker thread and use `communicate(input=...)` where appropriate; preserved `stdin` behavior by setting `stdin` only when needed.
- When executable resolution fails, record failure metrics and `last_error` for the task and skip spawning the process.
- Import `shutil` and `get_agent_cli` and update related CLI name mappings to use the resolved executable.
- Updated unit tests in `tests/unit/test_cron_service.py` to reflect the new `agent_service` usage, executable resolution, and the new failure/closed-stdin behaviors, and added tests for CLI-not-found and closed-stdin scenarios.

### Testing

- Ran the updated unit test file `tests/unit/test_cron_service.py` which includes tests for executable resolution, prompt handling, and closed-stdin fallback, and they succeeded.
- Verified that the new tests `test_run_scheduled_task_records_failure_when_cli_not_found` and `test_wait_for_workflow_process_handles_closed_stdin_during_communicate` pass alongside existing cron tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca4a3c090483328c618753c22d4702)