### PR TITLE
Add `claude` to agent CLI options in Settings

### DIFF
--- a/packages/frontend/src/pages/SettingsPage.tsx
+++ b/packages/frontend/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ const agentCliOptions = [
   "copilot",
   "codex",
   "ob1",
+  "claude",
 ];
 
 export const SettingsPage: React.FC = () => {


### PR DESCRIPTION
### Motivation
- The settings UI did not include `claude` in the `agentCli` selector even though the backend supports `agentCli: "claude"`, preventing users from choosing that option in the frontend.

### Description
- Add `"claude"` to the `agentCliOptions` array in `packages/frontend/src/pages/SettingsPage.tsx` so the Settings dropdown includes the Claude option.

### Testing
- Ran `make qa-quick`, which performed formatting, linting, frontend checks and backend unit tests, and completed successfully (frontend format/lint passed and backend unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5256e94f4833299063dc266ca993b)