### PR TITLE
Add Favorites section to homepage with star toggles

### DIFF
--- a/packages/frontend/src/components/icons/StarIcon.tsx
+++ b/packages/frontend/src/components/icons/StarIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface StarIconProps {
+  filled?: boolean;
+}
+
+export const StarIcon: React.FC<StarIconProps> = ({ filled = false }) => {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill={filled ? "white" : "none"}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M12 3.5L14.86 9.29L21.25 10.22L16.62 14.73L17.72 21.1L12 18.09L6.28 21.1L7.38 14.73L2.75 10.22L9.14 9.29L12 3.5Z"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/packages/frontend/src/pages/HomePage.test.tsx
+++ b/packages/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HomePage } from "./HomePage";
+
+const HISTORY_STORAGE_KEY = "made.navigation-history.v1";
+const FAVORITES_STORAGE_KEY = "made.favorites.v1";
+
+describe("HomePage favorites", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("adds and removes history items from favorites", async () => {
+    localStorage.setItem(
+      HISTORY_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "repository:alpha",
+          kind: "repository",
+          name: "alpha",
+          path: "/repositories/alpha",
+          visitedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ]),
+    );
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(
+        "No favorite repositories, tasks, knowledge artefacts, or constitutions yet.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Add alpha to favorites"));
+
+    const favoritesHeading = screen.getByRole("heading", { name: "Favorites" });
+    const favoritesSection = favoritesHeading.closest("section");
+    expect(favoritesSection).not.toBeNull();
+
+    const favoriteLink = within(favoritesSection as HTMLElement).getByRole(
+      "link",
+      { name: /alpha/i },
+    );
+    expect(favoriteLink).toHaveAttribute("href", "/repositories/alpha");
+
+    fireEvent.click(screen.getByLabelText("Remove alpha from favorites"));
+    expect(
+      screen.getByText(
+        "No favorite repositories, tasks, knowledge artefacts, or constitutions yet.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(localStorage.getItem(FAVORITES_STORAGE_KEY)).toBe("[]");
+  });
+});

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Panel } from "../components/Panel";
 import "../styles/page.css";
