### PR TITLE
Support repository-level agentCli override from local .made/settings.json

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -35,10 +35,10 @@ REGISTERED_AGENT_CLI_CLASSES: tuple[type[AgentCLI], ...] = (
 )
 
 
-def get_agent_cli():
+def get_agent_cli(context_path: Path | None = None):
     """Get the appropriate AgentCLI implementation based on settings."""
     try:
-        settings = read_settings()
+        settings = read_settings(context_path)
         agent_cli_setting = settings.get("agentCli", "opencode")
 
         if agent_cli_setting == "kiro":
@@ -336,7 +336,7 @@ def export_chat_history(
     )
 
     # Use typed interface
-    agent_cli = get_agent_cli()
+    agent_cli = get_agent_cli(working_dir)
     start_time = time.monotonic()
     result = agent_cli.export_session(session_id, working_dir)
     duration_seconds = time.monotonic() - start_time
@@ -382,7 +382,7 @@ def list_chat_sessions(
         limit,
     )
 
-    agent_cli = get_agent_cli()
+    agent_cli = get_agent_cli(working_dir)
     start_time = time.monotonic()
     result = agent_cli.list_sessions(working_dir)
     duration_seconds = time.monotonic() - start_time
@@ -428,7 +428,7 @@ def list_agents(repository_name: str | None = None) -> list[dict[str, object]]:
             else None
         )
 
-    agent_cli = get_agent_cli()
+    agent_cli = get_agent_cli(list_cwd)
     start_time = time.monotonic()
     result = agent_cli.list_agents(cwd=list_cwd)
     duration_seconds = time.monotonic() - start_time
@@ -512,7 +512,7 @@ def send_agent_message(
             response = "Agent request cancelled."
         else:
             # Use typed interface
-            agent_cli = get_agent_cli()
+            agent_cli = get_agent_cli(working_dir)
             start_time = time.monotonic()
             resolved_model = model if model and model != "default" else None
             result = agent_cli.run_agent(
@@ -553,7 +553,7 @@ def send_agent_message(
                 )
 
     except FileNotFoundError:
-        response = get_agent_cli().missing_command_error()
+        response = get_agent_cli(working_dir).missing_command_error()
         logger.error("Agent command not found for channel %s", channel)
 
         # Return error immediately - no process to poll

--- a/packages/pybackend/settings_service.py
+++ b/packages/pybackend/settings_service.py
@@ -11,13 +11,29 @@ def get_settings_path() -> Path:
     return made_dir / SETTINGS_FILE
 
 
-def read_settings():
-    settings_path = get_settings_path()
+def _default_settings() -> dict[str, str]:
+    return {
+        # Supported values: "opencode", "opencode-legacy", "kiro", "copilot", "codex", "ob1"
+        "agentCli": "opencode",
+    }
+
+
+def _repository_settings_path(context_path: Path | None) -> Path | None:
+    if context_path is None:
+        return None
+
+    resolved_context = context_path.resolve()
+    if resolved_context.is_file():
+        resolved_context = resolved_context.parent
+
+    candidate = resolved_context / ".made" / SETTINGS_FILE
+    return candidate if candidate.exists() else None
+
+
+def read_settings(context_path: Path | None = None):
+    settings_path = _repository_settings_path(context_path) or get_settings_path()
     if not settings_path.exists():
-        defaults = {
-            # Supported values: "opencode", "opencode-legacy", "kiro", "copilot", "codex", "ob1"
-            "agentCli": "opencode",
-        }
+        defaults = _default_settings()
         settings_path.write_text(json.dumps(defaults, indent=2), encoding="utf-8")
         return defaults
     return json.loads(settings_path.read_text(encoding="utf-8"))

--- a/packages/pybackend/tests/unit/test_agent_cli_setting.py
+++ b/packages/pybackend/tests/unit/test_agent_cli_setting.py
@@ -115,6 +115,40 @@ class TestAgentCliSetting(unittest.TestCase):
                 cli = get_agent_cli()
                 self.assertIsInstance(cli, OpenCodeDatabaseAgentCLI)
 
+    def test_repository_settings_override_global_agent_cli(self):
+        """Test repository-level .made/settings.json overrides global settings."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            repo_path = root / "repo"
+            (repo_path / ".made").mkdir(parents=True)
+            local_settings = repo_path / ".made" / "settings.json"
+            local_settings.write_text(json.dumps({"agentCli": "kiro"}))
+
+            global_settings = root / "global-settings.json"
+            global_settings.write_text(json.dumps({"agentCli": "opencode"}))
+
+            with patch(
+                "settings_service.get_settings_path", return_value=global_settings
+            ):
+                cli = get_agent_cli(repo_path)
+                self.assertIsInstance(cli, KiroAgentCLI)
+
+    def test_global_settings_used_when_repository_override_missing(self):
+        """Test global settings are used when repository-level settings are absent."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            repo_path = root / "repo"
+            repo_path.mkdir(parents=True)
+
+            global_settings = root / "global-settings.json"
+            global_settings.write_text(json.dumps({"agentCli": "copilot"}))
+
+            with patch(
+                "settings_service.get_settings_path", return_value=global_settings
+            ):
+                cli = get_agent_cli(repo_path)
+                self.assertIsInstance(cli, CopilotAgentCLI)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- The agent CLI was always resolved from the global `.made/settings.json`, but repository-specific workflows need to override the CLI on a per-project basis.
- We need the backend to honor a `<repo>/.made/settings.json` when running repository-scoped operations so the selected CLI reflects project configuration.

### Description
- Add repository-aware settings lookup in `packages/pybackend/settings_service.py` with `_repository_settings_path`, `_default_settings`, and `read_settings(context_path)` which prefers `<context>/.made/settings.json` when present.
- Update `get_agent_cli` in `packages/pybackend/agent_service.py` to accept an optional `context_path` and use `read_settings(context_path)` to select the appropriate `AgentCLI` implementation.
- Pass the repository/workspace working directory into `get_agent_cli` for repository-scoped operations (chat export, session listing, agent listing, message execution) and use it when composing missing-command errors.
- Add unit tests in `packages/pybackend/tests/unit/test_agent_cli_setting.py` to verify repository-local override precedence and global fallback behavior.

### Testing
- Ran the project QA quick suite with `make qa-quick`, which includes formatting, linting, frontend checks, and backend unit tests, and it completed successfully.
- Backend unit tests were executed (`uv run pytest -c pytest.cov.ini tests/unit/`) and all tests passed (346 passed, 1 skipped). 
- Linters/formatters (`prettier`, `ruff`, `eslint`) also ran as part of `make qa-quick` with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52054ac208332b65dfa5e663d924b)