### PR TITLE
Add URL parameters to preselect chat session and draft message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@playwright/test": "^1.43.1",
         "npm-run-all": "^4.1.5",
-        "wait-on": "^7.2.0"
+        "wait-on": "^9.0.4"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -116,6 +116,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -485,6 +486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -533,6 +535,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1138,21 +1141,58 @@
         }
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@headlessui/react": {
@@ -1975,30 +2015,6 @@
         "win32"
       ]
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2114,8 +2130,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2207,6 +2222,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2218,6 +2234,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2257,6 +2274,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2662,6 +2680,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2712,7 +2731,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3001,6 +3019,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3462,8 +3481,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3763,6 +3781,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5180,17 +5199,22 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-tokens": {
@@ -5218,6 +5242,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -5379,9 +5404,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5420,7 +5445,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6076,7 +6100,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6092,7 +6115,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6141,6 +6163,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6153,6 +6176,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6166,8 +6190,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6455,6 +6478,7 @@
       "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -7137,6 +7161,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7246,6 +7271,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7426,23 +7452,23 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.4.tgz",
+      "integrity": "sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
+        "axios": "^1.13.5",
+        "joi": "^18.0.2",
+        "lodash": "^4.17.23",
         "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       },
       "bin": {
         "wait-on": "bin/wait-on"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@playwright/test": "^1.43.1",
     "npm-run-all": "^4.1.5",
-    "wait-on": "^7.2.0"
+    "wait-on": "^9.0.4"
   },
   "overrides": {
     "picomatch": "4.0.4"

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
@@ -41,10 +41,17 @@ import {
   removeExternalMatterLink,
   saveExternalMatter,
 } from "../utils/externalLinks";
+import {
+  getChatBootstrapParams,
+  hasConsumedChatBootstrap,
+  markChatBootstrapConsumed,
+  stripChatBootstrapParams,
+} from "../utils/chatQueryParams";
 
 export const ConstitutionPage: React.FC = () => {
   const { name } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
@@ -90,6 +97,7 @@ export const ConstitutionPage: React.FC = () => {
   const [mentionCommandPaths, setMentionCommandPaths] = useState<string[]>([]);
   const [externalPath, setExternalPath] = useState<string | null>(null);
   const chatWindowRef = useRef<HTMLDivElement>(null);
+  const chatInputId = "constitution-agent-prompt";
   const isExternal = Boolean(name && isExternalMatterId(name));
   const linkedExternalMatter = useMemo(
     () => (isExternal && name ? getExternalMatter("constitution", name) : null),
@@ -105,6 +113,44 @@ export const ConstitutionPage: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [chat]);
+
+  useEffect(() => {
+    const { sessionId: incomingSessionId, message: incomingMessage } =
+      getChatBootstrapParams(searchParams);
+    if (!incomingSessionId && !incomingMessage) return;
+
+    const { nextParams, changed } = stripChatBootstrapParams(searchParams);
+    if (changed) {
+      setSearchParams(nextParams, { replace: true });
+    }
+
+    const path = window.location.pathname;
+    if (
+      hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
+    ) {
+      return;
+    }
+    markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
+
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+    if (incomingMessage) {
+      setPrompt(incomingMessage);
+    }
+    setActiveTab("agent");
+
+    requestAnimationFrame(() => {
+      const textarea = document.getElementById(
+        chatInputId,
+      ) as HTMLTextAreaElement | null;
+      textarea?.focus();
+      textarea?.setSelectionRange(
+        textarea.value.length,
+        textarea.value.length,
+      );
+    });
+  }, [searchParams, setSearchParams, sessionId, setSessionId]);
 
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;
@@ -497,6 +543,7 @@ export const ConstitutionPage: React.FC = () => {
             />
             {agentStatus && <div className="alert">{agentStatus}</div>}
             <MentionPathTextarea
+              id={chatInputId}
               value={prompt}
               onChange={setPrompt}
               suggestions={mentionCommandPaths}

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
@@ -41,10 +41,17 @@ import {
   removeExternalMatterLink,
   saveExternalMatter,
 } from "../utils/externalLinks";
+import {
+  getChatBootstrapParams,
+  hasConsumedChatBootstrap,
+  markChatBootstrapConsumed,
+  stripChatBootstrapParams,
+} from "../utils/chatQueryParams";
 
 export const KnowledgeArtefactPage: React.FC = () => {
   const { name } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
@@ -88,6 +95,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [mentionCommandPaths, setMentionCommandPaths] = useState<string[]>([]);
   const [externalPath, setExternalPath] = useState<string | null>(null);
   const chatWindowRef = useRef<HTMLDivElement>(null);
+  const chatInputId = "knowledge-agent-prompt";
   const isExternal = Boolean(name && isExternalMatterId(name));
   const linkedExternalMatter = useMemo(
     () => (isExternal && name ? getExternalMatter("knowledge", name) : null),
@@ -103,6 +111,44 @@ export const KnowledgeArtefactPage: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [chat]);
+
+  useEffect(() => {
+    const { sessionId: incomingSessionId, message: incomingMessage } =
+      getChatBootstrapParams(searchParams);
+    if (!incomingSessionId && !incomingMessage) return;
+
+    const { nextParams, changed } = stripChatBootstrapParams(searchParams);
+    if (changed) {
+      setSearchParams(nextParams, { replace: true });
+    }
+
+    const path = window.location.pathname;
+    if (
+      hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
+    ) {
+      return;
+    }
+    markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
+
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+    if (incomingMessage) {
+      setPrompt(incomingMessage);
+    }
+    setActiveTab("agent");
+
+    requestAnimationFrame(() => {
+      const textarea = document.getElementById(
+        chatInputId,
+      ) as HTMLTextAreaElement | null;
+      textarea?.focus();
+      textarea?.setSelectionRange(
+        textarea.value.length,
+        textarea.value.length,
+      );
+    });
+  }, [searchParams, setSearchParams, sessionId, setSessionId]);
 
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;
@@ -527,6 +573,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
           />
           {agentStatus && <div className="alert">{agentStatus}</div>}
           <MentionPathTextarea
+            id={chatInputId}
             value={prompt}
             onChange={setPrompt}
             suggestions={mentionCommandPaths}

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -54,6 +54,12 @@ import {
   buildMentionPathSections,
   commandPathsFromDefinitions,
 } from "../utils/pathMentions";
+import {
+  getChatBootstrapParams,
+  hasConsumedChatBootstrap,
+  markChatBootstrapConsumed,
+  stripChatBootstrapParams,
+} from "../utils/chatQueryParams";
 
 const stripCommandFrontmatter = (content: string) => {
   const delimiterPattern =
@@ -368,7 +374,7 @@ export const RepositoryPage: React.FC = () => {
   const { name } = useParams();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("agent");
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [repository, setRepository] = useState<RepositorySummary | null>(null);
   const [fileTree, setFileTree] = useState<FileNode | null>(null);
   const [fileActionError, setFileActionError] = useState<string | null>(null);
@@ -549,6 +555,45 @@ export const RepositoryPage: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [chat]);
+
+  useEffect(() => {
+    const { sessionId: incomingSessionId, message: incomingMessage } =
+      getChatBootstrapParams(searchParams);
+    if (!incomingSessionId && !incomingMessage) return;
+
+    const { nextParams, changed } = stripChatBootstrapParams(searchParams);
+    if (changed) {
+      setSearchParams(nextParams, { replace: true });
+    }
+
+    const path = window.location.pathname;
+    if (
+      hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
+    ) {
+      return;
+    }
+    markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
+
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+    if (incomingMessage) {
+      setPendingPrompt(incomingMessage);
+    }
+    setActiveTab("agent");
+
+    requestAnimationFrame(() => {
+      const textarea = document.getElementById(
+        chatInputId,
+      ) as HTMLTextAreaElement | null;
+      textarea?.focus();
+      textarea?.setSelectionRange(
+        textarea.value.length,
+        textarea.value.length,
+      );
+    });
+  }, [searchParams, setSearchParams, sessionId, setSessionId]);
+
   useEffect(() => {
     const tab = searchParams.get("tab");
     if (tab) {
@@ -602,6 +647,7 @@ export const RepositoryPage: React.FC = () => {
   const [movePath, setMovePath] = useState("");
   const [loadingFile, setLoadingFile] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
+  const chatInputId = "repository-agent-prompt";
 
   useEffect(() => {
     const search = splitMentionSearch(mentionQuery);
@@ -1706,6 +1752,7 @@ export const RepositoryPage: React.FC = () => {
           />
           {chatError && <div className="alert">{chatError}</div>}
           <MentionPathTextarea
+            id={chatInputId}
             value={pendingPrompt}
             onChange={setPendingPrompt}
             placeholder="Describe the change or ask the agent..."

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { marked } from "marked";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
@@ -34,10 +34,17 @@ import {
   DEFAULT_AGENT_VALUE,
 } from "../components/AgentSelector";
 import { commandPathsFromDefinitions } from "../utils/pathMentions";
+import {
+  getChatBootstrapParams,
+  hasConsumedChatBootstrap,
+  markChatBootstrapConsumed,
+  stripChatBootstrapParams,
+} from "../utils/chatQueryParams";
 
 export const TaskPage: React.FC = () => {
   const { name } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
@@ -77,6 +84,7 @@ export const TaskPage: React.FC = () => {
   const [sessionListLoading, setSessionListLoading] = useState(false);
   const [mentionCommandPaths, setMentionCommandPaths] = useState<string[]>([]);
   const chatWindowRef = useRef<HTMLDivElement>(null);
+  const chatInputId = "task-agent-prompt";
 
   const scrollToBottom = () => {
     if (chatWindowRef.current) {
@@ -87,6 +95,44 @@ export const TaskPage: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [chat]);
+
+  useEffect(() => {
+    const { sessionId: incomingSessionId, message: incomingMessage } =
+      getChatBootstrapParams(searchParams);
+    if (!incomingSessionId && !incomingMessage) return;
+
+    const { nextParams, changed } = stripChatBootstrapParams(searchParams);
+    if (changed) {
+      setSearchParams(nextParams, { replace: true });
+    }
+
+    const path = window.location.pathname;
+    if (
+      hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
+    ) {
+      return;
+    }
+    markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
+
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+    if (incomingMessage) {
+      setPrompt(incomingMessage);
+    }
+    setActiveTab("agent");
+
+    requestAnimationFrame(() => {
+      const textarea = document.getElementById(
+        chatInputId,
+      ) as HTMLTextAreaElement | null;
+      textarea?.focus();
+      textarea?.setSelectionRange(
+        textarea.value.length,
+        textarea.value.length,
+      );
+    });
+  }, [searchParams, setSearchParams, sessionId, setSessionId]);
 
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;
@@ -478,6 +524,7 @@ export const TaskPage: React.FC = () => {
                 />
                 {agentStatus && <div className="alert">{agentStatus}</div>}
                 <MentionPathTextarea
+                  id={chatInputId}
                   value={prompt}
                   onChange={setPrompt}
                   suggestions={mentionCommandPaths}

--- a/packages/frontend/src/utils/chatQueryParams.test.ts
+++ b/packages/frontend/src/utils/chatQueryParams.test.ts
@@ -1,0 +1,26 @@
+import {
+  getChatBootstrapParams,
+  stripChatBootstrapParams,
+} from "./chatQueryParams";
+import { describe, expect, it } from "vitest";
+
+describe("chatQueryParams", () => {
+  it("reads session and user message aliases", () => {
+    const params = new URLSearchParams(
+      "sid=session-123&userMessage=hello%20agent&tab=agent",
+    );
+    expect(getChatBootstrapParams(params)).toEqual({
+      sessionId: "session-123",
+      message: "hello agent",
+    });
+  });
+
+  it("removes only bootstrap parameters", () => {
+    const params = new URLSearchParams(
+      "sessionId=s1&message=hi&tab=agent&view=compact",
+    );
+    const { nextParams, changed } = stripChatBootstrapParams(params);
+    expect(changed).toBe(true);
+    expect(nextParams.toString()).toBe("tab=agent&view=compact");
+  });
+});

--- a/packages/frontend/src/utils/chatQueryParams.ts
+++ b/packages/frontend/src/utils/chatQueryParams.ts
@@ -1,0 +1,64 @@
+const SESSION_PARAM_KEYS = ["sessionId", "session", "sid"] as const;
+const MESSAGE_PARAM_KEYS = [
+  "userMessage",
+  "message",
+  "prompt",
+  "chatMessage",
+] as const;
+
+const CONSUMED_PREFIX = "made-chat-bootstrap-consumed";
+
+const getFirstValue = (
+  searchParams: URLSearchParams,
+  keys: readonly string[],
+) => {
+  for (const key of keys) {
+    const value = searchParams.get(key)?.trim();
+    if (value) return value;
+  }
+  return null;
+};
+
+export const getChatBootstrapParams = (searchParams: URLSearchParams) => ({
+  sessionId: getFirstValue(searchParams, SESSION_PARAM_KEYS),
+  message: getFirstValue(searchParams, MESSAGE_PARAM_KEYS),
+});
+
+export const stripChatBootstrapParams = (searchParams: URLSearchParams) => {
+  const nextParams = new URLSearchParams(searchParams);
+  const keys = [...SESSION_PARAM_KEYS, ...MESSAGE_PARAM_KEYS];
+  let changed = false;
+
+  keys.forEach((key) => {
+    if (nextParams.has(key)) {
+      nextParams.delete(key);
+      changed = true;
+    }
+  });
+
+  return { nextParams, changed };
+};
+
+const buildConsumedKey = (
+  pathname: string,
+  sessionId: string | null,
+  message: string | null,
+) => {
+  const normalizedSession = sessionId || "";
+  const normalizedMessage = message || "";
+  return `${CONSUMED_PREFIX}:${pathname}:${normalizedSession}:${normalizedMessage}`;
+};
+
+export const hasConsumedChatBootstrap = (
+  pathname: string,
+  sessionId: string | null,
+  message: string | null,
+) => sessionStorage.getItem(buildConsumedKey(pathname, sessionId, message)) === "1";
+
+export const markChatBootstrapConsumed = (
+  pathname: string,
+  sessionId: string | null,
+  message: string | null,
+) => {
+  sessionStorage.setItem(buildConsumedKey(pathname, sessionId, message), "1");
+};


### PR DESCRIPTION
### Motivation
- Allow deep-linking into any agent chat (repository, task, knowledge, constitution) by passing a session identifier and/or a draft user message via URL parameters so the correct chat session and composer are preselected.
- Prevent accidental double-insertion of the same draft when the page is reloaded.

### Description
- Add a small shared utility `packages/frontend/src/utils/chatQueryParams.ts` that reads session and message bootstrap params (supports aliases `sessionId|session|sid` and `userMessage|message|prompt|chatMessage`), strips them from the URL, and provides per-path/session/message consumption tracking via `sessionStorage` to avoid repeats.
- Wire the bootstrap logic into agent pages: `RepositoryPage`, `TaskPage`, `KnowledgeArtefactPage`, and `ConstitutionPage` to prefill the chat composer (without sending), optionally set the session if it differs, switch to the Agent tab, focus the textarea, and remove bootstrap query params while preserving unrelated params.
- Add `id` attributes to the chat textareas so they can be focused programmatically and ensure focus places the caret at the end of the prefilled text.
- Add unit tests `packages/frontend/src/utils/chatQueryParams.test.ts` to validate parsing and URL cleanup behavior.

### Testing
- Ran the unit test: `npm --prefix packages/frontend run test -- chatQueryParams.test.ts`, and it passed (2 tests).
- Built the frontend for production with `npm --prefix packages/frontend run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef886ac90833291b6f10fd12bd351)