### PR TITLE
Load chat session history from bootstrap params and handle session switching for agent pages

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -115,6 +115,7 @@ export const ConstitutionPage: React.FC = () => {
   }, [chat]);
 
   useEffect(() => {
+    if (!name) return;
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
@@ -124,6 +125,35 @@ export const ConstitutionPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    const switchSessionIfNeeded = async () => {
+      if (!incomingSessionId || incomingSessionId === sessionId) {
+        return;
+      }
+
+      setSessionId(incomingSessionId);
+      setChat([]);
+      setChatLoading(true);
+      try {
+        const history = await api.getConstitutionAgentHistory(
+          name,
+          incomingSessionId,
+        );
+        const mapped = mapHistoryToMessages(history.messages || []);
+        setChat(mapped);
+        setAgentStatus(null);
+      } catch (error) {
+        console.error("Failed to load session history", error);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load session history";
+        setAgentStatus(message);
+      } finally {
+        setChatLoading(false);
+      }
+    };
+    void switchSessionIfNeeded();
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -131,10 +161,6 @@ export const ConstitutionPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPrompt(incomingMessage);
     }
@@ -150,7 +176,7 @@ export const ConstitutionPage: React.FC = () => {
         textarea.value.length,
       );
     });
-  }, [searchParams, setSearchParams, sessionId, setSessionId]);
+  }, [api, name, searchParams, sessionId, setSearchParams, setSessionId]);
 
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -113,6 +113,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   }, [chat]);
 
   useEffect(() => {
+    if (!name) return;
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
@@ -122,6 +123,35 @@ export const KnowledgeArtefactPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    const switchSessionIfNeeded = async () => {
+      if (!incomingSessionId || incomingSessionId === sessionId) {
+        return;
+      }
+
+      setSessionId(incomingSessionId);
+      setChat([]);
+      setChatLoading(true);
+      try {
+        const history = await api.getKnowledgeAgentHistory(
+          name,
+          incomingSessionId,
+        );
+        const mapped = mapHistoryToMessages(history.messages || []);
+        setChat(mapped);
+        setAgentStatus(null);
+      } catch (error) {
+        console.error("Failed to load session history", error);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load session history";
+        setAgentStatus(message);
+      } finally {
+        setChatLoading(false);
+      }
+    };
+    void switchSessionIfNeeded();
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -129,10 +159,6 @@ export const KnowledgeArtefactPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPrompt(incomingMessage);
     }
@@ -148,7 +174,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
         textarea.value.length,
       );
     });
-  }, [searchParams, setSearchParams, sessionId, setSessionId]);
+  }, [api, name, searchParams, sessionId, setSearchParams, setSessionId]);
 
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -566,6 +566,11 @@ export const RepositoryPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    if (incomingSessionId && incomingSessionId !== sessionId) {
+      setSessionId(incomingSessionId);
+      setChat([]);
+    }
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -573,10 +578,6 @@ export const RepositoryPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPendingPrompt(incomingMessage);
     }

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -97,6 +97,7 @@ export const TaskPage: React.FC = () => {
   }, [chat]);
 
   useEffect(() => {
+    if (!name) return;
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
@@ -106,6 +107,32 @@ export const TaskPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
+    const switchSessionIfNeeded = async () => {
+      if (!incomingSessionId || incomingSessionId === sessionId) {
+        return;
+      }
+
+      setSessionId(incomingSessionId);
+      setChat([]);
+      setChatLoading(true);
+      try {
+        const history = await api.getTaskAgentHistory(name, incomingSessionId);
+        const mapped = mapHistoryToMessages(history.messages || []);
+        setChat(mapped);
+        setAgentStatus(null);
+      } catch (error) {
+        console.error("Failed to load session history", error);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load session history";
+        setAgentStatus(message);
+      } finally {
+        setChatLoading(false);
+      }
+    };
+    void switchSessionIfNeeded();
+
     const path = window.location.pathname;
     if (
       hasConsumedChatBootstrap(path, incomingSessionId, incomingMessage)
@@ -113,10 +140,6 @@ export const TaskPage: React.FC = () => {
       return;
     }
     markChatBootstrapConsumed(path, incomingSessionId, incomingMessage);
-
-    if (incomingSessionId && incomingSessionId !== sessionId) {
-      setSessionId(incomingSessionId);
-    }
     if (incomingMessage) {
       setPrompt(incomingMessage);
     }
@@ -132,7 +155,7 @@ export const TaskPage: React.FC = () => {
         textarea.value.length,
       );
     });
-  }, [searchParams, setSearchParams, sessionId, setSessionId]);
+  }, [api, name, searchParams, sessionId, setSearchParams, setSessionId]);
 
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;


### PR DESCRIPTION
### Motivation
- Ensure URL chat bootstrap parameters (`sessionId` / `message`) trigger a proper session switch and load prior chat history for agent pages instead of only setting session id.
- Prevent bootstrap handling from running before the matter `name` is available and ensure repository page clears chat when switching sessions.

### Description
- Added an early guard `if (!name) return;` in the chat bootstrap effect to avoid acting before the matter name is resolved.
- Introduced `switchSessionIfNeeded` async logic in `ConstitutionPage`, `KnowledgeArtefactPage`, and `TaskPage` to fetch session history via `api.get*AgentHistory`, map messages with `mapHistoryToMessages`, set the chat, manage `chatLoading`, and surface errors to `agentStatus` when loading fails.
- Updated `RepositoryPage` to clear the chat and set `sessionId` immediately when an incoming `sessionId` differs from the current `sessionId`.
- Added `api` and `name` to the effect dependency arrays so the effect uses current values and avoids stale closures.

### Testing
- Ran the TypeScript build with `yarn build` which completed successfully.
- Executed the frontend test suite with `yarn test` and all tests passed.
- Linted the codebase with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2587d1cf483328ffdde22a5f2f076)