### PR TITLE
Add saved session controls to agent chat and session picker

### DIFF
--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { renderMarkdown } from "../utils/markdown";
 import { ChatMessage } from "../types/chat";
+import { SaveIcon } from "./icons/SaveIcon";
+import { TrashIcon } from "./icons/TrashIcon";
 
 interface ChatWindowProps {
   chat: ChatMessage[];
@@ -9,6 +11,8 @@ interface ChatWindowProps {
   emptyMessage: string;
   sessionId?: string | null;
   onClearSession?: () => void;
+  onSaveSession?: () => void;
+  isSessionSaved?: boolean;
 }
 
 const formatTimestamp = (message: ChatMessage) => {
@@ -61,28 +65,6 @@ const CopyIcon: React.FC = () => (
   </svg>
 );
 
-const TrashIcon: React.FC = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-    focusable="false"
-  >
-    <path d="M3 6h18" />
-    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
-    <path d="M10 11v6" />
-    <path d="M14 11v6" />
-  </svg>
-);
-
 export const ChatWindow: React.FC<ChatWindowProps> = ({
   chat,
   chatWindowRef,
@@ -90,6 +72,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   emptyMessage,
   sessionId,
   onClearSession,
+  onSaveSession,
+  isSessionSaved,
 }) => (
   <div className="chat-window" ref={chatWindowRef}>
     {chat.map((message) => {
@@ -132,6 +116,16 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     {sessionId && (
       <div className="chat-session-id" aria-label="Session ID">
         <span>Session ID: {sessionId}</span>
+        <button
+          type="button"
+          className="icon-button-small"
+          aria-label={isSessionSaved ? "Session saved" : "Save session"}
+          title={isSessionSaved ? "Session already saved" : "Save session"}
+          onClick={onSaveSession}
+          disabled={!onSaveSession || isSessionSaved}
+        >
+          <SaveIcon />
+        </button>
         <button
           type="button"
           className="icon-button-small"

--- a/packages/frontend/src/components/SessionPickerModal.tsx
+++ b/packages/frontend/src/components/SessionPickerModal.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { ChatSession } from "../hooks/useApi";
 import { Modal } from "./Modal";
+import { TrashIcon } from "./icons/TrashIcon";
 
 interface SessionPickerModalProps {
   open: boolean;
   loading: boolean;
   error: string | null;
   sessions: ChatSession[];
+  savedSessionIds: string[];
   onClose: () => void;
   onSelect: (session: ChatSession) => void;
+  onRemoveSavedSession: (sessionId: string) => void;
 }
 
 export const SessionPickerModal: React.FC<SessionPickerModalProps> = ({
@@ -16,27 +19,63 @@ export const SessionPickerModal: React.FC<SessionPickerModalProps> = ({
   loading,
   error,
   sessions,
+  savedSessionIds,
   onClose,
   onSelect,
+  onRemoveSavedSession,
 }) => {
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+  const savedSessions = savedSessionIds
+    .map(
+      (id) =>
+        sessionById.get(id) || {
+          id,
+          title: "Saved session",
+          updated: "Not in recent sessions",
+        },
+    )
+    .filter(
+      (session, index, list) =>
+        list.findIndex((candidate) => candidate.id === session.id) === index,
+    );
+  const regularSessions = sessions.filter(
+    (session) => !savedSessionIds.includes(session.id),
+  );
+
+  const renderSessionPill = (session: ChatSession, allowRemove = false) => (
+    <div key={session.id} className="session-pill">
+      <button
+        type="button"
+        className="session-pill-select"
+        onClick={() => onSelect(session)}
+      >
+        <span className="session-pill-id">{session.id}</span>
+        <span className="session-pill-title">{session.title}</span>
+        <span className="session-pill-date">{session.updated}</span>
+      </button>
+      {allowRemove && (
+        <button
+          type="button"
+          className="icon-button-small session-pill-remove"
+          aria-label={`Remove saved session ${session.id}`}
+          title="Remove saved session"
+          onClick={() => onRemoveSavedSession(session.id)}
+        >
+          <TrashIcon />
+        </button>
+      )}
+    </div>
+  );
+
   return (
     <Modal open={open} title="Choose a session" onClose={onClose}>
       {loading && <p>Loading sessions...</p>}
       {error && <div className="alert">{error}</div>}
       {!loading && (
         <div className="session-list">
-          {sessions.map((session) => (
-            <button
-              key={session.id}
-              className="session-pill"
-              onClick={() => onSelect(session)}
-            >
-              <span className="session-pill-id">{session.id}</span>
-              <span className="session-pill-title">{session.title}</span>
-              <span className="session-pill-date">{session.updated}</span>
-            </button>
-          ))}
-          {!sessions.length && !error && (
+          {savedSessions.map((session) => renderSessionPill(session, true))}
+          {regularSessions.map((session) => renderSessionPill(session))}
+          {!savedSessions.length && !regularSessions.length && !error && (
             <p className="muted">No sessions available.</p>
           )}
         </div>

--- a/packages/frontend/src/hooks/usePersistentStringList.ts
+++ b/packages/frontend/src/hooks/usePersistentStringList.ts
@@ -1,0 +1,42 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+const readStringList = (storageKey: string): string[] => {
+  try {
+    const value = localStorage.getItem(storageKey);
+    if (!value) return [];
+
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch (error) {
+    console.warn("Failed to read string list from localStorage", error);
+    return [];
+  }
+};
+
+export const usePersistentStringList = (
+  storageKey: string,
+): [string[], Dispatch<SetStateAction<string[]>>] => {
+  const [value, setValue] = useState<string[]>(() =>
+    readStringList(storageKey),
+  );
+
+  useEffect(() => {
+    setValue(readStringList(storageKey));
+  }, [storageKey]);
+
+  useEffect(() => {
+    try {
+      if (value.length) {
+        localStorage.setItem(storageKey, JSON.stringify(value));
+      } else {
+        localStorage.removeItem(storageKey);
+      }
+    } catch (error) {
+      console.warn("Failed to persist string list to localStorage", error);
+    }
+  }, [storageKey, value]);
+
+  return [value, setValue];
+};

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -15,6 +15,7 @@ import { CommandsTab } from "../components/CommandsTab";
 import { HarnessesTab } from "../components/HarnessesTab";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { usePersistentStringList } from "../hooks/usePersistentStringList";
 import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
@@ -67,6 +68,13 @@ export const ConstitutionPage: React.FC = () => {
         : `constitution-session-${agentCli}`,
     [agentCli, name],
   );
+  const savedSessionStorageKey = useMemo(
+    () =>
+      name
+        ? `constitution-saved-sessions-${name}-${agentCli}`
+        : `constitution-saved-sessions-${agentCli}`,
+    [agentCli, name],
+  );
   const harnessHistoryStorageKey = useMemo(
     () =>
       name
@@ -80,6 +88,9 @@ export const ConstitutionPage: React.FC = () => {
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
+    savedSessionStorageKey,
+  );
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
@@ -440,6 +451,22 @@ export const ConstitutionPage: React.FC = () => {
     }
   };
 
+  const handleSaveSession = useCallback(() => {
+    if (!sessionId) return;
+    setSavedSessionIds((previous) =>
+      previous.includes(sessionId) ? previous : [sessionId, ...previous],
+    );
+  }, [sessionId, setSavedSessionIds]);
+
+  const handleRemoveSavedSession = useCallback(
+    (savedId: string) => {
+      setSavedSessionIds((previous) =>
+        previous.filter((session) => session !== savedId),
+      );
+    },
+    [setSavedSessionIds],
+  );
+
   const loadCommands = useCallback(async () => {
     const response = await api.getCommands();
     const commands = response.commands || [];
@@ -591,6 +618,10 @@ export const ConstitutionPage: React.FC = () => {
               emptyMessage="Start a conversation to discuss this constitution."
               sessionId={sessionId}
               onClearSession={() => setClearSessionModalOpen(true)}
+              onSaveSession={handleSaveSession}
+              isSessionSaved={Boolean(
+                sessionId && savedSessionIds.includes(sessionId),
+              )}
             />
             {agentStatus && <div className="alert">{agentStatus}</div>}
             <MentionPathTextarea
@@ -691,8 +722,10 @@ export const ConstitutionPage: React.FC = () => {
         loading={sessionListLoading}
         error={sessionListError}
         sessions={sessionOptions}
+        savedSessionIds={savedSessionIds}
         onClose={() => setSessionModalOpen(false)}
         onSelect={handleSessionSelect}
+        onRemoveSavedSession={handleRemoveSavedSession}
       />
     </div>
   );

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -15,6 +15,7 @@ import { CommandsTab } from "../components/CommandsTab";
 import { HarnessesTab } from "../components/HarnessesTab";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { usePersistentStringList } from "../hooks/usePersistentStringList";
 import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
@@ -67,6 +68,13 @@ export const KnowledgeArtefactPage: React.FC = () => {
         : `knowledge-session-${agentCli}`,
     [agentCli, name],
   );
+  const savedSessionStorageKey = useMemo(
+    () =>
+      name
+        ? `knowledge-saved-sessions-${name}-${agentCli}`
+        : `knowledge-saved-sessions-${agentCli}`,
+    [agentCli, name],
+  );
   const harnessHistoryStorageKey = useMemo(
     () =>
       name ? `knowledge-harness-history-${name}` : "knowledge-harness-history",
@@ -78,6 +86,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
+    savedSessionStorageKey,
+  );
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
@@ -438,6 +449,22 @@ export const KnowledgeArtefactPage: React.FC = () => {
     }
   };
 
+  const handleSaveSession = useCallback(() => {
+    if (!sessionId) return;
+    setSavedSessionIds((previous) =>
+      previous.includes(sessionId) ? previous : [sessionId, ...previous],
+    );
+  }, [sessionId, setSavedSessionIds]);
+
+  const handleRemoveSavedSession = useCallback(
+    (savedId: string) => {
+      setSavedSessionIds((previous) =>
+        previous.filter((session) => session !== savedId),
+      );
+    },
+    [setSavedSessionIds],
+  );
+
   const tags = Array.isArray(frontmatter.tags)
     ? (frontmatter.tags as string[]).join(", ")
     : "";
@@ -606,6 +633,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
             emptyMessage="Start a conversation to collaborate with agents."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}
+            onSaveSession={handleSaveSession}
+            isSessionSaved={Boolean(
+              sessionId && savedSessionIds.includes(sessionId),
+            )}
           />
           {agentStatus && <div className="alert">{agentStatus}</div>}
           <MentionPathTextarea
@@ -710,8 +741,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
         loading={sessionListLoading}
         error={sessionListError}
         sessions={sessionOptions}
+        savedSessionIds={savedSessionIds}
         onClose={() => setSessionModalOpen(false)}
         onSelect={handleSessionSelect}
+        onRemoveSavedSession={handleRemoveSavedSession}
       />
     </div>
   );

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "../components/AgentSelector";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { usePersistentStringList } from "../hooks/usePersistentStringList";
 import { useAgentCli } from "../hooks/useAgentCli";
 import {
   api,
@@ -391,6 +392,13 @@ export const RepositoryPage: React.FC = () => {
         : `repository-session-${agentCli}`,
     [agentCli, name],
   );
+  const savedSessionStorageKey = useMemo(
+    () =>
+      name
+        ? `repository-saved-sessions-${name}-${agentCli}`
+        : `repository-saved-sessions-${agentCli}`,
+    [agentCli, name],
+  );
   const modelStorageKey = useMemo(
     () => (name ? `repository-model-${name}` : "repository-model"),
     [name],
@@ -401,6 +409,9 @@ export const RepositoryPage: React.FC = () => {
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
+    savedSessionStorageKey,
+  );
   const [pendingPrompt, setPendingPrompt] = useState("");
   const [selectedModel, setSelectedModel] = usePersistentString(
     modelStorageKey,
@@ -1285,6 +1296,22 @@ export const RepositoryPage: React.FC = () => {
     }
   };
 
+  const handleSaveSession = useCallback(() => {
+    if (!sessionId) return;
+    setSavedSessionIds((previous) =>
+      previous.includes(sessionId) ? previous : [sessionId, ...previous],
+    );
+  }, [sessionId, setSavedSessionIds]);
+
+  const handleRemoveSavedSession = useCallback(
+    (savedId: string) => {
+      setSavedSessionIds((previous) =>
+        previous.filter((session) => session !== savedId),
+      );
+    },
+    [setSavedSessionIds],
+  );
+
   const getCommandArgumentPlan = (command: CommandDefinition) => {
     const labelsFromHint = extractArgumentLabels(command.argumentHint);
 
@@ -1778,6 +1805,10 @@ export const RepositoryPage: React.FC = () => {
             emptyMessage="No conversation yet."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}
+            onSaveSession={handleSaveSession}
+            isSessionSaved={Boolean(
+              sessionId && savedSessionIds.includes(sessionId),
+            )}
           />
           {chatError && <div className="alert">{chatError}</div>}
           <MentionPathTextarea
@@ -2364,8 +2395,10 @@ export const RepositoryPage: React.FC = () => {
         loading={sessionListLoading}
         error={sessionListError}
         sessions={sessionOptions}
+        savedSessionIds={savedSessionIds}
         onClose={() => setSessionModalOpen(false)}
         onSelect={handleSessionSelect}
+        onRemoveSavedSession={handleRemoveSavedSession}
       />
 
       <ClearSessionModal

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -15,6 +15,7 @@ import { CommandsTab } from "../components/CommandsTab";
 import { HarnessesTab } from "../components/HarnessesTab";
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
+import { usePersistentStringList } from "../hooks/usePersistentStringList";
 import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
@@ -58,6 +59,13 @@ export const TaskPage: React.FC = () => {
       name ? `task-session-${name}-${agentCli}` : `task-session-${agentCli}`,
     [agentCli, name],
   );
+  const savedSessionStorageKey = useMemo(
+    () =>
+      name
+        ? `task-saved-sessions-${name}-${agentCli}`
+        : `task-saved-sessions-${agentCli}`,
+    [agentCli, name],
+  );
   const harnessHistoryStorageKey = useMemo(
     () => (name ? `task-harness-history-${name}` : "task-harness-history"),
     [name],
@@ -68,6 +76,9 @@ export const TaskPage: React.FC = () => {
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
   const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
+    savedSessionStorageKey,
+  );
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
@@ -376,6 +387,22 @@ export const TaskPage: React.FC = () => {
     }
   };
 
+  const handleSaveSession = useCallback(() => {
+    if (!sessionId) return;
+    setSavedSessionIds((previous) =>
+      previous.includes(sessionId) ? previous : [sessionId, ...previous],
+    );
+  }, [sessionId, setSavedSessionIds]);
+
+  const handleRemoveSavedSession = useCallback(
+    (savedId: string) => {
+      setSavedSessionIds((previous) =>
+        previous.filter((session) => session !== savedId),
+      );
+    },
+    [setSavedSessionIds],
+  );
+
   const loadCommands = useCallback(async () => {
     const response = await api.getCommands();
     const commands = response.commands || [];
@@ -550,6 +577,10 @@ export const TaskPage: React.FC = () => {
                   emptyMessage="Start a conversation to discuss this task."
                   sessionId={sessionId}
                   onClearSession={() => setClearSessionModalOpen(true)}
+                  onSaveSession={handleSaveSession}
+                  isSessionSaved={Boolean(
+                    sessionId && savedSessionIds.includes(sessionId),
+                  )}
                 />
                 {agentStatus && <div className="alert">{agentStatus}</div>}
                 <MentionPathTextarea
@@ -630,8 +661,10 @@ export const TaskPage: React.FC = () => {
         loading={sessionListLoading}
         error={sessionListError}
         sessions={sessionOptions}
+        savedSessionIds={savedSessionIds}
         onClose={() => setSessionModalOpen(false)}
         onSelect={handleSessionSelect}
+        onRemoveSavedSession={handleRemoveSavedSession}
       />
     </div>
   );

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -503,12 +503,22 @@ textarea {
 }
 
 .session-pill {
+  position: relative;
   width: 100%;
-  text-align: left;
   border: 1px solid var(--border);
   background: var(--surface);
   border-radius: 1rem;
+  padding: 0;
+}
+
+.session-pill-select {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
   padding: 0.75rem 1rem;
+  padding-right: 3rem;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -518,14 +528,21 @@ textarea {
     transform 0.2s ease,
     background-color 0.2s ease;
   will-change: transform;
+  border-radius: 1rem;
 }
 
 .session-pill:hover,
-.session-pill:focus-visible {
+.session-pill-select:focus-visible {
   border-color: var(--accent);
   transform: translateY(-1px);
   background-color: color-mix(in srgb, var(--surface) 90%, var(--accent));
   outline: none;
+}
+
+.session-pill-remove {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
 }
 
 .session-pill-id {


### PR DESCRIPTION
### Motivation
- Provide a way for users to save the current agent session from the chat (disk/save icon) and present saved sessions at the top of the session picker with a remove (bin) action, reusing existing icons and small-button styles.

### Description
- Added a `usePersistentStringList` hook to persist an array of saved session IDs in `localStorage` (`packages/frontend/src/hooks/usePersistentStringList.ts`).
- Show a save (disk) action in `ChatWindow` next to the Session ID using the shared `SaveIcon` and `icon-button-small` styling, and disable it when already saved (`packages/frontend/src/components/ChatWindow.tsx`).
- Updated `SessionPickerModal` to render saved sessions first and render a top-right trash icon per saved session to remove it from the saved list (`packages/frontend/src/components/SessionPickerModal.tsx`).
- Wired save/remove behavior into agent-enabled pages and session flows (`RepositoryPage`, `TaskPage`, `ConstitutionPage`, `KnowledgeArtefactPage`) and adjusted session pill styles in `index.css` to accommodate the remove control.

### Testing
- Ran `make qa-quick`, which finished successfully and includes formatting, linting and test steps.  The backend unit test run completed (`uv run pytest`), with the test suite passing (375 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7051e2bd88332920c1d13d71ae4d8)