### PR TITLE
Add repository web preview endpoint and frontend tab to serve static files

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -696,6 +696,9 @@ export const RepositoryPage: React.FC = () => {
   const [loadingFile, setLoadingFile] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
   const chatInputId = "repository-agent-prompt";
+  const webPreviewUrl = name
+    ? `/api/repositories/${encodeURIComponent(name)}/web`
+    : "";
 
   useEffect(() => {
     const search = splitMentionSearch(mentionQuery);
@@ -2028,6 +2031,24 @@ export const RepositoryPage: React.FC = () => {
       content: (
         <Panel title="Repository Terminal">
           <TerminalTab repositoryName={name || undefined} />
+        </Panel>
+      ),
+    },
+    {
+      id: "web-browser",
+      label: "Web Browser",
+      content: (
+        <Panel title="Repository Web Preview">
+          <iframe
+            src={webPreviewUrl}
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: "10px",
+              height: "70vh",
+              width: "100%",
+            }}
+            title="Repository web browser"
+          />
         </Panel>
       ),
     },

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import fcntl
+import html
 import importlib.metadata
 import json
 import logging
@@ -12,6 +13,7 @@ import subprocess
 import termios
 from copy import deepcopy
 from pathlib import Path
+from urllib.parse import quote
 
 from uvicorn.config import LOGGING_CONFIG
 
@@ -29,7 +31,7 @@ from fastapi import (
 )
 from fastapi.websockets import WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 
 from agent_service import (
     ChannelBusyError,
@@ -408,7 +410,31 @@ def repository_web(name: str, path: str = ""):
         )
 
     if target.is_dir():
-        target = target / "index.html"
+        index_file = target / "index.html"
+        if index_file.is_file():
+            return FileResponse(index_file)
+
+        request_path = safe_relative.rstrip("/")
+        base_url = f"/api/repositories/{quote(name)}/web"
+        current_url = f"{base_url}/{request_path}" if request_path else base_url
+        entries = []
+        if request_path:
+            parent_path = request_path.rsplit("/", 1)[0]
+            parent_url = f"{base_url}/{parent_path}" if parent_path else base_url
+            entries.append(f'<li><a href="{parent_url}">..</a></li>')
+        for child in sorted(
+            target.iterdir(), key=lambda item: (item.is_file(), item.name.lower())
+        ):
+            child_relative = "/".join(
+                segment for segment in [request_path, child.name] if segment
+            )
+            child_url = f"{base_url}/{quote(child_relative, safe='/')}"
+            label = f"{child.name}/" if child.is_dir() else child.name
+            entries.append(f'<li><a href="{child_url}">{html.escape(label)}</a></li>')
+        listing = "\n".join(entries) or "<li><em>(empty)</em></li>"
+        return HTMLResponse(
+            f"<html><body><h1>Index of {html.escape(current_url)}</h1><ul>{listing}</ul></body></html>"
+        )
 
     if not target.exists() or not target.is_file():
         raise HTTPException(

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -29,6 +29,7 @@ from fastapi import (
 )
 from fastapi.websockets import WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 
 from agent_service import (
     ChannelBusyError,
@@ -387,6 +388,35 @@ def repository_files(name: str, path: str = Query(".")):
         return list_repository_files(name, path)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@app.get("/api/repositories/{name}/web")
+@app.get("/api/repositories/{name}/web/{path:path}")
+def repository_web(name: str, path: str = ""):
+    try:
+        repo_path = _repository_path(name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+    safe_relative = Path(path or "").as_posix().lstrip("/")
+    target = (repo_path / safe_relative).resolve()
+
+    if repo_path not in target.parents and target != repo_path:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid web path",
+        )
+
+    if target.is_dir():
+        target = target / "index.html"
+
+    if not target.exists() or not target.is_file():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Web file not found",
+        )
+
+    return FileResponse(target)
 
 
 @app.get("/api/repositories/{name}/file")

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -594,6 +594,28 @@ class TestRepositoryEndpoints:
         data = response.json()
         assert data["content"] == mock_content
 
+    def test_repository_web_serves_index_html(self, tmp_path):
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+        (repo_path / "index.html").write_text("<h1>Hello</h1>", encoding="utf-8")
+
+        with patch("app._repository_path", return_value=repo_path):
+            response = client.get("/api/repositories/test-repo/web")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "<h1>Hello</h1>" in response.text
+
+    def test_repository_web_missing_file_returns_not_found(self, tmp_path):
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+
+        with patch("app._repository_path", return_value=repo_path):
+            response = client.get("/api/repositories/test-repo/web/missing.html")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Web file not found"
+
     def test_read_repository_file_no_path(self):
         """Test reading repository file without path."""
         response = client.get("/api/repositories/test-repo/file")

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -616,6 +616,22 @@ class TestRepositoryEndpoints:
         assert response.status_code == 404
         assert response.json()["detail"] == "Web file not found"
 
+    def test_repository_web_lists_directory_when_index_missing(self, tmp_path):
+        repo_path = tmp_path / "test-repo"
+        docs_path = repo_path / "docs"
+        docs_path.mkdir(parents=True)
+        (docs_path / "guide.html").write_text("guide", encoding="utf-8")
+        (docs_path / "assets").mkdir()
+
+        with patch("app._repository_path", return_value=repo_path):
+            response = client.get("/api/repositories/test-repo/web/docs")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "Index of /api/repositories/test-repo/web/docs" in response.text
+        assert 'href="/api/repositories/test-repo/web/docs/guide.html"' in response.text
+        assert 'href="/api/repositories/test-repo/web/docs/assets"' in response.text
+
     def test_read_repository_file_no_path(self):
         """Test reading repository file without path."""
         response = client.get("/api/repositories/test-repo/file")


### PR DESCRIPTION
### Motivation

- Provide an easy way to preview static web content stored in a repository via the UI. 
- Allow browsing a repository's `index.html` (and other files) through a dedicated web preview panel.

### Description

- Added a backend endpoint `GET /api/repositories/{name}/web` and `GET /api/repositories/{name}/web/{path:path}` that serves files from the repository using `FileResponse` and returns `index.html` for directory requests. 
- Implemented path safety checks by resolving the requested path and ensuring it remains inside the repository root, returning `400` for invalid paths and `404` for missing files. 
- Imported `FileResponse` in `app.py` and wired the new handler into the FastAPI app. 
- Updated the frontend `RepositoryPage` to add a `Web Browser` tab that renders an `iframe` pointing to the new preview URL via the `webPreviewUrl` variable.

### Testing

- Added unit tests in `packages/pybackend/tests/unit/test_api.py`: `test_repository_web_serves_index_html` and `test_repository_web_missing_file_returns_not_found`.
- Ran the unit test suite for the API tests, and the new tests passed (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e745b1348332a42290ed3728a11b)