### PR TITLE
Make agent history export resilient to invalid session IDs

### DIFF
--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import signal
 import subprocess
 import time
@@ -131,6 +132,7 @@ def _is_missing_session_error(error_message: str | None) -> bool:
         "session file not found" in normalized
         or "session not found" in normalized
         or "no such session" in normalized
+        or bool(re.search(r"\bsession\b.*\bnot found\b", normalized))
     )
 
 
@@ -364,6 +366,14 @@ def export_chat_history(
     )
 
     if not result.success:
+        if _is_missing_session_error(result.error_message):
+            logger.warning(
+                "Chat history requested for unknown session (channel: %s, session: %s); returning empty history",
+                channel or "<unspecified>",
+                session_id,
+            )
+            return {"sessionId": session_id, "messages": []}
+
         logger.error(
             "Exporting chat history failed (channel: %s, session: %s): %s",
             channel or "<unspecified>",
@@ -372,8 +382,6 @@ def export_chat_history(
         )
         if "command not found" in (result.error_message or ""):
             raise FileNotFoundError(result.error_message)
-        if _is_missing_session_error(result.error_message):
-            raise FileNotFoundError(result.error_message or "Session not found")
         raise RuntimeError(result.error_message or "Failed to export session history")
 
     # Filter messages by start timestamp if provided

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -429,8 +429,8 @@ class TestAgentService:
             list_chat_sessions("test-repo", limit=5)
 
     @patch("agent_service.get_agent_cli")
-    def test_export_chat_history_missing_session_raises_not_found(self, mock_get_cli):
-        """Test missing sessions are mapped to FileNotFoundError."""
+    def test_export_chat_history_missing_session_returns_empty(self, mock_get_cli):
+        """Test missing sessions return an empty history payload."""
         from agent_service import export_chat_history
         from agent_results import ExportResult
 
@@ -443,8 +443,32 @@ class TestAgentService:
             error_message="Session file not found for ID: 1",
         )
 
-        with pytest.raises(FileNotFoundError, match="Session file not found"):
-            export_chat_history("1", None, "test-repo")
+        assert export_chat_history("1", None, "test-repo") == {
+            "sessionId": "1",
+            "messages": [],
+        }
+
+    @patch("agent_service.get_agent_cli")
+    def test_export_chat_history_missing_session_with_directory_error_returns_empty(
+        self, mock_get_cli
+    ):
+        """Treat session-not-found variants as empty history."""
+        from agent_service import export_chat_history
+        from agent_results import ExportResult
+
+        mock_cli = Mock()
+        mock_get_cli.return_value = mock_cli
+        mock_cli.export_session.return_value = ExportResult(
+            success=False,
+            session_id="1",
+            messages=[],
+            error_message="Session 1 not found in directory /tmp/repo",
+        )
+
+        assert export_chat_history("1", None, "test-repo") == {
+            "sessionId": "1",
+            "messages": [],
+        }
 
     def test_parse_agent_list_includes_details(self):
         """Parse agent list output including detail lines."""


### PR DESCRIPTION
### Motivation
- Calls to `export_chat_history` were raising 500 errors when the agent CLI reported various "session not found" messages, causing failures for stale or incorrect `session_id` values during history polling or manual loads.

### Description
- Broadened missing-session detection in `_is_missing_session_error` to include variants like "Session 1 not found in directory ..." using a regex match.  
- Made `export_chat_history` defensive by returning an empty history payload (`{"sessionId": session_id, "messages": []}`) when a missing-session error is detected instead of raising an exception.  
- Added/updated unit tests in `packages/pybackend/tests/unit/test_unit.py` to assert the empty-history behavior for both standard and directory-style missing-session error messages.  
- Added the `re` import to `packages/pybackend/agent_service.py` to support the new regex-based detection.

### Testing
- Ran `make qa-quick` which completed successfully and reported the full test suite result (`375 passed, 1 skipped`).  
- Ran focused pytest `cd packages/pybackend && uv run pytest tests/unit/test_unit.py -k "export_chat_history_missing_session"` which passed (`2 passed`).  
- Ran linter/formatter checks with `uv run ruff check agent_service.py tests/unit/test_unit.py` which passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e659fb987c8332a88f9a6aba27ebfd)