### PR TITLE
Polish file editor button styling and add copy controls

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -565,6 +565,13 @@ export const RepositoryPage: React.FC = () => {
     });
   }, [chat]);
 
+  const copyToClipboard = useCallback((content: string, label: string) => {
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(content).catch((error) => {
+      console.error(`Failed to copy ${label}`, error);
+    });
+  }, []);
+
   const scrollToBottom = () => {
     if (chatWindowRef.current) {
       chatWindowRef.current.scrollTop = chatWindowRef.current.scrollHeight;
@@ -2168,7 +2175,7 @@ export const RepositoryPage: React.FC = () => {
                   actions={
                     <button
                       type="button"
-                      className="secondary comment-action"
+                      className="primary"
                       onClick={() => openFileCommentModal("diff")}
                     >
                       Comment
@@ -2235,13 +2242,25 @@ export const RepositoryPage: React.FC = () => {
               }
               actions={
                 selectedFile && (
-                  <button
-                    className="primary"
-                    onClick={handleSaveFile}
-                    disabled={loadingFile}
-                  >
-                    Save File
-                  </button>
+                  <div className="panel-action-buttons">
+                    <button
+                      type="button"
+                      className="primary"
+                      onClick={handleSaveFile}
+                      disabled={loadingFile}
+                    >
+                      Save File
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary comment-action"
+                      onClick={() =>
+                        copyToClipboard(editorContent, "editor content")
+                      }
+                    >
+                      Copy Raw
+                    </button>
+                  </div>
                 )
               }
             >
@@ -2271,13 +2290,24 @@ export const RepositoryPage: React.FC = () => {
               title="Preview"
               actions={
                 selectedFile && (
-                  <button
-                    type="button"
-                    className="secondary comment-action"
-                    onClick={() => openFileCommentModal("preview")}
-                  >
-                    Comment
-                  </button>
+                  <div className="panel-action-buttons">
+                    <button
+                      type="button"
+                      className="secondary comment-action"
+                      onClick={() => openFileCommentModal("preview")}
+                    >
+                      Comment
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary comment-action"
+                      onClick={() =>
+                        copyToClipboard(editorContent, "preview content")
+                      }
+                    >
+                      Copy Preview
+                    </button>
+                  </div>
                 )
               }
             >


### PR DESCRIPTION
### Motivation

- Make file editor actions visually consistent with the project’s blueish action style and provide quick copy actions for raw and preview content in the editor panels.

### Description

- Add a reusable `copyToClipboard` helper in `packages/frontend/src/pages/RepositoryPage.tsx` to centralize clipboard behavior. 
- Change the Diff View "Comment" action to use the primary blue style for consistency in file-editing views. 
- Replace single-button editor actions with a `panel-action-buttons` group that includes a primary `Save File` button and a `Copy Raw` action that copies `editorContent`. 
- Add a `Copy Preview` button to the Preview panel that copies the current `editorContent` (markdown-rendered or raw) to the clipboard.

### Testing

- Ran the repository quality gate `make qa-quick`, which executed formatting, linting, frontend checks, and backend unit tests, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cf4e93888332b2282caac111c1d8)