### PR TITLE
Fix external matter links when route params are URL-decoded

### DIFF
--- a/packages/frontend/src/utils/externalLinks.test.ts
+++ b/packages/frontend/src/utils/externalLinks.test.ts
@@ -5,6 +5,7 @@ import {
   getExternalMatter,
   listExternalMatter,
   removeExternalMatterLink,
+  saveExternalMatter,
 } from "./externalLinks";
 
 describe("externalLinks", () => {
@@ -30,5 +31,26 @@ describe("externalLinks", () => {
     expect(removeExternalMatterLink("knowledge", "external-missing")).toBe(
       false,
     );
+  });
+
+  it("resolves entries by decoded route IDs", () => {
+    const linked = addExternalMatterLink(
+      "constitution",
+      "~/.config/opencode/AGENTS.md",
+    );
+    expect(linked).not.toBeNull();
+
+    const decodedRouteId = `external-${linked!.path}`;
+    expect(getExternalMatter("constitution", decodedRouteId)).toEqual(linked);
+
+    saveExternalMatter("constitution", decodedRouteId, "updated", {
+      type: "global",
+    });
+    expect(getExternalMatter("constitution", linked!.id)?.content).toBe(
+      "updated",
+    );
+
+    expect(removeExternalMatterLink("constitution", decodedRouteId)).toBe(true);
+    expect(listExternalMatter("constitution")).toHaveLength(0);
   });
 });

--- a/packages/frontend/src/utils/externalLinks.ts
+++ b/packages/frontend/src/utils/externalLinks.ts
@@ -15,6 +15,16 @@ const storageKey = (kind: ExternalMatterKind) => `${STORAGE_PREFIX}-${kind}`;
 
 const createId = (path: string) => `${ID_PREFIX}${encodeURIComponent(path)}`;
 
+const normalizeId = (id: string) => {
+  if (!id.startsWith(ID_PREFIX)) return id;
+  const rawPath = id.slice(ID_PREFIX.length);
+  try {
+    return createId(decodeURIComponent(rawPath));
+  } catch {
+    return createId(rawPath);
+  }
+};
+
 const nameFromPath = (path: string) => {
   const trimmed = path.trim();
   if (!trimmed) return "external-file";
@@ -84,7 +94,8 @@ export const getExternalMatter = (
   kind: ExternalMatterKind,
   id: string,
 ): ExternalMatter | null => {
-  const found = parseStored(kind).find((item) => item.id === id);
+  const normalizedId = normalizeId(id);
+  const found = parseStored(kind).find((item) => item.id === normalizedId);
   return found ?? null;
 };
 
@@ -94,9 +105,10 @@ export const saveExternalMatter = (
   content: string,
   frontmatter: Record<string, unknown>,
 ) => {
+  const normalizedId = normalizeId(id);
   const current = parseStored(kind);
   const next = current.map((item) =>
-    item.id === id ? { ...item, content, frontmatter } : item,
+    item.id === normalizedId ? { ...item, content, frontmatter } : item,
   );
   writeStored(kind, next);
 };
@@ -105,8 +117,9 @@ export const removeExternalMatterLink = (
   kind: ExternalMatterKind,
   id: string,
 ): boolean => {
+  const normalizedId = normalizeId(id);
   const current = parseStored(kind);
-  const next = current.filter((item) => item.id !== id);
+  const next = current.filter((item) => item.id !== normalizedId);
   if (next.length === current.length) return false;
   writeStored(kind, next);
   return true;


### PR DESCRIPTION
### Motivation
- React Router can provide decoded route params like `external-~/.config/opencode/AGENTS.md` while stored external-matter IDs are URL-encoded, causing linked external constitutions/knowledge items to be reported as "not found". 
- Normalize IDs at lookup/update/delete so the frontend resolves links regardless of whether the router gives an encoded or decoded id.

### Description
- Added `normalizeId` to `packages/frontend/src/utils/externalLinks.ts` to canonicalize IDs by decoding then re-encoding path segments when necessary.
- Applied `normalizeId` in `getExternalMatter`, `saveExternalMatter`, and `removeExternalMatterLink` so read/update/delete operations work with decoded route params.
- Added a unit test in `packages/frontend/src/utils/externalLinks.test.ts` that verifies decoded route IDs can read, save, and remove linked external constitutions.
- Updated `externalLinks.ts` and `externalLinks.test.ts` (frontend utilities and tests) to cover the decoded-route-ID scenario.

### Testing
- Ran frontend unit tests for the changed file: `cd packages/frontend && npm test -- src/utils/externalLinks.test.ts`, and the test suite passed (`1 file, 3 tests, 3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5031f9b8833298c86ae2e345d418)