### PR TITLE
Move workflow harness generation from prompt flow to backend

### DIFF
--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -1,51 +1,42 @@
 {
-  "T1": {
+  "PR416_RCA": {
     "status": "done",
     "evidence": [
-<<<<<<< HEAD
-      "PR #407: CI Docker Build failed with TypeScript error in src/utils/markdown.ts(23,20): error TS2345: Argument of type 'Window' is not assignable to parameter of type 'WindowLike'",
-      "5xWhy RCA: 1) Why did Docker build fail? -> tsc type check error in markdown.ts. 2) Why type error? -> DOMPurify(win) called with Window type that does not satisfy WindowLike. 3) Why does Window not satisfy WindowLike? -> DOMPurify's WindowLike is Pick<typeof globalThis, ...> which references globalThis properties not in lib.dom.d.ts Window. 4) Why mismatch? -> TypeScript lib.dom.d.ts Window and globalThis differ in stricter builds (the PR likely changed tsconfig or dompurify version changed its types). 5) Why was this not caught locally? -> Local dev server uses Vite which skips tsc; only the Docker build runs tsc && vite build, so error only appeared in CI."
+      "loaded existing dev/state/task-ledger.json: old T1-T4 entries were from 2026-05-09 and all status=done",
+      "gh pr view 416 --json ...: Docker Build=FAILURE; Vercel=FAILURE; QA, backend tests, system tests, preview=SUCCESS",
+      "gh run view 25924804254 --job 76203062400 --log-failed: src/pages/ConstitutionPage.tsx(685,13): error TS2322 ... Property 'onSendMessage' does not exist on type 'IntrinsicAttributes & HarnessesTabProps'",
+      "gh run view 25924804254 --job 76203062400 --log-failed: src/pages/RepositoryPage.tsx(2011,27): error TS2339: Property 'generateRepositoryWorkflowHarnesses' does not exist on type ...",
+      "5xWhy: 1. Why did CI fail? Docker frontend build ran tsc and exited 2. 2. Why did tsc fail? It found stale HarnessesTab props and a missing typed API method. 3. Why were stale props present? The backend harness generation refactor removed prompt/send-message behavior from HarnessesTab but not all call sites were updated. 4. Why was the missing API method present? The hook implementation used by RepositoryPage was not fully exposed in the returned API object/type used by production build. 5. Why was this missed before PR update? make qa-quick passed, but it did not include the same production frontend TypeScript build path that Docker/Vercel execute."
     ],
-    "last_verified": "2026-05-03T17:30:00Z"
+    "last_verified": "2026-05-15T15:09:49Z"
   },
-  "TASK_2": {
+  "PR416_PLAN": {
     "status": "done",
     "evidence": [
-      "Fix plan: Cast win to DOMPurify.WindowLike (or use 'as unknown as DOMPurify.WindowLike') to satisfy TypeScript. Alternative: use DOMPurify.sanitize directly with window check. Simplest fix: cast the window object."
+      "git switch codex/refactor-workflow-generation-to-backend: Switched to a new branch 'codex/refactor-workflow-generation-to-backend' tracking origin/codex/refactor-workflow-generation-to-backend",
+      "Plan: remove stale onSendMessage/agentCli props from HarnessesTab call sites or replace them with backend generation callbacks; expose generateRepositoryWorkflowHarnesses in useApi; add a global /api/workflows/generate-harnesses endpoint and frontend api method so global HarnessesTab instances still generate harness scripts; run production frontend build and repository QA before commit."
     ],
-    "last_verified": "2026-05-03T17:30:00Z"
+    "last_verified": "2026-05-15T15:11:39Z"
   },
-  "TASK_3": {
-=======
-      "gh pr checks 406 -> Docker Build: fail",
-      "gh run view 25285764665 -> error TS2345: Argument of type 'Window' is not assignable to parameter of type 'WindowLike'",
-      "Location: packages/frontend/src/utils/markdown.ts(77,20)",
-      "Root cause (5xWhy): 1) Docker build fails -> 2) tsc compilation fails -> 3) DOMPurify(win) where win is Window doesn't match WindowLike type -> 4) DOMPurify type expects WindowLike (specific subset of globalThis) but Window is a superset with more properties -> 5) The code cast (globalThis as {window?: Window}).window returns Window but DOMPurify factory needs WindowLike which is a more specific structural type. Fix: cast win to 'DOMPurify.WindowLike' or use 'as unknown as DOMPurify.WindowLike'"
+  "PR416_IMPLEMENT": {
+    "status": "done",
+    "evidence": [
+      "grep agentCli={agentCli} packages/frontend/src --include '*.tsx': No files found",
+      "npm run build --workspace packages/frontend: ✓ built in 1.07s",
+      "uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py -q: 125 passed in 4.83s",
+      "make qa-quick: 391 passed, 1 skipped in 12.11s; All quick quality assurance tasks completed successfully",
+      "make docker-build: Image made-frontend Built; Image made-pybackend Built"
     ],
-    "last_verified": "2026-05-03T17:30:00Z"
+    "last_verified": "2026-05-15T15:16:36Z"
   },
-  "T2": {
->>>>>>> origin/main
+  "PR416_COMMIT_PUSH": {
     "status": "in_progress",
     "evidence": [],
-    "last_verified": "2026-05-03T17:30:00Z"
+    "last_verified": "2026-05-15T15:16:56Z"
   },
-  "T3": {
+  "PR416_CI": {
     "status": "pending",
     "evidence": [],
-    "last_verified": "2026-05-03T17:30:00Z"
-  },
-  "T4": {
-    "status": "pending",
-    "evidence": [],
-    "last_verified": "2026-05-03T17:30:00Z"
-<<<<<<< HEAD
-=======
-  },
-  "T5": {
-    "status": "pending",
-    "evidence": [],
-    "last_verified": "2026-05-03T17:30:00Z"
->>>>>>> origin/main
+    "last_verified": "2026-05-15T15:09:10Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -30,9 +30,13 @@
     "last_verified": "2026-05-15T15:16:36Z"
   },
   "PR416_COMMIT_PUSH": {
-    "status": "in_progress",
-    "evidence": [],
-    "last_verified": "2026-05-15T15:16:56Z"
+    "status": "done",
+    "evidence": [
+      "git commit -m 'fix: complete backend workflow harness wiring': [codex/refactor-workflow-generation-to-backend 4e037f6] fix: complete backend workflow harness wiring",
+      "git push: aaa66f3..4e037f6 codex/refactor-workflow-generation-to-backend -> codex/refactor-workflow-generation-to-backend",
+      "pre-push make qa-quick: 391 passed, 1 skipped in 25.53s; All quick quality assurance tasks completed successfully"
+    ],
+    "last_verified": "2026-05-15T15:18:54Z"
   },
   "PR416_CI": {
     "status": "pending",

--- a/packages/frontend/src/components/HarnessesTab.tsx
+++ b/packages/frontend/src/components/HarnessesTab.tsx
@@ -29,8 +29,7 @@ type HarnessesTabProps = {
     workflows: WorkflowDefinition[],
   ) => Promise<{ workflows: WorkflowDefinition[] }>;
   listAgents: () => Promise<{ agents: { name: string }[] }>;
-  onSendMessage: (message: string) => void;
-  agentCli: string;
+  onGenerateHarnesses: (workflows: WorkflowDefinition[]) => Promise<void>;
   historyStorageKey: string;
   maxHistory?: number;
   mentionPathSuggestions?: string[];
@@ -49,8 +48,7 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
   loadWorkflows,
   saveWorkflows,
   listAgents,
-  onSendMessage,
-  agentCli,
+  onGenerateHarnesses,
   historyStorageKey,
   maxHistory = 10,
   mentionPathSuggestions = [],
@@ -236,8 +234,7 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
           loadWorkflows={loadWorkflows}
           saveWorkflows={(payload) => saveWorkflows(payload.workflows)}
           listAgents={listAgents}
-          onRunWorkflow={onSendMessage}
-          agentCli={agentCli}
+          onRunWorkflow={onGenerateHarnesses}
           mentionPathSuggestions={mentionPathSuggestions}
         />
       </Panel>

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -11,10 +11,7 @@ import { RefreshIcon } from "./icons/RefreshIcon";
 import { SaveIcon } from "./icons/SaveIcon";
 import { TrashIcon } from "./icons/TrashIcon";
 import { XIcon } from "./icons/XIcon";
-import {
-  buildWorkflowHarnessPrompt,
-  workflowShellScriptPath,
-} from "../utils/workflowHarnessPrompt";
+import { workflowShellScriptPath } from "../utils/workflowHarnessPrompt";
 
 export type WorkflowStep = {
   type: "agent" | "bash";
@@ -39,8 +36,7 @@ type WorkflowBuilderPanelProps = {
     workflows: WorkflowDefinition[];
   }) => Promise<unknown>;
   listAgents: () => Promise<{ agents: AvailableAgent[] }>;
-  onRunWorkflow: (prompt: string) => void;
-  agentCli: string;
+  onRunWorkflow: (workflows: WorkflowDefinition[]) => Promise<void>;
   mentionPathSuggestions?: string[];
 };
 
@@ -84,7 +80,6 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
   saveWorkflows,
   listAgents,
   onRunWorkflow,
-  agentCli,
   mentionPathSuggestions = [],
 }) => {
   const [workflows, setWorkflows] = useState<WorkflowDefinition[]>([]);
@@ -312,13 +307,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                         : item,
                     );
                     await persist(next);
-                    const workflowForPrompt = {
-                      ...workflow,
-                      shellScriptPath,
-                    };
-                    onRunWorkflow(
-                      buildWorkflowHarnessPrompt(workflowForPrompt, agentCli),
-                    );
+                    await onRunWorkflow(next);
                   }}
                 >
                   <PlayIcon />

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -575,6 +575,17 @@ export const api = {
         body: JSON.stringify({ workflows }),
       },
     ),
+  generateRepositoryWorkflowHarnesses: (
+    name: string,
+    workflows: WorkflowDefinition[],
+  ) =>
+    request<{ written: string[] }>(
+      `/repositories/${name}/workflows/generate-harnesses`,
+      {
+        method: "POST",
+        body: JSON.stringify({ workflows }),
+      },
+    ),
   getCommands: () => request<{ commands: CommandDefinition[] }>("/commands"),
   getHarnesses: () => request<{ harnesses: HarnessDefinition[] }>("/harnesses"),
   runHarness: (path: string, args?: string) =>
@@ -614,6 +625,11 @@ export const api = {
   saveWorkflows: (workflows: WorkflowDefinition[]) =>
     request<{ workflows: WorkflowDefinition[] }>("/workflows", {
       method: "PUT",
+      body: JSON.stringify({ workflows }),
+    }),
+  generateWorkflowHarnesses: (workflows: WorkflowDefinition[]) =>
+    request<{ written: string[] }>("/workflows/generate-harnesses", {
+      method: "POST",
       body: JSON.stringify({ workflows }),
     }),
   getAgents: () => request<{ agents: AvailableAgent[] }>("/agents"),

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -682,8 +682,10 @@ export const ConstitutionPage: React.FC = () => {
             loadWorkflows={() => api.getWorkflows()}
             saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
             listAgents={() => api.getAgents()}
-            onSendMessage={(message) => void handleSendMessage(message)}
-            agentCli={agentCli}
+            onGenerateHarnesses={async (workflows) => {
+              await api.generateWorkflowHarnesses(workflows);
+              await loadHarnesses();
+            }}
             historyStorageKey={harnessHistoryStorageKey}
             mentionPathSuggestions={mentionCommandPaths}
           />

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -697,8 +697,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
           loadWorkflows={() => api.getWorkflows()}
           saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
           listAgents={() => api.getAgents()}
-          onSendMessage={(message) => void handleSendMessage(message)}
-          agentCli={agentCli}
+          onGenerateHarnesses={async (workflows) => {
+            await api.generateWorkflowHarnesses(workflows);
+            await loadHarnesses();
+          }}
           historyStorageKey={harnessHistoryStorageKey}
           mentionPathSuggestions={mentionCommandPaths}
         />

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -2007,11 +2007,13 @@ export const RepositoryPage: React.FC = () => {
                 api.saveRepositoryWorkflows(name || "", payload.workflows)
               }
               listAgents={() => api.getRepositoryAgents(name || "")}
-              onRunWorkflow={(message) => {
-                void handleSendMessage(message);
-                setActiveTab("agent");
+              onRunWorkflow={async (workflows) => {
+                await api.generateRepositoryWorkflowHarnesses(
+                  name || "",
+                  workflows,
+                );
+                await loadHarnesses();
               }}
-              agentCli={agentCli}
               mentionPathSuggestions={mentionPathSuggestions}
             />
           </Panel>

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -641,8 +641,10 @@ export const TaskPage: React.FC = () => {
                 loadWorkflows={() => api.getWorkflows()}
                 saveWorkflows={(workflows) => api.saveWorkflows(workflows)}
                 listAgents={() => api.getAgents()}
-                onSendMessage={(message) => void handleSendMessage(message)}
-                agentCli={agentCli}
+                onGenerateHarnesses={async (workflows) => {
+                  await api.generateWorkflowHarnesses(workflows);
+                  await loadHarnesses();
+                }}
                 historyStorageKey={harnessHistoryStorageKey}
                 mentionPathSuggestions={mentionCommandPaths}
               />

--- a/packages/frontend/src/utils/workflowHarnessPrompt.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.ts
@@ -83,6 +83,7 @@ export const buildWorkflowHarnessPrompt = (
     workflow.shellScriptPath || workflowShellScriptPath(workflow.name),
   );
   output = apply(output, "{{WORKFLOW_YAML}}", workflowToYaml(workflow));
+  output = apply(output, "{ { WORKFLOW_YAML } }", workflowToYaml(workflow));
   output = apply(output, "{{CURRENT_AGENT_CLI}}", agentCli || "opencode");
   return output;
 };

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -64,6 +64,7 @@ from external_matter_service import read_external_matter, write_external_matter
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
 from workflow_service import list_workspace_workflows, read_workflows, write_workflows
+from workflow_harness_service import generate_workflow_harnesses, WorkflowParseError
 from cron_service import (
     force_terminate_job,
     get_cron_job_diagnostics,
@@ -826,6 +827,28 @@ def repository_git_worktree_delete(name: str):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@app.post("/api/repositories/{name}/workflows/generate-harnesses")
+def generate_repository_workflow_harnesses(name: str, payload: dict = Body(...)):
+    try:
+        _repository_path(name)
+        logger.info("Generating harnesses for repository workflows: %s", name)
+        written = generate_workflow_harnesses(payload, get_workspace_home() / name)
+        return {"written": written}
+    except WorkflowParseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except Exception as exc:
+        logger.exception("Failed to generate harnesses for repository '%s'", name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        ) from exc
 
 
 @app.get("/api/repositories/{name}/workflows")

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -101,6 +101,7 @@ from settings_service import read_settings, write_settings
 from config import (
     ensure_directory,
     ensure_made_structure,
+    get_made_home,
     get_made_directory,
     get_workspace_home,
     get_backend_host,
@@ -891,6 +892,23 @@ def global_workflows():
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         )
+
+
+@app.post("/api/workflows/generate-harnesses")
+def generate_global_workflow_harnesses(payload: dict = Body(...)):
+    try:
+        logger.info("Generating harnesses for global workflows")
+        written = generate_workflow_harnesses(payload, get_made_home())
+        return {"written": written}
+    except WorkflowParseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    except Exception as exc:
+        logger.exception("Failed to generate global workflow harnesses")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        ) from exc
 
 
 @app.put("/api/workflows")

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1472,3 +1472,33 @@ class TestVersionEndpoint:
         assert "commit_sha" in data
         assert "build_date" in data
         assert "environment" in data
+    @patch("app._repository_path")
+    @patch("app.generate_workflow_harnesses")
+    def test_generate_repository_workflow_harnesses_success(self, mock_generate, mock_repo_path):
+        mock_repo_path.return_value = "/tmp/sample"
+        mock_generate.return_value = [".harness/test.sh"]
+
+        response = client.post(
+            "/api/repositories/sample/workflows/generate-harnesses",
+            json={"workflows": []},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"written": [".harness/test.sh"]}
+
+    @patch("app._repository_path")
+    @patch("app.generate_workflow_harnesses")
+    def test_generate_repository_workflow_harnesses_validation_error(self, mock_generate, mock_repo_path):
+        from workflow_harness_service import WorkflowParseError
+
+        mock_repo_path.return_value = "/tmp/sample"
+        mock_generate.side_effect = WorkflowParseError("bad payload")
+
+        response = client.post(
+            "/api/repositories/sample/workflows/generate-harnesses",
+            json={"workflows": []},
+        )
+
+        assert response.status_code == 400
+
+

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -3,8 +3,10 @@ Unit tests for the MADE Python Backend API endpoints.
 Tests cover all main API endpoints with proper mocking of services.
 """
 
-from fastapi.testclient import TestClient
+from pathlib import Path
 from unittest.mock import patch
+
+from fastapi.testclient import TestClient
 
 from agent_service import ChannelBusyError
 
@@ -1501,4 +1503,32 @@ class TestVersionEndpoint:
 
         assert response.status_code == 400
 
+    @patch("app.get_made_home")
+    @patch("app.generate_workflow_harnesses")
+    def test_generate_global_workflow_harnesses_success(
+        self, mock_generate, mock_made_home
+    ):
+        mock_made_home.return_value = Path("/tmp/made")
+        mock_generate.return_value = [".harness/test.sh"]
 
+        response = client.post(
+            "/api/workflows/generate-harnesses",
+            json={"workflows": []},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"written": [".harness/test.sh"]}
+        mock_generate.assert_called_once_with({"workflows": []}, Path("/tmp/made"))
+
+    @patch("app.generate_workflow_harnesses")
+    def test_generate_global_workflow_harnesses_validation_error(self, mock_generate):
+        from workflow_harness_service import WorkflowParseError
+
+        mock_generate.side_effect = WorkflowParseError("bad payload")
+
+        response = client.post(
+            "/api/workflows/generate-harnesses",
+            json={"workflows": []},
+        )
+
+        assert response.status_code == 400

--- a/packages/pybackend/workflow_harness_service.py
+++ b/packages/pybackend/workflow_harness_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import re
+import stat
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+
+class WorkflowParseError(ValueError):
+    """Raised when workflows cannot be validated."""
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class BaseStep(StrictModel):
+    name: str | None = None
+
+
+class BashStep(BaseStep):
+    type: Literal["bash"]
+    run: str
+
+
+class AgentStep(BaseStep):
+    type: Literal["agent"]
+    prompt: str
+    agent: str | None = None
+
+
+Step = Annotated[BashStep | AgentStep, Field(discriminator="type")]
+
+
+class Workflow(StrictModel):
+    id: str
+    name: str
+    enabled: bool
+    schedule: str | None = None
+    steps: list[Step]
+    shell_script_path: str = Field(alias="shellScriptPath")
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if not re.fullmatch(r"wf_[A-Za-z0-9_-]+", value):
+            raise ValueError("must match ^wf_[A-Za-z0-9_-]+$")
+        return value
+
+
+class WorkflowFile(StrictModel):
+    workflows: list[Workflow]
+
+
+def parse_workflow_payload(payload: dict) -> WorkflowFile:
+    try:
+        return WorkflowFile.model_validate(payload)
+    except ValidationError as error:
+        raise WorkflowParseError(str(error)) from error
+
+
+def render_harness(workflow: Workflow) -> str:
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        f"echo {bash_quote(f'Starting workflow: {workflow.name}')}",
+        "",
+    ]
+    for index, step in enumerate(workflow.steps, start=1):
+        lines.append(f"# Step {index}: {step.name or step.type}")
+        if isinstance(step, BashStep):
+            lines.extend(step.run.splitlines())
+        else:
+            lines.extend(render_agent_step(step))
+        lines.append("")
+
+    lines.append(f"echo {bash_quote(f'Workflow finished: {workflow.name}')}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_agent_step(step: AgentStep) -> list[str]:
+    lines = ["cmd=(opencode run --format json)"]
+    if step.agent:
+        lines.append(f"cmd+=(--agent {bash_quote(step.agent)})")
+    lines.append(f"printf '%s' {bash_quote(step.prompt)} | \"${{cmd[@]}}\"")
+    return lines
+
+
+def generate_workflow_harnesses(payload: dict, output_root: Path) -> list[str]:
+    workflow_file = parse_workflow_payload(payload)
+    written: list[str] = []
+    for workflow in workflow_file.workflows:
+        output_path = output_root / workflow.shell_script_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(render_harness(workflow), encoding="utf-8")
+        mode = output_path.stat().st_mode
+        output_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        written.append(workflow.shell_script_path)
+    return written
+
+
+def bash_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"

--- a/packages/pybackend/workflow_harness_service.py
+++ b/packages/pybackend/workflow_harness_service.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 
 class WorkflowParseError(ValueError):
-    """Raised when workflows cannot be validated."""
+    pass
 
 
 class StrictModel(BaseModel):
@@ -18,6 +18,13 @@ class StrictModel(BaseModel):
 
 class BaseStep(StrictModel):
     name: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_optional_string(cls, value: str | None) -> str | None:
+        if value is not None and value.strip() == "":
+            raise ValueError("must not be empty")
+        return value
 
 
 class BashStep(BaseStep):
@@ -31,7 +38,24 @@ class AgentStep(BaseStep):
     agent: str | None = None
 
 
-Step = Annotated[BashStep | AgentStep, Field(discriminator="type")]
+class VarsStep(BaseStep):
+    type: Literal["vars"]
+    values: dict[str, str]
+
+    @field_validator("values")
+    @classmethod
+    def validate_values(cls, value: dict[str, str]) -> dict[str, str]:
+        if not value:
+            raise ValueError("must contain at least one variable")
+        for name, command in value.items():
+            if not re.fullmatch(r"[A-Z_][A-Z0-9_]*", name):
+                raise ValueError(f"invalid variable name: {name}")
+            if command.strip() == "":
+                raise ValueError(f"empty command for variable: {name}")
+        return value
+
+
+Step = Annotated[VarsStep | BashStep | AgentStep, Field(discriminator="type")]
 
 
 class Workflow(StrictModel):
@@ -49,6 +73,22 @@ class Workflow(StrictModel):
             raise ValueError("must match ^wf_[A-Za-z0-9_-]+$")
         return value
 
+    @field_validator("steps")
+    @classmethod
+    def validate_steps(cls, value: list[Step]) -> list[Step]:
+        if not value:
+            raise ValueError("must contain at least one step")
+        return value
+
+    @field_validator("shell_script_path")
+    @classmethod
+    def validate_shell_script_path(cls, value: str) -> str:
+        if not re.fullmatch(r"\.harness/[A-Za-z0-9._/-]+\.sh", value):
+            raise ValueError("must be a relative .harness/*.sh path")
+        if ".." in Path(value).parts:
+            raise ValueError("must not contain '..'")
+        return value
+
 
 class WorkflowFile(StrictModel):
     workflows: list[Workflow]
@@ -59,35 +99,6 @@ def parse_workflow_payload(payload: dict) -> WorkflowFile:
         return WorkflowFile.model_validate(payload)
     except ValidationError as error:
         raise WorkflowParseError(str(error)) from error
-
-
-def render_harness(workflow: Workflow) -> str:
-    lines = [
-        "#!/usr/bin/env bash",
-        "set -euo pipefail",
-        "",
-        f"echo {bash_quote(f'Starting workflow: {workflow.name}')}",
-        "",
-    ]
-    for index, step in enumerate(workflow.steps, start=1):
-        lines.append(f"# Step {index}: {step.name or step.type}")
-        if isinstance(step, BashStep):
-            lines.extend(step.run.splitlines())
-        else:
-            lines.extend(render_agent_step(step))
-        lines.append("")
-
-    lines.append(f"echo {bash_quote(f'Workflow finished: {workflow.name}')}")
-    lines.append("")
-    return "\n".join(lines)
-
-
-def render_agent_step(step: AgentStep) -> list[str]:
-    lines = ["cmd=(opencode run --format json)"]
-    if step.agent:
-        lines.append(f"cmd+=(--agent {bash_quote(step.agent)})")
-    lines.append(f"printf '%s' {bash_quote(step.prompt)} | \"${{cmd[@]}}\"")
-    return lines
 
 
 def generate_workflow_harnesses(payload: dict, output_root: Path) -> list[str]:
@@ -101,6 +112,33 @@ def generate_workflow_harnesses(payload: dict, output_root: Path) -> list[str]:
         output_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         written.append(workflow.shell_script_path)
     return written
+
+
+def render_harness(workflow: Workflow) -> str:
+    lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""]
+    for index, step in enumerate(workflow.steps, start=1):
+        lines.extend(render_step(index, step))
+    return "\n".join(lines) + "\n"
+
+
+def render_step(index: int, step: Step) -> list[str]:
+    function_name = f"step_{index}"
+    lines = [f"{function_name}() {{"]
+    if isinstance(step, VarsStep):
+        for name, command in step.values.items():
+            lines.append(f"  {name}=$({command})")
+        lines += ["}", f"{function_name}", ""]
+        return lines
+    if isinstance(step, BashStep):
+        lines.extend(f"  {line}" if line else "" for line in step.run.splitlines())
+        lines += ["}", f"{function_name}", ""]
+        return lines
+    lines.append("  local cmd=(opencode run --format json)")
+    if step.agent:
+        lines.append(f"  cmd+=(--agent {bash_quote(step.agent)})")
+    lines.append(f"  printf '%s' {bash_quote(step.prompt)} | \"${{cmd[@]}}\"")
+    lines += ["}", f"{function_name}", ""]
+    return lines
 
 
 def bash_quote(value: str) -> str:


### PR DESCRIPTION
### Motivation
- Replace the prompt-based workflow→harness generation with a deterministic, backend-driven implementation using strict Pydantic validation to avoid LLM/prompt fragility and ensure reproducible harness scripts.
- Keep harness generation triggered from the frontend but move the generation logic into the Python backend so scripts are created server-side and persisted into the repository workspace.

### Description
- Added `packages/pybackend/workflow_harness_service.py` which defines Pydantic models (`WorkflowFile`, `Workflow`, `Step`, `BashStep`, `AgentStep`), validates workflow payloads, and renders deterministic bash harness scripts via `generate_workflow_harnesses` and `render_harness`.
- Added a new backend endpoint `POST /api/repositories/{name}/workflows/generate-harnesses` that validates payloads, writes generated harness scripts under the repository workspace, and returns written paths with proper 400/404/500 error handling (`app.py`).
- Updated frontend to call the backend generator instead of producing an agent prompt: `WorkflowBuilderPanel` now persists `shellScriptPath` and calls `onRunWorkflow` with the workflows payload; `HarnessesTab` and `RepositoryPage` were updated to invoke `generateRepositoryWorkflowHarnesses` and refresh harnesses; `useApi.ts` now exposes `generateRepositoryWorkflowHarnesses`.
- Removed the previous prompt construction flow in the run path and the `agentCli` dependency for the run action so harness generation is purely backend-driven.

### Testing
- Ran the repository quick QA: `make qa-quick` which performed formatting and linting on frontend and backend and completed successfully.
- Ran backend unit tests via the QA run (`cd packages/pybackend && uv sync && uv run pytest -c pytest.cov.ini tests/unit/`) with all tests passing: `387 passed, 1 skipped`.
- Ruff formatting/lint checks and frontend formatting/linting were executed as part of `make qa-quick` and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071926fcb48332a69836a1d31bb5f0)