### PR TITLE
Move sidebar version label to bottom of menu

### DIFF
--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -45,7 +45,6 @@ export const Sidebar: React.FC<SidebarProps> = ({ open, onNavigate }) => {
   return (
     <nav className={`sidebar ${open ? "open" : ""}`}>
       <div className="sidebar-header">MADE</div>
-      {version && <div className="sidebar-version">v{version}</div>}
       <ul>
         {MENU_ITEMS.map((item) => {
           const Icon = item.icon;
@@ -65,6 +64,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ open, onNavigate }) => {
           );
         })}
       </ul>
+      {version && <div className="sidebar-version">v{version}</div>}
     </nav>
   );
 };

--- a/packages/frontend/src/styles/sidebar.css
+++ b/packages/frontend/src/styles/sidebar.css
@@ -20,6 +20,7 @@
 
 .sidebar ul {
   list-style: none;
+  flex: 1;
   padding: 0;
   margin: 0;
   display: flex;
@@ -66,6 +67,7 @@
   font-size: 0.7rem;
   text-align: center;
   color: var(--muted);
-  margin-top: 0;
-  margin-bottom: 0.5rem;
+  margin-top: auto;
+  margin-bottom: 0;
+  padding-top: 0.5rem;
 }


### PR DESCRIPTION
### Motivation
- Place the app version visually at the end of the sidebar menu so it appears at the bottom instead of above the navigation items.

### Description
- Moved the version JSX in `packages/frontend/src/components/Sidebar.tsx` from above the `<ul>` to below it so it renders after the menu list.
- Updated `packages/frontend/src/styles/sidebar.css` to make `.sidebar ul` grow (`flex: 1`) and adjusted `.sidebar-version` spacing (`margin-top: auto`, `margin-bottom: 0`, `padding-top: 0.5rem`) so the label is pushed to the bottom.

### Testing
- Ran `make qa-quick`, which completed successfully including frontend formatting/lint and backend linters and unit tests.
- Backend unit tests executed via `uv run pytest` passed `383` tests with `1` skipped, and an attempted Playwright screenshot failed due to browser download being blocked (`403 Domain forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b3c5d97c8332b3530a480be47eb8)