### PR TITLE
Add 'pi' agent option to frontend Settings page

### DIFF
--- a/packages/frontend/src/pages/SettingsPage.tsx
+++ b/packages/frontend/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ const agentCliOptions = [
   "opencode",
   "opencode-legacy",
   "kiro",
+  "pi",
   "copilot",
   "codex",
   "ob1",


### PR DESCRIPTION
### Motivation
- Make the `pi` agent available in the frontend settings so it can be selected from the `agentCli` dropdown.

### Description
- Added `"pi"` to the `agentCliOptions` array in `packages/frontend/src/pages/SettingsPage.tsx`.

### Testing
- Ran `make qa-quick`, which executed formatting, linters, and tests; the run completed successfully and all automated checks passed (frontend checks and backend unit tests via `uv run pytest` — `375 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede626ee508332bc68bd280c7c1a09)