### PR TITLE
Add Todo tab and backend CRUD for .made/TODO.md

### DIFF
--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -1,30 +1,45 @@
 {
-  "T1": {
+  "TASK_1": {
     "status": "done",
     "evidence": [
-      "PR #395 analyzed: lint errors found in backend (ruff): 18 errors including unused imports, line length issues",
-      "make lint output shows: Found 18 errors in packages/pybackend/*.py"
+      "gh pr checks 403: Docker Build=fail, System tests (E2E)=fail",
+      "Docker Build error: src/pages/RepositoryPage.tsx(829,7): error TS2448: Block-scoped variable 'loadTodos' used before its declaration.",
+      "E2E error: getByRole('heading', { name: 'Repository: demo-project' }) not found",
+      "Root cause analysis (5xWhy):",
+      "Why 1: Docker build fails -> TypeScript compilation error TS2448/TS2454",
+      "Why 2: TS error -> loadTodos used in useEffect at line 829 before declaration at line 1539",
+      "Why 3: Declared after use -> loadTodos useCallback placed too late in component (after other hooks that reference it)",
+      "Why 4: Wrong ordering -> Codex agent put the useEffect([loadTodos]) hook near other useEffects (line ~828) but defined loadTodos useCallback much later (~line 1539)",
+      "Why 5: Root cause -> JavaScript/TypeScript block-scoped variables (const) are not hoisted, so forward references in useEffect dependency arrays cause compile errors",
+      "E2E Why 1: Test fails on 'Repository: demo-project' heading -> heading not visible",
+      "E2E Why 2: Heading not visible -> page navigation to repo page not completing",
+      "E2E Why 3: Page not loading -> TypeScript build error means production JS has issues OR heading text changed",
+      "E2E Why 4: Heading text check -> grep shows h1 still says 'Repository: {name}' at line 2496",
+      "E2E Why 5: Root cause -> E2E runs against dev server, the TS error doesn't affect dev (vite transpiles without strict type checking), so E2E failure is likely pre-existing or caused by tab navigation changes breaking the heading"
     ],
-    "last_verified": "2026-04-28T00:00:00Z"
+    "last_verified": "2026-05-02T10:45:00Z"
   },
-  "T2": {
+  "TASK_2": {
+    "status": "done",
+    "evidence": [
+      "Plan: Move loadTodos useCallback declaration to before the useEffect that depends on it (around line 824)",
+      "For E2E: Investigate if heading is still rendered correctly after Todo tab addition"
+    ],
+    "last_verified": "2026-05-02T10:45:00Z"
+  },
+  "TASK_3": {
     "status": "in_progress",
     "evidence": [],
-    "last_verified": "2026-04-28T00:00:00Z"
+    "last_verified": "2026-05-02T10:45:00Z"
   },
-  "T3": {
+  "TASK_4": {
     "status": "pending",
     "evidence": [],
-    "last_verified": "2026-04-28T00:00:00Z"
+    "last_verified": "2026-05-02T10:45:00Z"
   },
-  "T4": {
+  "TASK_5": {
     "status": "pending",
     "evidence": [],
-    "last_verified": "2026-04-28T00:00:00Z"
-  },
-  "T5": {
-    "status": "pending",
-    "evidence": [],
-    "last_verified": "2026-04-28T00:00:00Z"
+    "last_verified": "2026-05-02T10:45:00Z"
   }
 }

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -254,6 +254,11 @@ export type HarnessDefinition = {
   source: string;
 };
 
+export type RepositoryTodo = {
+  text: string;
+  done: boolean;
+};
+
 export type TemplateApplyResponse = {
   repository: string;
   template: string;
@@ -530,6 +535,28 @@ export const api = {
   getRepositoryWorkflows: (name: string) =>
     request<{ workflows: WorkflowDefinition[] }>(
       `/repositories/${name}/workflows`,
+    ),
+  getRepositoryTodos: (name: string) =>
+    request<{ todos: RepositoryTodo[] }>(`/repositories/${name}/todos`),
+  addRepositoryTodo: (name: string, text: string) =>
+    request<{ todos: RepositoryTodo[] }>(`/repositories/${name}/todos`, {
+      method: "POST",
+      body: JSON.stringify({ text }),
+    }),
+  updateRepositoryTodo: (name: string, index: number, done: boolean) =>
+    request<{ todos: RepositoryTodo[] }>(
+      `/repositories/${name}/todos/${index}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ done }),
+      },
+    ),
+  deleteRepositoryTodo: (name: string, index: number) =>
+    request<{ todos: RepositoryTodo[] }>(
+      `/repositories/${name}/todos/${index}`,
+      {
+        method: "DELETE",
+      },
     ),
   saveRepositoryWorkflows: (name: string, workflows: WorkflowDefinition[]) =>
     request<{ workflows: WorkflowDefinition[] }>(

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -824,9 +824,6 @@ export const RepositoryPage: React.FC = () => {
   useEffect(() => {
     loadCommands();
   }, [loadCommands]);
-  useEffect(() => {
-    void loadTodos();
-  }, [loadTodos]);
 
   const loadHarnesses = useCallback(() => {
     if (!name) return;
@@ -1551,6 +1548,10 @@ export const RepositoryPage: React.FC = () => {
       setTodoLoading(false);
     }
   }, [name]);
+
+  useEffect(() => {
+    void loadTodos();
+  }, [loadTodos]);
 
   const handleAddTodo = async () => {
     if (!name || !newTodoText.trim()) return;

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -30,6 +30,7 @@ import {
   ChatSession,
   FileNode,
   HarnessDefinition,
+  RepositoryTodo,
   RepositoryFileGitDetails,
   RepositorySummary,
   RepositoryGitStatus,
@@ -674,6 +675,11 @@ export const RepositoryPage: React.FC = () => {
   const [fileCommentText, setFileCommentText] = useState("");
   const [createModal, setCreateModal] = useState(false);
   const [uploadModal, setUploadModal] = useState(false);
+  const [todoModalOpen, setTodoModalOpen] = useState(false);
+  const [newTodoText, setNewTodoText] = useState("");
+  const [todos, setTodos] = useState<RepositoryTodo[]>([]);
+  const [todoLoading, setTodoLoading] = useState(false);
+  const [todoError, setTodoError] = useState<string | null>(null);
   const [renameModal, setRenameModal] = useState<{
     open: boolean;
     from: string | null;
@@ -818,6 +824,9 @@ export const RepositoryPage: React.FC = () => {
   useEffect(() => {
     loadCommands();
   }, [loadCommands]);
+  useEffect(() => {
+    void loadTodos();
+  }, [loadTodos]);
 
   const loadHarnesses = useCallback(() => {
     if (!name) return;
@@ -1527,6 +1536,42 @@ export const RepositoryPage: React.FC = () => {
     setUploadFile(null);
   };
 
+  const loadTodos = useCallback(async () => {
+    if (!name) return;
+    setTodoLoading(true);
+    try {
+      const response = await api.getRepositoryTodos(name);
+      setTodos(response.todos || []);
+      setTodoError(null);
+    } catch (error) {
+      setTodoError(
+        error instanceof Error ? error.message : "Unable to load todos",
+      );
+    } finally {
+      setTodoLoading(false);
+    }
+  }, [name]);
+
+  const handleAddTodo = async () => {
+    if (!name || !newTodoText.trim()) return;
+    const response = await api.addRepositoryTodo(name, newTodoText.trim());
+    setTodos(response.todos || []);
+    setNewTodoText("");
+    setTodoModalOpen(false);
+  };
+
+  const handleToggleTodo = async (index: number, done: boolean) => {
+    if (!name) return;
+    const response = await api.updateRepositoryTodo(name, index, done);
+    setTodos(response.todos || []);
+  };
+
+  const handleDeleteTodo = async (index: number) => {
+    if (!name) return;
+    const response = await api.deleteRepositoryTodo(name, index);
+    setTodos(response.todos || []);
+  };
+
   const handleUploadFile = async () => {
     if (!name) return;
     const trimmedPath = uploadPath.trim();
@@ -2023,6 +2068,56 @@ export const RepositoryPage: React.FC = () => {
             </div>
           </Panel>
         </div>
+      ),
+    },
+    {
+      id: "todo",
+      label: "Todo",
+      content: (
+        <Panel
+          title="Repository Todos"
+          actions={
+            <button className="primary" onClick={() => setTodoModalOpen(true)}>
+              Add Todo
+            </button>
+          }
+        >
+          {todoError && <div className="alert error">{todoError}</div>}
+          {todoLoading ? (
+            <div className="alert">Loading todos...</div>
+          ) : (
+            <div className="file-browser">
+              {todos.length === 0 ? (
+                <div className="empty">No todos in .made/TODO.md</div>
+              ) : (
+                todos.map((todo, index) => (
+                  <div className="file-node" key={`${todo.text}-${index}`}>
+                    <div className="file-row">
+                      <input
+                        type="checkbox"
+                        checked={todo.done}
+                        onChange={(event) =>
+                          void handleToggleTodo(index, event.target.checked)
+                        }
+                      />
+                      <div className="file-name">{todo.text}</div>
+                      <div className="file-actions">
+                        <button
+                          type="button"
+                          className="copy-button file-action-button"
+                          onClick={() => void handleDeleteTodo(index)}
+                          aria-label={`Delete todo ${todo.text}`}
+                        >
+                          <TrashIcon />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </Panel>
       ),
     },
     {
@@ -2549,6 +2644,31 @@ export const RepositoryPage: React.FC = () => {
           </button>
           <button className="primary" onClick={handleCreateFile}>
             Create
+          </button>
+        </div>
+      </Modal>
+
+      <Modal
+        open={todoModalOpen}
+        title="Add Todo"
+        onClose={() => setTodoModalOpen(false)}
+      >
+        <div className="form-group">
+          <label htmlFor="new-todo">Todo</label>
+          <textarea
+            id="new-todo"
+            value={newTodoText}
+            onChange={(event) => setNewTodoText(event.target.value)}
+            placeholder="Describe a task..."
+            rows={4}
+          />
+        </div>
+        <div className="modal-actions">
+          <button className="secondary" onClick={() => setTodoModalOpen(false)}>
+            Cancel
+          </button>
+          <button className="primary" onClick={() => void handleAddTodo()}>
+            Add
           </button>
         </div>
       </Modal>

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import pty
+import re
 import shutil
 import struct
 import subprocess
@@ -556,6 +557,87 @@ def delete_repository_file_endpoint(name: str, payload: dict = Body(...)):
             "Failed to delete file '%s' from repository '%s'", file_path, name
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+def _parse_todo_lines(content: str) -> list[dict]:
+    todos: list[dict] = []
+    for line in content.splitlines():
+        match = re.match(r"^\s*[-*]\s+\[( |x|X)\]\s+(.*)$", line)
+        if not match:
+            continue
+        todos.append(
+            {"text": match.group(2).strip(), "done": match.group(1).lower() == "x"}
+        )
+    return todos
+
+
+def _format_todo_lines(todos: list[dict]) -> str:
+    if not todos:
+        return ""
+    return "\n".join(
+        f"- [{'x' if bool(todo.get('done')) else ' '}] {str(todo.get('text', '')).strip()}"
+        for todo in todos
+        if str(todo.get("text", "")).strip()
+    )
+
+
+@app.get("/api/repositories/{name}/todos")
+def list_repository_todos_endpoint(name: str):
+    try:
+        content = read_repository_file(name, ".made/TODO.md")
+        return {"todos": _parse_todo_lines(content)}
+    except FileNotFoundError:
+        return {"todos": []}
+
+
+@app.post("/api/repositories/{name}/todos")
+def add_repository_todo_endpoint(name: str, payload: dict = Body(...)):
+    text = str(payload.get("text", "")).strip()
+    if not text:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Todo text is required"
+        )
+    try:
+        existing = _parse_todo_lines(read_repository_file(name, ".made/TODO.md"))
+    except FileNotFoundError:
+        existing = []
+    existing.append({"text": text, "done": False})
+    write_repository_file(name, ".made/TODO.md", _format_todo_lines(existing))
+    return {"todos": existing}
+
+
+@app.put("/api/repositories/{name}/todos/{index}")
+def update_repository_todo_endpoint(name: str, index: int, payload: dict = Body(...)):
+    try:
+        todos = _parse_todo_lines(read_repository_file(name, ".made/TODO.md"))
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="TODO file not found"
+        )
+    if index < 0 or index >= len(todos):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Todo not found"
+        )
+    todos[index]["done"] = bool(payload.get("done", False))
+    write_repository_file(name, ".made/TODO.md", _format_todo_lines(todos))
+    return {"todos": todos}
+
+
+@app.delete("/api/repositories/{name}/todos/{index}")
+def delete_repository_todo_endpoint(name: str, index: int):
+    try:
+        todos = _parse_todo_lines(read_repository_file(name, ".made/TODO.md"))
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="TODO file not found"
+        )
+    if index < 0 or index >= len(todos):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Todo not found"
+        )
+    todos.pop(index)
+    write_repository_file(name, ".made/TODO.md", _format_todo_lines(todos))
+    return {"todos": todos}
 
 
 @app.post("/api/repositories/{name}/agent")


### PR DESCRIPTION
### Motivation
- Provide a lightweight, repository-scoped Todo UI that reads and persists markdown checklist items kept in `.made/TODO.md` so users can track small tasks next to the file browser. 
- Implement a simple full-stack flow (API + client + UI) that supports listing, toggling, adding and removing todos using the existing file storage primitives.

### Description
- Added markdown checklist parsing/formatting helpers `_parse_todo_lines` and `_format_todo_lines` and new repository endpoints `GET /api/repositories/{name}/todos`, `POST /api/repositories/{name}/todos`, `PUT /api/repositories/{name}/todos/{index}`, and `DELETE /api/repositories/{name}/todos/{index}` in `packages/pybackend/app.py` to read/write `.made/TODO.md` as markdown checklists. 
- Extended frontend API client in `packages/frontend/src/hooks/useApi.ts` with `RepositoryTodo` type and client methods `getRepositoryTodos`, `addRepositoryTodo`, `updateRepositoryTodo`, and `deleteRepositoryTodo`. 
- Implemented a new `Todo` tab in `packages/frontend/src/pages/RepositoryPage.tsx` that loads todos, renders each item using the file-browser row styles with a checkbox and a trash icon, and exposes an `Add Todo` button + modal to append new todos; actions call the new API methods and refresh local state. 
- Reused existing UI components/styles (panel, modal, file-browser classes) to keep the implementation simple and consistent with the repository view.

### Testing
- Ran the repository quality gate with `make qa-quick` which performed formatting and linting for frontend and backend successfully. 
- Frontend formatting/lint steps completed successfully and the changed files were formatted by `prettier` and ESLint (no lint errors introduced). 
- Backend unit test suite executed via `uv run pytest` and completed successfully (`386 passed, 1 skipped`) and backend linters (`ruff`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d070f5a88332a217b9a2389159d1)