### PR TITLE
Fix duplicate harness entries in harness lists

### DIFF
--- a/packages/frontend/src/components/HarnessesTab.tsx
+++ b/packages/frontend/src/components/HarnessesTab.tsx
@@ -104,7 +104,13 @@ export const HarnessesTab: React.FC<HarnessesTabProps> = ({
     setHarnessLoading(true);
     loadHarnesses()
       .then((response) => {
-        setAvailableHarnesses(response);
+        const uniqueHarnesses = response.filter(
+          (harness, index, allHarnesses) =>
+            allHarnesses.findIndex(
+              (candidate) => candidate.path === harness.path,
+            ) === index,
+        );
+        setAvailableHarnesses(uniqueHarnesses);
         setHarnessError(null);
       })
       .catch((error) => {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -839,7 +839,13 @@ export const RepositoryPage: React.FC = () => {
     api
       .getRepositoryHarnesses(name)
       .then((response) => {
-        setAvailableHarnesses(response.harnesses);
+        const uniqueHarnesses = response.harnesses.filter(
+          (harness, index, allHarnesses) =>
+            allHarnesses.findIndex(
+              (candidate) => candidate.path === harness.path,
+            ) === index,
+        );
+        setAvailableHarnesses(uniqueHarnesses);
         setHarnessError(null);
       })
       .catch((error) => {


### PR DESCRIPTION
### Motivation
- Harness scripts could appear multiple times in the UI when overlapping scan sources return the same file path, so the list needs deduplication by path.

### Description
- In `packages/frontend/src/components/HarnessesTab.tsx` deduplicate harnesses returned by `loadHarnesses` by `path` before calling `setAvailableHarnesses`.
- In `packages/frontend/src/pages/RepositoryPage.tsx` deduplicate `response.harnesses` by `path` before calling `setAvailableHarnesses`.
- Deduplication is implemented using `Array.prototype.filter` with `findIndex` comparing `candidate.path === harness.path`.

### Testing
- Ran `make qa-quick` which runs formatting, linters, and tests, and it completed successfully.
- Frontend formatting and `eslint` passed and backend `ruff` checks passed.
- Backend unit tests ran via `uv run pytest` with `391 passed, 1 skipped`, and overall QA succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075ee8a6748332a4714331f4e00427)