### PR TITLE
Generate production-safe workflow harness scripts

### DIFF
--- a/packages/pybackend/tests/unit/test_workflow_harness_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_harness_service.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import pytest
+
+from workflow_harness_service import (
+    WorkflowParseError,
+    generate_workflow_harnesses,
+    parse_workflow_payload,
+    render_harness,
+)
+
+
+def sample_payload() -> dict:
+    return {
+        "workflows": [
+            {
+                "id": "wf_release_flow",
+                "name": "Release Flow",
+                "enabled": True,
+                "schedule": None,
+                "shellScriptPath": ".harness/release-flow.sh",
+                "steps": [
+                    {
+                        "type": "vars",
+                        "name": "Resolve SHA",
+                        "values": {"GIT_SHA": "git rev-parse HEAD"},
+                    },
+                    {
+                        "type": "bash",
+                        "name": "Echo SHA",
+                        "run": "echo \"$GIT_SHA\"\n",
+                    },
+                    {
+                        "type": "agent",
+                        "name": "Summarize",
+                        "agent": "reviewer",
+                        "prompt": "Summarize release notes\nwith bullets",
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def test_render_harness_includes_logging_dry_run_and_agent_helpers():
+    workflow = parse_workflow_payload(sample_payload()).workflows[0]
+
+    harness = render_harness(workflow)
+
+    assert "set -euo pipefail" in harness
+    assert "DRY_RUN=false" in harness
+    assert 'if [[ $# -eq 1 && "$1" == "--dry-run" ]]; then' in harness
+    assert 'LOG_DIR="${FLOWSH_LOG_DIR:-.flowsh/logs}"' in harness
+    assert "run_step() {" in harness
+    assert "run_stateful_step() {" in harness
+    assert "run_agent() {" in harness
+    assert 'cmd+=(--agent "$agent")' in harness
+    assert "Step 1 (vars): Resolve SHA" in harness
+    assert "Step 2 (bash): Echo SHA" in harness
+    assert "Step 3 (agent): Summarize" in harness
+    assert "run_stateful_step step_resolve_sha" in harness
+    assert "run_step step_echo_sha" in harness
+    assert "run_step step_summarize" in harness
+    assert "prompt=$(cat <<'PROMPT_EOF'" in harness
+
+
+def test_generate_workflow_harnesses_writes_executable_file(tmp_path: Path):
+    payload = sample_payload()
+
+    written = generate_workflow_harnesses(payload, tmp_path)
+
+    assert written == [".harness/release-flow.sh"]
+    output_path = tmp_path / ".harness/release-flow.sh"
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
+    assert output_path.stat().st_mode & 0o111
+
+
+def test_parse_workflow_payload_rejects_duplicate_workflow_ids():
+    payload = sample_payload()
+    duplicate = payload["workflows"][0].copy()
+    duplicate["shellScriptPath"] = ".harness/other.sh"
+    payload["workflows"].append(duplicate)
+
+    with pytest.raises(WorkflowParseError, match="duplicate workflow ids"):
+        parse_workflow_payload(payload)

--- a/packages/pybackend/workflow_harness_service.py
+++ b/packages/pybackend/workflow_harness_service.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 
 class WorkflowParseError(ValueError):
-    pass
+    """Raised when workflow payload cannot be validated."""
 
 
 class StrictModel(BaseModel):
@@ -31,11 +31,25 @@ class BashStep(BaseStep):
     type: Literal["bash"]
     run: str
 
+    @field_validator("run")
+    @classmethod
+    def validate_run(cls, value: str) -> str:
+        if value.strip() == "":
+            raise ValueError("must not be empty")
+        return value
+
 
 class AgentStep(BaseStep):
     type: Literal["agent"]
     prompt: str
     agent: str | None = None
+
+    @field_validator("prompt", "agent")
+    @classmethod
+    def validate_strings(cls, value: str | None) -> str | None:
+        if value is not None and value.strip() == "":
+            raise ValueError("must not be empty")
+        return value
 
 
 class VarsStep(BaseStep):
@@ -47,11 +61,13 @@ class VarsStep(BaseStep):
     def validate_values(cls, value: dict[str, str]) -> dict[str, str]:
         if not value:
             raise ValueError("must contain at least one variable")
+
         for name, command in value.items():
             if not re.fullmatch(r"[A-Z_][A-Z0-9_]*", name):
                 raise ValueError(f"invalid variable name: {name}")
             if command.strip() == "":
                 raise ValueError(f"empty command for variable: {name}")
+
         return value
 
 
@@ -71,6 +87,13 @@ class Workflow(StrictModel):
     def validate_id(cls, value: str) -> str:
         if not re.fullmatch(r"wf_[A-Za-z0-9_-]+", value):
             raise ValueError("must match ^wf_[A-Za-z0-9_-]+$")
+        return value
+
+    @field_validator("name")
+    @classmethod
+    def validate_non_empty(cls, value: str) -> str:
+        if value.strip() == "":
+            raise ValueError("must not be empty")
         return value
 
     @field_validator("steps")
@@ -93,6 +116,19 @@ class Workflow(StrictModel):
 class WorkflowFile(StrictModel):
     workflows: list[Workflow]
 
+    @field_validator("workflows")
+    @classmethod
+    def validate_workflows(cls, value: list[Workflow]) -> list[Workflow]:
+        if not value:
+            raise ValueError("must contain at least one workflow")
+
+        ids = [workflow.id for workflow in value]
+        duplicate_ids = sorted({workflow_id for workflow_id in ids if ids.count(workflow_id) > 1})
+        if duplicate_ids:
+            raise ValueError(f"duplicate workflow ids: {', '.join(duplicate_ids)}")
+
+        return value
+
 
 def parse_workflow_payload(payload: dict) -> WorkflowFile:
     try:
@@ -104,6 +140,7 @@ def parse_workflow_payload(payload: dict) -> WorkflowFile:
 def generate_workflow_harnesses(payload: dict, output_root: Path) -> list[str]:
     workflow_file = parse_workflow_payload(payload)
     written: list[str] = []
+
     for workflow in workflow_file.workflows:
         output_path = output_root / workflow.shell_script_path
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -111,35 +148,214 @@ def generate_workflow_harnesses(payload: dict, output_root: Path) -> list[str]:
         mode = output_path.stat().st_mode
         output_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         written.append(workflow.shell_script_path)
+
     return written
 
 
 def render_harness(workflow: Workflow) -> str:
-    lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""]
+    script_name = Path(workflow.shell_script_path).name
+    lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        f"SCRIPT_NAME={bash_quote(script_name)}",
+        'WORKFLOW_NAME="${SCRIPT_NAME%.sh}"',
+        "WORKFLOW_SLUG=$(printf '%s' \"$WORKFLOW_NAME\" \\",
+        "  | tr '[:upper:]' '[:lower:]' \\",
+        "  | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')",
+        "LOG_TIMESTAMP=\"$(date -u +'%Y%m%dT%H%M%SZ')\"",
+        'LOG_BASENAME="flowsh-${WORKFLOW_SLUG}-${LOG_TIMESTAMP}-$$.log"',
+        "",
+        section("Argument handling"),
+        "DRY_RUN=false",
+        'if [[ $# -eq 1 && "$1" == "--dry-run" ]]; then',
+        "  DRY_RUN=true",
+        "elif [[ $# -gt 0 ]]; then",
+        "  printf \"Usage: %s [--dry-run]\\n\" \"$0\" >&2",
+        "  exit 2",
+        "fi",
+        "",
+        section("Log file setup - local by default, override with FLOWSH_LOG_DIR"),
+        'LOG_DIR="${FLOWSH_LOG_DIR:-.flowsh/logs}"',
+        'mkdir -p "$LOG_DIR"',
+        'LOG_FILE="${LOG_DIR}/${LOG_BASENAME}"',
+        "",
+        section("log() — ISO-8601 UTC timestamps, INFO/ERROR, stderr + log file"),
+        "log() {",
+        '  local level="$1"; shift',
+        "  local message",
+        "  message=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ') [${level}] $*\"",
+        "  printf '%s\\n' \"$message\" >&2",
+        "  printf '%s\\n' \"$message\" >> \"$LOG_FILE\" 2>/dev/null || true",
+        "}",
+        "",
+        section("catch() — centralized step failure hook"),
+        "catch() {",
+        '  local step_name="$1"',
+        '  local exit_code="$2"',
+        '  log ERROR "Step failed: ${step_name} (exit=${exit_code})"',
+        "}",
+        "",
+        section("run_step() — dry-run and failure handling; streams output via tee"),
+        "run_step() {",
+        '  local step_name="$1"',
+        "",
+        '  if [[ "$DRY_RUN" == true ]]; then',
+        '    log INFO "[DRY-RUN] would run: ${step_name}"',
+        "    return 0",
+        "  fi",
+        "",
+        '  log INFO "Running step: ${step_name}"',
+        "",
+        "  set +e",
+        '  if ( : >> "$LOG_FILE" ) 2>/dev/null; then',
+        '    "$step_name" 2>&1 | tee -a "$LOG_FILE"',
+        "    local status=${PIPESTATUS[0]}",
+        "  else",
+        '    "$step_name"',
+        "    local status=$?",
+        "  fi",
+        "  set -e",
+        "",
+        "  if [[ $status -ne 0 ]]; then",
+        '    catch "$step_name" "$status"',
+        "  fi",
+        '  return "$status"',
+        "}",
+        "",
+        section("run_stateful_step() — dry-run and failure handling without subshells"),
+        "run_stateful_step() {",
+        '  local step_name="$1"',
+        "",
+        '  if [[ "$DRY_RUN" == true ]]; then',
+        '    log INFO "[DRY-RUN] would run: ${step_name}"',
+        "    return 0",
+        "  fi",
+        "",
+        '  log INFO "Running step: ${step_name}"',
+        "",
+        "  set +e",
+        '  "$step_name"',
+        "  local status=$?",
+        "  set -e",
+        "",
+        "  if [[ $status -ne 0 ]]; then",
+        '    catch "$step_name" "$status"',
+        "  fi",
+        '  return "$status"',
+        "}",
+        "",
+        section("run_agent() — prompt handling and OpenCode CLI invocation"),
+        "run_agent() {",
+        '  local prompt="$1"',
+        '  local agent="${2:-}"',
+        "",
+        "  local cmd=(opencode run --format json)",
+        '  if [[ -n "$agent" ]]; then',
+        '    cmd+=(--agent "$agent")',
+        "  fi",
+        "",
+        '  if [[ "$DRY_RUN" == true ]]; then',
+        '    log INFO "[DRY-RUN] would run: $(printf \'%q \' \"${cmd[@]}\") (with prompt)"',
+        "    return 0",
+        "  fi",
+        "",
+        '  printf \'%s\' "$prompt" | "${cmd[@]}"',
+        "}",
+        "",
+        section(f"Starting workflow: {workflow.name}"),
+        f"log INFO {bash_quote(f'Starting workflow: {workflow.name}')}",
+        "",
+    ]
+
     for index, step in enumerate(workflow.steps, start=1):
         lines.extend(render_step(index, step))
+
+    lines.extend([
+        section(f"Workflow finished: {workflow.name}"),
+        f"log INFO {bash_quote(f'Workflow finished: {workflow.name}')}",
+        "",
+    ])
+
     return "\n".join(lines) + "\n"
 
 
 def render_step(index: int, step: Step) -> list[str]:
-    function_name = f"step_{index}"
-    lines = [f"{function_name}() {{"]
+    function_name = step_function_name(index, step.name)
+    title = step.name or default_step_title(index, step)
+    lines = [section(f"Step {index} ({step.type}): {title}"), f"{function_name}() {{"]
+
     if isinstance(step, VarsStep):
         for name, command in step.values.items():
             lines.append(f"  {name}=$({command})")
-        lines += ["}", f"{function_name}", ""]
-        return lines
-    if isinstance(step, BashStep):
-        lines.extend(f"  {line}" if line else "" for line in step.run.splitlines())
-        lines += ["}", f"{function_name}", ""]
-        return lines
-    lines.append("  local cmd=(opencode run --format json)")
-    if step.agent:
-        lines.append(f"  cmd+=(--agent {bash_quote(step.agent)})")
-    lines.append(f"  printf '%s' {bash_quote(step.prompt)} | \"${{cmd[@]}}\"")
-    lines += ["}", f"{function_name}", ""]
+    elif isinstance(step, BashStep):
+        for command_line in step.run.strip().splitlines():
+            lines.append(f"  {command_line}" if command_line.strip() else "")
+    elif isinstance(step, AgentStep):
+        delimiter = heredoc_delimiter("PROMPT", step.prompt)
+        lines.extend([
+            "  local prompt",
+            f"  prompt=$(cat <<'{delimiter}'",
+            *step.prompt.splitlines(),
+            delimiter,
+            "  )",
+        ])
+        if step.agent:
+            lines.append(f"  local agent={bash_quote(step.agent)}")
+            lines.append('  run_agent "$prompt" "$agent"')
+        else:
+            lines.append('  run_agent "$prompt"')
+
+    runner = "run_stateful_step" if isinstance(step, VarsStep) else "run_step"
+    lines.extend(["}", f"{runner} {function_name}", ""])
     return lines
+
+
+def default_step_title(index: int, step: Step) -> str:
+    if isinstance(step, VarsStep):
+        return ", ".join(step.values.keys())
+    if isinstance(step, BashStep):
+        return truncate_one_line(step.run)
+    if isinstance(step, AgentStep):
+        return truncate_one_line(step.prompt)
+    return f"step {index}"
+
+
+def truncate_one_line(text: str, limit: int = 80) -> str:
+    compact = re.sub(r"\s+", " ", text).strip()
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1] + "…"
+
+
+def step_function_name(index: int, name: str | None) -> str:
+    source = name or f"step_{index}"
+    slug = re.sub(r"[^A-Za-z0-9_]+", "_", source).strip("_")
+    if not slug:
+        slug = f"step_{index}"
+    if slug[0].isdigit():
+        slug = f"step_{slug}"
+    if not slug.startswith("step_"):
+        slug = f"step_{slug}"
+    return slug.lower()
+
+
+def heredoc_delimiter(base: str, text: str) -> str:
+    delimiter = f"{base}_EOF"
+    counter = 1
+    while delimiter in text:
+        counter += 1
+        delimiter = f"{base}_EOF_{counter}"
+    return delimiter
 
 
 def bash_quote(value: str) -> str:
     return "'" + value.replace("'", "'\\''") + "'"
+
+
+def section(title: str) -> str:
+    return "\n".join([
+        "# ---------------------------------------------------------------------------",
+        f"# {title}",
+        "# ---------------------------------------------------------------------------",
+    ])


### PR DESCRIPTION
### Motivation
- The existing harness generator produced overly simple shell scripts that lacked logging, dry-run support, safe escaping, and consistent step handling.  
- The goal is to reproduce the original conversion behavior so generated scripts are compatible with the rest of the system (logging, dry-run, heredoc prompts, OpenCode CLI invocation).  
- Add stronger schema validation to catch malformed workflow payloads earlier and prevent invalid harness output.

### Description
- Rewrote `packages/pybackend/workflow_harness_service.py` to use stricter `pydantic` models and validators for `BashStep`, `AgentStep`, `VarsStep`, `Workflow`, and `WorkflowFile` (including duplicate workflow id detection).  
- Replaced minimal shell rendering with a full-featured `render_harness` that emits: script header, argument handling (`--dry-run`), structured timestamped logging, `log()` helper, centralized `catch()` hook, `run_step()` and `run_stateful_step()` wrappers, and a `run_agent()` helper that invokes `opencode run --format json` with optional `--agent`.  
- Improved step rendering to produce safe function names via `step_function_name`, nicer default titles via `default_step_title` and `truncate_one_line`, heredoc-based prompt handling for agent steps with unique delimiters (`heredoc_delimiter`), and robust shell quoting via `bash_quote`.  
- `generate_workflow_harnesses` writes the rendered scripts to `output_root / workflow.shell_script_path` and sets the executable bit on created files.

### Testing
- Ran `python -m py_compile packages/pybackend/workflow_harness_service.py` which succeeded.  
- Attempted `python -m pytest packages/pybackend/tests/unit/test_workflow_harness_service.py` which failed because the test path does not exist in the repository.  
- Ran `python -m pytest packages/pybackend/tests/unit/test_api.py -k workflow_harnesses` which failed during test collection with `ModuleNotFoundError: No module named 'fastapi'` indicating backend test dependencies are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077770bc8483328a3f0d2d756492bf)