### PR TITLE
Include `--dir` when invoking opencode CLI (template, implementation, tests)

### DIFF
--- a/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
+++ b/packages/frontend/src/templates/WORKFLOW_TO_HARNESS_PROMPT_TEMPLATE.md
@@ -383,7 +383,7 @@ The examples below show different CLI formats. The generator MUST use the approp
 
 Base command:
 
-    opencode run --format json
+    opencode run --dir "{{WORKING_DIRECTORY}}" --format json
 
 Options:
 

--- a/packages/pybackend/opencode_database_agent_cli.py
+++ b/packages/pybackend/opencode_database_agent_cli.py
@@ -498,7 +498,7 @@ class OpenCodeDatabaseAgentCLI(AgentCLI):
         """Run agent with message using CLI subprocess and return structured result."""
         try:
             # Build command inline
-            command = ["opencode", "run"]
+            command = ["opencode", "run", "--dir", str(cwd)]
             if session_id:
                 command.extend(["-s", session_id])
             if agent:

--- a/packages/pybackend/tests/unit/test_opencode_database_agent_cli.py
+++ b/packages/pybackend/tests/unit/test_opencode_database_agent_cli.py
@@ -522,6 +522,8 @@ class TestOpenCodeDatabaseAgentCLI(unittest.TestCase):
             [
                 "opencode",
                 "run",
+                "--dir",
+                "/test",
                 "-s",
                 "session1",
                 "--agent",


### PR DESCRIPTION
### Motivation

- Ensure the configured opencode CLI is invoked with an explicit working directory so runs execute in the intended project context.

### Description

- Updated the frontend CLI prompt template to show `opencode run --dir "{{WORKING_DIRECTORY}}" --format json` for opencode/opencode-legacy.
- Changed the Python agent CLI implementation to add `"--dir", str(cwd)` when building the `opencode run` command.
- Updated the unit test `test_run_agent_success` to assert the subprocess call includes `"--dir", "/test"` in the command arguments.

### Testing

- Ran unit tests for `test_opencode_database_agent_cli.py`, including the updated `test_run_agent_success`, and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04dfd69b108332826382bb2af87495)