### PR TITLE
Resolve repository-relative image paths in markdown renderer and add tests

### DIFF
--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -1,45 +1,32 @@
 {
-  "TASK_1": {
+  "T1": {
     "status": "done",
     "evidence": [
-      "gh pr checks 403: Docker Build=fail, System tests (E2E)=fail",
-      "Docker Build error: src/pages/RepositoryPage.tsx(829,7): error TS2448: Block-scoped variable 'loadTodos' used before its declaration.",
-      "E2E error: getByRole('heading', { name: 'Repository: demo-project' }) not found",
-      "Root cause analysis (5xWhy):",
-      "Why 1: Docker build fails -> TypeScript compilation error TS2448/TS2454",
-      "Why 2: TS error -> loadTodos used in useEffect at line 829 before declaration at line 1539",
-      "Why 3: Declared after use -> loadTodos useCallback placed too late in component (after other hooks that reference it)",
-      "Why 4: Wrong ordering -> Codex agent put the useEffect([loadTodos]) hook near other useEffects (line ~828) but defined loadTodos useCallback much later (~line 1539)",
-      "Why 5: Root cause -> JavaScript/TypeScript block-scoped variables (const) are not hoisted, so forward references in useEffect dependency arrays cause compile errors",
-      "E2E Why 1: Test fails on 'Repository: demo-project' heading -> heading not visible",
-      "E2E Why 2: Heading not visible -> page navigation to repo page not completing",
-      "E2E Why 3: Page not loading -> TypeScript build error means production JS has issues OR heading text changed",
-      "E2E Why 4: Heading text check -> grep shows h1 still says 'Repository: {name}' at line 2496",
-      "E2E Why 5: Root cause -> E2E runs against dev server, the TS error doesn't affect dev (vite transpiles without strict type checking), so E2E failure is likely pre-existing or caused by tab navigation changes breaking the heading"
+      "gh pr checks 406 -> Docker Build: fail",
+      "gh run view 25285764665 -> error TS2345: Argument of type 'Window' is not assignable to parameter of type 'WindowLike'",
+      "Location: packages/frontend/src/utils/markdown.ts(77,20)",
+      "Root cause (5xWhy): 1) Docker build fails -> 2) tsc compilation fails -> 3) DOMPurify(win) where win is Window doesn't match WindowLike type -> 4) DOMPurify type expects WindowLike (specific subset of globalThis) but Window is a superset with more properties -> 5) The code cast (globalThis as {window?: Window}).window returns Window but DOMPurify factory needs WindowLike which is a more specific structural type. Fix: cast win to 'DOMPurify.WindowLike' or use 'as unknown as DOMPurify.WindowLike'"
     ],
-    "last_verified": "2026-05-02T10:45:00Z"
+    "last_verified": "2026-05-03T17:30:00Z"
   },
-  "TASK_2": {
-    "status": "done",
-    "evidence": [
-      "Plan: Move loadTodos useCallback declaration to before the useEffect that depends on it (around line 824)",
-      "For E2E: Investigate if heading is still rendered correctly after Todo tab addition"
-    ],
-    "last_verified": "2026-05-02T10:45:00Z"
-  },
-  "TASK_3": {
+  "T2": {
     "status": "in_progress",
     "evidence": [],
-    "last_verified": "2026-05-02T10:45:00Z"
+    "last_verified": "2026-05-03T17:30:00Z"
   },
-  "TASK_4": {
+  "T3": {
     "status": "pending",
     "evidence": [],
-    "last_verified": "2026-05-02T10:45:00Z"
+    "last_verified": "2026-05-03T17:30:00Z"
   },
-  "TASK_5": {
+  "T4": {
     "status": "pending",
     "evidence": [],
-    "last_verified": "2026-05-02T10:45:00Z"
+    "last_verified": "2026-05-03T17:30:00Z"
+  },
+  "T5": {
+    "status": "pending",
+    "evidence": [],
+    "last_verified": "2026-05-03T17:30:00Z"
   }
 }

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { renderMarkdown } from "../utils/markdown";
+import { MarkdownRenderOptions, renderMarkdown } from "../utils/markdown";
 import { ChatMessage } from "../types/chat";
 import { SaveIcon } from "./icons/SaveIcon";
 import { TrashIcon } from "./icons/TrashIcon";
@@ -13,6 +13,7 @@ interface ChatWindowProps {
   onClearSession?: () => void;
   onSaveSession?: () => void;
   isSessionSaved?: boolean;
+  markdownOptions?: MarkdownRenderOptions;
 }
 
 const formatTimestamp = (message: ChatMessage) => {
@@ -74,6 +75,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   onClearSession,
   onSaveSession,
   isSessionSaved,
+  markdownOptions,
 }) => (
   <div className="chat-window" ref={chatWindowRef}>
     {chat.map((message) => {
@@ -97,7 +99,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
             className="markdown"
             dangerouslySetInnerHTML={{
               __html: strippedMessage.trim()
-                ? renderMarkdown(strippedMessage)
+                ? renderMarkdown(strippedMessage, markdownOptions)
                 : "<em>Empty message</em>",
             }}
           />

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -630,6 +630,9 @@ export const ConstitutionPage: React.FC = () => {
               isSessionSaved={Boolean(
                 sessionId && savedSessionIds.includes(sessionId),
               )}
+              markdownOptions={{
+                currentFilePath: name || undefined,
+              }}
             />
             {agentStatus && <div className="alert">{agentStatus}</div>}
             <MentionPathTextarea

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -645,6 +645,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
             isSessionSaved={Boolean(
               sessionId && savedSessionIds.includes(sessionId),
             )}
+            markdownOptions={{
+              currentFilePath: name || undefined,
+            }}
           />
           {agentStatus && <div className="alert">{agentStatus}</div>}
           <MentionPathTextarea

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -2411,7 +2411,10 @@ export const RepositoryPage: React.FC = () => {
                 <div
                   className="markdown"
                   dangerouslySetInnerHTML={{
-                    __html: renderMarkdown(editorContent || ""),
+                    __html: renderMarkdown(editorContent || "", {
+                      repositoryName: name || undefined,
+                      currentFilePath: selectedFile || undefined,
+                    }),
                   }}
                 />
               ) : (

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1873,6 +1873,10 @@ export const RepositoryPage: React.FC = () => {
             isSessionSaved={Boolean(
               sessionId && savedSessionIds.includes(sessionId),
             )}
+            markdownOptions={{
+              repositoryName: name || undefined,
+              currentFilePath: selectedFile || "README.md",
+            }}
           />
           {chatError && <div className="alert">{chatError}</div>}
           <MentionPathTextarea

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -589,6 +589,9 @@ export const TaskPage: React.FC = () => {
                   isSessionSaved={Boolean(
                     sessionId && savedSessionIds.includes(sessionId),
                   )}
+                  markdownOptions={{
+                    currentFilePath: name || undefined,
+                  }}
                 />
                 {agentStatus && <div className="alert">{agentStatus}</div>}
                 <MentionPathTextarea

--- a/packages/frontend/src/utils/markdown.test.ts
+++ b/packages/frontend/src/utils/markdown.test.ts
@@ -11,9 +11,7 @@ describe("renderMarkdown", () => {
   });
 
   it("adds target=_blank and rel to links that have no target", () => {
-    const html = renderMarkdown(
-      '<a href="https://example.com">Example</a>',
-    );
+    const html = renderMarkdown('<a href="https://example.com">Example</a>');
 
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noopener noreferrer"');
@@ -25,6 +23,18 @@ describe("renderMarkdown", () => {
     expect(html).toContain("<img");
     expect(html).toContain('src="https://example.com/cat.png"');
     expect(html).toContain('alt="A cat"');
+  });
+
+  it("resolves repository-relative image paths into web URLs", () => {
+    const html = renderMarkdown("![Diagram](../assets/flow.png)", {
+      repositoryName: "sample repo",
+      currentFilePath: "docs/guides/intro.md",
+    });
+
+    expect(html).toContain("<img");
+    expect(html).toContain(
+      'src="http://localhost:3000/api/repositories/sample%20repo/web/docs/assets/flow.png"',
+    );
   });
 
   it("removes unsafe image urls", () => {

--- a/packages/frontend/src/utils/markdown.ts
+++ b/packages/frontend/src/utils/markdown.ts
@@ -74,7 +74,7 @@ const resolveRepositoryAssetUrl = (
 const getPurify = () => {
   const win = (globalThis as { window?: Window }).window;
   if (!win) return null;
-  return DOMPurify(win);
+  return DOMPurify(win as unknown as DOMPurify.WindowLike);
 };
 
 const sanitizeHtml = (html: string) => {

--- a/packages/frontend/src/utils/markdown.ts
+++ b/packages/frontend/src/utils/markdown.ts
@@ -1,6 +1,11 @@
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
+export type MarkdownRenderOptions = {
+  repositoryName?: string;
+  currentFilePath?: string;
+};
+
 const addExternalLinkAttributes = (html: string) =>
   html.replace(/<a\s+([^>]*?)>/g, (_, attributes: string) => {
     let updatedAttributes = attributes;
@@ -15,6 +20,55 @@ const addExternalLinkAttributes = (html: string) =>
 
     return `<a ${updatedAttributes}>`;
   });
+
+const isRelativePath = (value: string) =>
+  !!value &&
+  !value.startsWith("#") &&
+  !/^[a-z][a-z0-9+.-]*:/i.test(value) &&
+  !value.startsWith("//");
+
+const resolveRepositoryAssetUrl = (
+  source: string,
+  repositoryName?: string,
+  currentFilePath?: string,
+): string => {
+  if (!repositoryName || !currentFilePath || !isRelativePath(source))
+    return source;
+
+  try {
+    const baseDirectory = currentFilePath.includes("/")
+      ? currentFilePath.slice(0, currentFilePath.lastIndexOf("/"))
+      : "";
+
+    const relativePath = source.startsWith("/")
+      ? source.slice(1)
+      : [baseDirectory, source].filter(Boolean).join("/");
+
+    const normalized = relativePath
+      .split("/")
+      .reduce<string[]>((segments, segment) => {
+        if (!segment || segment === ".") return segments;
+        if (segment === "..") {
+          if (segments.length > 0) segments.pop();
+          return segments;
+        }
+        segments.push(segment);
+        return segments;
+      }, [])
+      .join("/");
+
+    const origin =
+      (globalThis as { window?: Window }).window?.location?.origin || "";
+    const encodedPath = normalized
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+
+    return `${origin}/api/repositories/${encodeURIComponent(repositoryName)}/web/${encodedPath}`;
+  } catch {
+    return source;
+  }
+};
 
 // DOMPurify is a factory — always bind explicitly to the current window
 const getPurify = () => {
@@ -85,4 +139,28 @@ marked.use({
   },
 });
 
-export const renderMarkdown = (content: string) => marked(content) as string;
+export const renderMarkdown = (
+  content: string,
+  options?: MarkdownRenderOptions,
+) => {
+  const rendered = marked.parse(content, {
+    async: false,
+  }) as string;
+
+  if (!options?.repositoryName || !options.currentFilePath) {
+    return rendered;
+  }
+
+  return rendered.replace(
+    /<img\b([^>]*?)\bsrc="([^"]*)"([^>]*)>/gi,
+    (_, before: string, src: string, after: string) => {
+      const nextSrc = resolveRepositoryAssetUrl(
+        src,
+        options.repositoryName,
+        options.currentFilePath,
+      );
+
+      return `<img${before}src="${nextSrc}"${after}>`;
+    },
+  );
+};


### PR DESCRIPTION
### Motivation

- Allow markdown images that use repository-relative paths to render as web-accessible URLs when previewing files in the repository UI. 
- Ensure links still open safely in a new tab and that unsafe image URLs are stripped by the sanitizer. 
- Provide deterministic behavior for previews by encoding path segments and using the current origin.

### Description

- Added `MarkdownRenderOptions` and extended `renderMarkdown` to accept `repositoryName` and `currentFilePath` and to post-process rendered HTML to rewrite `<img src=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75308584083329bd0573119872802)