### PR TITLE
Expand harness discovery locations and update tests

### DIFF
--- a/packages/pybackend/harness_service.py
+++ b/packages/pybackend/harness_service.py
@@ -32,10 +32,12 @@ def _load_repo_harnesses(repo_name: str | None) -> List[Dict[str, Any]]:
     repo_path = get_workspace_home() / repo_name
     harness_entries: List[Tuple[Path, str]] = []
     if repo_path.exists():
-        for directory in [repo_path / ".opencode" / "harness", repo_path / ".harness"]:
-            for path in directory.rglob("*.sh"):
-                if path.is_file():
-                    harness_entries.append((path, "repository"))
+        for path in repo_path.glob(".*/harness/**/*.sh"):
+            if path.is_file():
+                harness_entries.append((path, "repository"))
+        for path in (repo_path / ".harness").rglob("*.sh"):
+            if path.is_file():
+                harness_entries.append((path, "repository"))
 
     return [
         _load_harness_file(path, source) for path, source in sorted(harness_entries)
@@ -45,14 +47,22 @@ def _load_repo_harnesses(repo_name: str | None) -> List[Dict[str, Any]]:
 def list_harnesses(repo_name: str | None = None) -> List[Dict[str, Any]]:
     harnesses: List[Dict[str, Any]] = []
     harness_roots: List[Tuple[Path, str]] = [
-        (get_made_home(), "made"),
-        (get_workspace_home(), "workspace"),
-        (Path.home(), "user"),
+        (get_made_home() / ".made" / "harness", "made"),
+        (get_workspace_home() / ".made" / "harness", "workspace"),
+        (get_made_home() / ".kiro" / "harness", "made"),
+        (get_workspace_home() / ".kiro" / "harness", "workspace"),
+        (Path.home() / ".made" / "harness", "user"),
+        (Path.home() / ".claude" / "harness", "user"),
+        (Path.home() / ".codex" / "harness", "user"),
+        (Path.home() / ".kiro" / "harness", "user"),
+        (Path.home() / ".opencode" / "harness", "user"),
+        (get_made_home() / ".harness", "made"),
+        (get_workspace_home() / ".harness", "workspace"),
+        (Path.home() / ".harness", "user"),
     ]
 
-    for root, source in harness_roots:
-        for directory in [root / ".opencode" / "harness", root / ".harness"]:
-            harnesses.extend(_load_harnesses_from_dir(directory, source))
+    for directory, source in harness_roots:
+        harnesses.extend(_load_harnesses_from_dir(directory, source))
 
     harnesses.extend(_load_repo_harnesses(repo_name))
     return harnesses

--- a/packages/pybackend/tests/unit/test_harness_service.py
+++ b/packages/pybackend/tests/unit/test_harness_service.py
@@ -29,15 +29,15 @@ def temp_env(tmp_path, monkeypatch):
 def test_list_harnesses_collects_all_locations(temp_env):
     workspace, made_home, user_home = temp_env
     repo_path = workspace / "sample-repo"
-    repo_harness = repo_path / ".opencode" / "harness" / "repo.sh"
-    workspace_harness = workspace / ".harness" / "workspace.sh"
-    made_harness = made_home / ".harness" / "made.sh"
+    repo_harness = repo_path / ".codex" / "harness" / "repo.sh"
+    workspace_harness = workspace / ".made" / "harness" / "workspace.sh"
+    made_harness = made_home / ".made" / "harness" / "made.sh"
     user_harness = user_home / ".opencode" / "harness" / "user.sh"
 
     for path in [
-        repo_path / ".opencode" / "harness",
-        workspace / ".harness",
-        made_home / ".harness",
+        repo_path / ".codex" / "harness",
+        workspace / ".made" / "harness",
+        made_home / ".made" / "harness",
         user_home / ".opencode" / "harness",
     ]:
         path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Motivation
- Support additional common harness directory names and locations so repository, workspace and user harness scripts are discovered across variants like `.made`, `.codex`, `.kiro`, `.claude` and legacy `.opencode`/`.harness` layouts.
- Make repository-level scanning more flexible for dot-prefixed directories that contain a `harness` subtree.

### Description
- Changed `_load_repo_harnesses` to include `repo_path.glob(".*/harness/**/*.sh")` for dot-prefixed harness folders and to still traverse `repo_path / ".harness"` with `rglob` for backward compatibility.
- Reworked `list_harnesses` to explicitly enumerate multiple harness root candidates such as `get_made_home() / ".made" / "harness"`, `get_workspace_home() / ".made" / "harness"`, `Path.home() / ".codex" / "harness"`, `Path.home() / ".kiro" / "harness"`, `Path.home() / ".opencode" / "harness"`, and legacy `*.harness` locations and then load harnesses from each directory via `_load_harnesses_from_dir`.
- Simplified the loop that collects harness entries to iterate over `(directory, source)` pairs and removed nested per-root internal directory loops.
- Updated unit tests in `packages/pybackend/tests/unit/test_harness_service.py` to reflect the new expected harness locations and names.

### Testing
- Ran unit tests in `packages/pybackend/tests/unit/test_harness_service.py` which exercise `list_harnesses` and `run_harness`.
- `test_list_harnesses_collects_all_locations` and `test_run_harness_starts_process` executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0734dc80fc83328e6af172eb8f50de)