+import { StarIcon } from "../components/icons/StarIcon";
+import { getFavorites, toggleFavorite } from "../utils/favorites";
 import {
   getHistoryKindLabel,
   getNavigationHistory,
@@ -36,6 +38,11 @@ const QUICK_LINKS = [
 
 export const HomePage: React.FC = () => {
   const history = useMemo(() => getNavigationHistory(), []);
+  const [favorites, setFavorites] = useState(() => getFavorites());
+  const favoriteIds = useMemo(
+    () => new Set(favorites.map((entry) => entry.id)),
+    [favorites],
+  );
 
   return (
     <div className="page">
@@ -55,6 +62,24 @@ export const HomePage: React.FC = () => {
       </div>
 
       <section className="history-section">
+        <h2>Favorites</h2>
+        {favorites.length === 0 ? (
+          <p className="meta-secondary">
+            No favorite repositories, tasks, knowledge artefacts, or
+            constitutions yet.
+          </p>
+        ) : (
+          <div className="panel-grid">
+            {favorites.map((entry) => (
+              <Panel key={entry.id} title={entry.name} to={entry.path}>
+                <p>{getHistoryKindLabel(entry.kind)}</p>
+              </Panel>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="history-section">
         <h2>Recent history</h2>
         {history.length === 0 ? (
           <p className="meta-secondary">
@@ -69,6 +94,27 @@ export const HomePage: React.FC = () => {
                 title={entry.name}
                 to={entry.path}
                 className="history-panel"
+                actions={
+                  <button
+                    type="button"
+                    className="copy-button favorite-toggle"
+                    aria-label={
+                      favoriteIds.has(entry.id)
+                        ? `Remove ${entry.name} from favorites`
+                        : `Add ${entry.name} to favorites`
+                    }
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      toggleFavorite(entry);
+                      setFavorites(getFavorites());
+                    }}
+                  >
+                    <StarIcon
+                      filled={favoriteIds.has(entry.id)}
+                    />
+                  </button>
+                }
               >
                 <p>{getHistoryKindLabel(entry.kind)}</p>
                 <p className="meta-secondary">

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -543,6 +543,16 @@
   gap: 0.35rem;
 }
 
+.favorite-toggle {
+  opacity: 1;
+  color: var(--muted);
+}
+
+.favorite-toggle:hover,
+.favorite-toggle:focus-visible {
+  color: var(--text);
+}
+
 .nested-tree-block {
   display: grid;
   gap: 0.8rem;

--- a/packages/frontend/src/utils/favorites.ts
+++ b/packages/frontend/src/utils/favorites.ts
@@ -1,0 +1,74 @@
+import { HistoryEntry, HistoryKind } from "./navigationHistory";
+
+export interface FavoriteEntry {
+  id: string;
+  kind: HistoryKind;
+  name: string;
+  path: string;
+  favoritedAt: string;
+}
+
+const STORAGE_KEY = "made.favorites.v1";
+
+const isFavoriteEntry = (value: unknown): value is FavoriteEntry => {
+  if (!value || typeof value !== "object") return false;
+
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.id === "string" &&
+    typeof entry.kind === "string" &&
+    typeof entry.name === "string" &&
+    typeof entry.path === "string" &&
+    typeof entry.favoritedAt === "string"
+  );
+};
+
+const parseFavorites = (raw: string | null): FavoriteEntry[] => {
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(isFavoriteEntry);
+  } catch (error) {
+    console.warn("Failed to parse favorites", error);
+    return [];
+  }
+};
+
+const saveFavorites = (favorites: FavoriteEntry[]): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+};
+
+export const getFavorites = (): FavoriteEntry[] => {
+  return parseFavorites(localStorage.getItem(STORAGE_KEY)).sort(
+    (a, b) => Date.parse(b.favoritedAt) - Date.parse(a.favoritedAt),
+  );
+};
+
+export const isFavorite = (id: string): boolean => {
+  return getFavorites().some((entry) => entry.id === id);
+};
+
+export const toggleFavorite = (entry: HistoryEntry): boolean => {
+  const existing = getFavorites();
+  const isCurrentlyFavorite = existing.some((item) => item.id === entry.id);
+
+  if (isCurrentlyFavorite) {
+    saveFavorites(existing.filter((item) => item.id !== entry.id));
+    return false;
+  }
+
+  saveFavorites([
+    {
+      id: entry.id,
+      kind: entry.kind,
+      name: entry.name,
+      path: entry.path,
+      favoritedAt: new Date().toISOString(),
+    },
+    ...existing,
+  ]);
+  return true;
+};


### PR DESCRIPTION
### Motivation
- Provide a lightweight way for users to mark repositories, tasks, knowledge artefacts and constitutions as favorites and access them quickly from the home page. 
- Keep favorites frontend-only and simple by persisting them in localStorage for now.

### Description
- Add a reusable `StarIcon` component with outlined and filled (white) states to represent favorite toggles (`packages/frontend/src/components/icons/StarIcon.tsx`).
- Implement favorites storage and helpers (`getFavorites`, `toggleFavorite`, etc.) using localStorage key `made.favorites.v1` (`packages/frontend/src/utils/favorites.ts`).
- Add a new `Favorites` section to the home page that renders favorited items as clickable panels and add a star action to each Recent history panel to add/remove favorites without navigating (`packages/frontend/src/pages/HomePage.tsx`).
- Add minimal styles for the favorite toggle to match existing icon affordances and add a unit test for the home page favorite flow (`packages/frontend/src/styles/page.css`, `packages/frontend/src/pages/HomePage.test.tsx`).

### Testing
- Ran the frontend unit test for the new behavior with `npm --workspace packages/frontend run test -- HomePage.test.tsx`, and the test passed. 
- Ran the frontend linter with `npm --workspace packages/frontend run lint`, and lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd78b8201c8332bd7bccbfc9bba9e8)