### PR TITLE
Ensure incoming chat `sessionId` is set before bootstrap-consumed check

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -124,6 +124,10 @@ export const ConstitutionPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -131,10 +135,6 @@ export const ConstitutionPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPrompt(incomingMessage);
     }

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -122,6 +122,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -129,10 +133,6 @@ export const KnowledgeArtefactPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPrompt(incomingMessage);
     }

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -566,6 +566,10 @@ export const RepositoryPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -573,10 +577,6 @@ export const RepositoryPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPendingPrompt(incomingMessage);
     }

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -106,6 +106,10 @@ export const TaskPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+    }
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -113,10 +117,6 @@ export const TaskPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPrompt(incomingMessage);
     }


### PR DESCRIPTION
### Motivation
- The chat bootstrap flow should use the incoming `sessionId` when determining whether bootstrap params have already been consumed for the current path, so the check must see the updated session id.

### Description
- Moved the `setSessionId(incomingSessionId)` call to occur immediately after parsing bootstrap params and before the `hasConsumedChatBootstrap` check in four pages (`ConstitutionPage`, `KnowledgeArtefactPage`, `RepositoryPage`, `TaskPage`).
- Removed the duplicate `setSessionId` call that previously ran after `markChatBootstrapConsumed` in each page.
- No other behavioral changes were introduced; the prompt/session handling and focus logic remains unchanged.

### Testing
- Ran TypeScript typecheck with `tsc --noEmit` and there were no type errors. 
- Ran linting with `yarn lint` and the code passed lint rules. 
- Ran unit tests with `yarn test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2587d1cf483328ffdde22a5f2f076)