### PR TITLE
feat(frontend): open markdown links externally and style as dashed underline

### DIFF
--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { marked } from "marked";
+import { renderMarkdown } from "../utils/markdown";
 import { ChatMessage } from "../types/chat";
 
 interface ChatWindowProps {
@@ -113,7 +113,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
             className="markdown"
             dangerouslySetInnerHTML={{
               __html: strippedMessage.trim()
-                ? marked(strippedMessage)
+                ? renderMarkdown(strippedMessage)
                 : "<em>Empty message</em>",
             }}
           />

--- a/packages/frontend/src/components/CommandsTab.tsx
+++ b/packages/frontend/src/components/CommandsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { marked } from "marked";
+import { renderMarkdown } from "../utils/markdown";
 import { Panel } from "./Panel";
 import { Modal } from "./Modal";
 import { CommandDefinition } from "../hooks/useApi";
@@ -411,7 +411,7 @@ export const CommandsTab: React.FC<CommandsTabProps> = ({
           <div
             className="markdown"
             dangerouslySetInnerHTML={{
-              __html: marked(commandPreviewContent),
+              __html: renderMarkdown(commandPreviewContent),
             }}
           />
         ) : (

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { marked } from "marked";
+import { renderMarkdown } from "../utils/markdown";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { ChatWindow } from "../components/ChatWindow";
@@ -484,7 +484,7 @@ export const ConstitutionPage: React.FC = () => {
           <Panel title="Preview">
             <div
               className="markdown"
-              dangerouslySetInnerHTML={{ __html: marked(content || "") }}
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content || "") }}
             />
           </Panel>
         </div>

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { marked } from "marked";
+import { renderMarkdown } from "../utils/markdown";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { ChatWindow } from "../components/ChatWindow";
@@ -502,7 +502,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
           <Panel title="Preview">
             <div
               className="markdown"
-              dangerouslySetInnerHTML={{ __html: marked(content || "") }}
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content || "") }}
             />
           </Panel>
         </div>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { marked } from "marked";
+import { renderMarkdown } from "../utils/markdown";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { Modal } from "../components/Modal";
@@ -2196,7 +2196,7 @@ export const RepositoryPage: React.FC = () => {
                 <div
                   className="markdown"
                   dangerouslySetInnerHTML={{
-                    __html: marked(editorContent || ""),
+                    __html: renderMarkdown(editorContent || ""),
                   }}
                 />
               ) : (
@@ -2393,7 +2393,7 @@ export const RepositoryPage: React.FC = () => {
           <div
             className="markdown"
             dangerouslySetInnerHTML={{
-              __html: marked(commandPreviewContent),
+              __html: renderMarkdown(commandPreviewContent),
             }}
           />
         ) : (

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { marked } from "marked";
+import { renderMarkdown } from "../utils/markdown";
 import { Panel } from "../components/Panel";
 import { TabView } from "../components/TabView";
 import { ChatWindow } from "../components/ChatWindow";
@@ -446,7 +446,7 @@ export const TaskPage: React.FC = () => {
                 <Panel title="Preview">
                   <div
                     className="markdown"
-                    dangerouslySetInnerHTML={{ __html: marked(content || "") }}
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(content || "") }}
                   />
                 </Panel>
               </div>

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -555,6 +555,13 @@ textarea {
   margin-top: 0.75rem;
 }
 
+
+.markdown a {
+  text-decoration-line: underline;
+  text-decoration-style: dashed;
+  text-underline-offset: 0.18em;
+}
+
 .chat-message .markdown p:first-child {
   margin-top: 0;
 }

--- a/packages/frontend/src/utils/markdown.test.ts
+++ b/packages/frontend/src/utils/markdown.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { renderMarkdown } from "./markdown";
+
+describe("renderMarkdown", () => {
+  it("adds attributes so markdown links open in a new tab", () => {
+    const html = renderMarkdown("[OpenAI](https://openai.com)");
+
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("keeps existing link attributes from inline html", () => {
+    const html = renderMarkdown(
+      '<a href="https://example.com" target="_self" rel="bookmark">Example</a>',
+    );
+
+    expect(html).toContain('target="_self"');
+    expect(html).toContain('rel="bookmark"');
+  });
+});

--- a/packages/frontend/src/utils/markdown.ts
+++ b/packages/frontend/src/utils/markdown.ts
@@ -1,0 +1,26 @@
+import { marked } from "marked";
+
+const addExternalLinkAttributes = (html: string) =>
+  html.replace(/<a\s+([^>]*?)>/g, (_, attributes: string) => {
+    let updatedAttributes = attributes;
+
+    if (!/\btarget\s*=/.test(updatedAttributes)) {
+      updatedAttributes += ' target="_blank"';
+    }
+
+    if (!/\brel\s*=/.test(updatedAttributes)) {
+      updatedAttributes += ' rel="noopener noreferrer"';
+    }
+
+    return `<a ${updatedAttributes}>`;
+  });
+
+marked.use({
+  hooks: {
+    postprocess(html) {
+      return addExternalLinkAttributes(html);
+    },
+  },
+});
+
+export const renderMarkdown = (content: string) => marked(content) as string;


### PR DESCRIPTION
### Motivation
- Ensure Markdown links open in a new window/tab by default for a safer UX and consistent external-link behavior.
- Centralize markdown rendering so link attribute injection is applied consistently across chat, previews and editors.
- Improve visual affordance for links inside rendered Markdown by adding a dashed underline style.

### Description
- Add a shared `renderMarkdown` utility (`packages/frontend/src/utils/markdown.ts`) that post-processes generated HTML and injects `target="_blank"` and `rel="noopener noreferrer"` on `<a>` tags when not already present.
- Replace direct `marked(...)` calls with `renderMarkdown(...)` in chat, command previews and Markdown preview/editors (updated call sites in `ChatWindow`, `CommandsTab`, `RepositoryPage`, `ConstitutionPage`, `KnowledgeArtefactPage`, `TaskPage`).
- Add CSS rule in `packages/frontend/src/styles/index.css` to render links inside `.markdown` with `text-decoration-style: dashed` and a small underline offset.
- Add unit tests for `renderMarkdown` at `packages/frontend/src/utils/markdown.test.ts` to verify attribute injection and preservation of existing link attributes.

### Testing
- Ran `npm run test --prefix packages/frontend -- markdown.test.ts`, which completed successfully (`2 passed`).
- Ran `npm run lint --prefix packages/frontend`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24e8dd7f48332a42b8b3c8c5a193a)