### PR TITLE
Fix repository chat bootstrap session switching

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -119,6 +119,7 @@ export const ConstitutionPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
+    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
@@ -138,10 +139,12 @@ export const ConstitutionPage: React.FC = () => {
           name,
           incomingSessionId,
         );
+        if (cancelled) return;
         const mapped = mapHistoryToMessages(history.messages || []);
         setChat(mapped);
         setAgentStatus(null);
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to load session history", error);
         const message =
           error instanceof Error
@@ -149,6 +152,7 @@ export const ConstitutionPage: React.FC = () => {
             : "Failed to load session history";
         setAgentStatus(message);
       } finally {
+        if (cancelled) return;
         setChatLoading(false);
       }
     };
@@ -176,6 +180,10 @@ export const ConstitutionPage: React.FC = () => {
         textarea.value.length,
       );
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [api, name, searchParams, sessionId, setSearchParams, setSessionId]);
 
   const copyAllMessages = useCallback(() => {

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -117,6 +117,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
+    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
@@ -136,10 +137,12 @@ export const KnowledgeArtefactPage: React.FC = () => {
           name,
           incomingSessionId,
         );
+        if (cancelled) return;
         const mapped = mapHistoryToMessages(history.messages || []);
         setChat(mapped);
         setAgentStatus(null);
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to load session history", error);
         const message =
           error instanceof Error
@@ -147,6 +150,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
             : "Failed to load session history";
         setAgentStatus(message);
       } finally {
+        if (cancelled) return;
         setChatLoading(false);
       }
     };
@@ -174,6 +178,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
         textarea.value.length,
       );
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [api, name, searchParams, sessionId, setSearchParams, setSessionId]);
 
   const copyAllMessages = useCallback(() => {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -560,6 +560,7 @@ export const RepositoryPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
+    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
@@ -579,10 +580,12 @@ export const RepositoryPage: React.FC = () => {
           name,
           incomingSessionId,
         );
+        if (cancelled) return;
         const mapped = mapHistoryToMessages(history.messages || []);
         setChat(mapped);
         setChatError(null);
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to load session history", error);
         const message =
           error instanceof Error
@@ -590,6 +593,7 @@ export const RepositoryPage: React.FC = () => {
             : "Failed to load session history";
         setChatError(message);
       } finally {
+        if (cancelled) return;
         setChatLoading(false);
       }
     };
@@ -617,6 +621,10 @@ export const RepositoryPage: React.FC = () => {
         textarea.value.length,
       );
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     api,
     name,

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -566,10 +566,34 @@ export const RepositoryPage: React.FC = () => {
       setSearchParams(nextParams, { replace: true });
     }
 
-    if (incomingSessionId && incomingSessionId !== sessionId) {
+    const switchSessionIfNeeded = async () => {
+      if (!name || !incomingSessionId || incomingSessionId === sessionId) {
+        return;
+      }
+
       setSessionId(incomingSessionId);
       setChat([]);
-    }
+      setChatLoading(true);
+      try {
+        const history = await api.getRepositoryAgentHistory(
+          name,
+          incomingSessionId,
+        );
+        const mapped = mapHistoryToMessages(history.messages || []);
+        setChat(mapped);
+        setChatError(null);
+      } catch (error) {
+        console.error("Failed to load session history", error);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load session history";
+        setChatError(message);
+      } finally {
+        setChatLoading(false);
+      }
+    };
+    void switchSessionIfNeeded();
 
     const path = window.location.pathname;
     if (
@@ -593,7 +617,14 @@ export const RepositoryPage: React.FC = () => {
         textarea.value.length,
       );
     });
-  }, [searchParams, setSearchParams, sessionId, setSessionId]);
+  }, [
+    api,
+    name,
+    searchParams,
+    sessionId,
+    setSearchParams,
+    setSessionId,
+  ]);
 
   useEffect(() => {
     const tab = searchParams.get("tab");

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -101,6 +101,7 @@ export const TaskPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
+    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
@@ -117,10 +118,12 @@ export const TaskPage: React.FC = () => {
       setChatLoading(true);
       try {
         const history = await api.getTaskAgentHistory(name, incomingSessionId);
+        if (cancelled) return;
         const mapped = mapHistoryToMessages(history.messages || []);
         setChat(mapped);
         setAgentStatus(null);
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to load session history", error);
         const message =
           error instanceof Error
@@ -128,6 +131,7 @@ export const TaskPage: React.FC = () => {
             : "Failed to load session history";
         setAgentStatus(message);
       } finally {
+        if (cancelled) return;
         setChatLoading(false);
       }
     };
@@ -155,6 +159,10 @@ export const TaskPage: React.FC = () => {
         textarea.value.length,
       );
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [api, name, searchParams, sessionId, setSearchParams, setSessionId]);
 
   const copyAllMessages = useCallback(() => {


### PR DESCRIPTION
### Motivation
- URLs with `?session=...` could show the new session ID but keep a different conversation history when another session was already loaded. 
- The change aims to make session switches deterministic and immediate by loading the referenced session history right away.

### Description
- Replace the previous one-line session-id update with an async `switchSessionIfNeeded` that loads history via `api.getRepositoryAgentHistory` and maps it into chat messages.  
- Clear stale chat (`setChat([])`) and set `chatLoading` while loading, and surface load failures in `chatError`.  
- Keep existing bootstrap flow (strip query params, focus input, set pending prompt, set active tab, consumed-marking) intact.  
- Add `api` and `name` to the `useEffect` dependency list for correct reactive behavior.

### Testing
- Ran unit tests `npm --prefix packages/frontend test -- src/utils/chatQueryParams.test.ts` and they passed.  
- Ran frontend build `npm --prefix packages/frontend run build` which completed successfully (build warnings about chunk size only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2630ab3348332b800c5a39e9d6b39)