### PR TITLE
Add `vars` workflow step support to workflow builder

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       timeout_minutes:
-        description: 'Preview timeout in minutes'
+        description: "Preview timeout in minutes"
         required: false
-        default: '5'
+        default: "5"
         type: string
 
 concurrency:
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    timeout-minutes: 20  # small buffer above 10-minute tunnel lifetime
+    timeout-minutes: 20 # small buffer above 10-minute tunnel lifetime
 
     env:
       PREVIEW_TIMEOUT_MINUTES: ${{ github.event.inputs.timeout_minutes || '5' }}
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -88,7 +88,7 @@ jobs:
         id: detect
         run: |
           echo "🔍 Searching for Node.js frontend in this PR branch..."
-          
+
           # Look for frontend specifically (exclude root package.json)
           frontend_package=""
           if [ -f "packages/frontend/package.json" ]; then
@@ -97,7 +97,7 @@ jobs:
               frontend_package="packages/frontend"
             fi
           fi
-          
+
           if [ -z "$frontend_package" ]; then
             echo "::warning::No frontend package detected in packages/frontend. This is expected for backend-only changes."
             echo "🪄 Skipping preview deployment — no frontend present."
@@ -113,8 +113,8 @@ jobs:
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      
+          python-version: "3.12"
+
       - name: Install UV
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -125,79 +125,79 @@ jobs:
       - name: Install opencode
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         run: |
-           set -euo pipefail
-           INSTALL_DIR="$HOME/.opencode/bin"
-           mkdir -p "$INSTALL_DIR"
+          set -euo pipefail
+          INSTALL_DIR="$HOME/.opencode/bin"
+          mkdir -p "$INSTALL_DIR"
 
-           TMPDIR="$(mktemp -d)"
-           trap 'rm -rf "$TMPDIR"' EXIT
-           ARCHIVE_PATH="$TMPDIR/opencode.tar.gz"
-           DOWNLOAD_URL="https://github.com/anomalyco/opencode/releases/latest/download/opencode-linux-x64.tar.gz"
+          TMPDIR="$(mktemp -d)"
+          trap 'rm -rf "$TMPDIR"' EXIT
+          ARCHIVE_PATH="$TMPDIR/opencode.tar.gz"
+          DOWNLOAD_URL="https://github.com/anomalyco/opencode/releases/latest/download/opencode-linux-x64.tar.gz"
 
-           # Robust download function with retry logic and fallback
-           download_with_retry() {
-             local url="$1"
-             local output="$2"
-             local max_attempts=3
-             
-             echo "🔄 Downloading OpenCode CLI from GitHub releases..."
-             
-             # Try curl with retries
-             for attempt in $(seq 1 $max_attempts); do
-               echo "📥 Attempt $attempt/$max_attempts using curl..."
-               if curl --connect-timeout 30 --max-time 120 --retry-connrefused \
-                       --fail --silent --show-error --location \
-                       "$url" -o "$output"; then
-                 echo "✅ Download successful with curl on attempt $attempt"
-                 return 0
-               else
-                 local exit_code=$?
-                 echo "❌ curl attempt $attempt failed (exit code: $exit_code)"
-                 if [ $attempt -lt $max_attempts ]; then
-                   local delay=$((attempt * 5))
-                   echo "⏳ Waiting ${delay}s before retry..."
-                   sleep $delay
-                 fi
-               fi
-             done
-             
-             # Fallback to wget if curl failed
-             echo "🔄 Trying fallback method with wget..."
-             if wget --timeout=30 --tries=2 --waitretry=5 -q "$url" -O "$output"; then
-               echo "✅ Download successful with wget fallback"
-               return 0
-             else
-               echo "❌ wget fallback also failed"
-               return 1
-             fi
-           }
+          # Robust download function with retry logic and fallback
+          download_with_retry() {
+            local url="$1"
+            local output="$2"
+            local max_attempts=3
+            
+            echo "🔄 Downloading OpenCode CLI from GitHub releases..."
+            
+            # Try curl with retries
+            for attempt in $(seq 1 $max_attempts); do
+              echo "📥 Attempt $attempt/$max_attempts using curl..."
+              if curl --connect-timeout 30 --max-time 120 --retry-connrefused \
+                      --fail --silent --show-error --location \
+                      "$url" -o "$output"; then
+                echo "✅ Download successful with curl on attempt $attempt"
+                return 0
+              else
+                local exit_code=$?
+                echo "❌ curl attempt $attempt failed (exit code: $exit_code)"
+                if [ $attempt -lt $max_attempts ]; then
+                  local delay=$((attempt * 5))
+                  echo "⏳ Waiting ${delay}s before retry..."
+                  sleep $delay
+                fi
+              fi
+            done
+            
+            # Fallback to wget if curl failed
+            echo "🔄 Trying fallback method with wget..."
+            if wget --timeout=30 --tries=2 --waitretry=5 -q "$url" -O "$output"; then
+              echo "✅ Download successful with wget fallback"
+              return 0
+            else
+              echo "❌ wget fallback also failed"
+              return 1
+            fi
+          }
 
-           # Download with robust retry logic
-           if ! download_with_retry "$DOWNLOAD_URL" "$ARCHIVE_PATH"; then
-             echo "💥 Failed to download OpenCode CLI after all retry attempts and fallbacks"
-             echo "🔍 This is likely a temporary CDN issue. Please retry the workflow."
-             exit 1
-           fi
+          # Download with robust retry logic
+          if ! download_with_retry "$DOWNLOAD_URL" "$ARCHIVE_PATH"; then
+            echo "💥 Failed to download OpenCode CLI after all retry attempts and fallbacks"
+            echo "🔍 This is likely a temporary CDN issue. Please retry the workflow."
+            exit 1
+          fi
 
-           # Validate download
-           if [ ! -f "$ARCHIVE_PATH" ] || [ ! -s "$ARCHIVE_PATH" ]; then
-             echo "❌ Downloaded file is missing or empty"
-             exit 1
-           fi
-           
-           file_size=$(stat -f%z "$ARCHIVE_PATH" 2>/dev/null || stat -c%s "$ARCHIVE_PATH" 2>/dev/null || echo "0")
-           if [ "$file_size" -lt 100000 ]; then
-             echo "❌ Downloaded file seems too small ($file_size bytes), likely corrupted"
-             exit 1
-           fi
-           
-           echo "✅ Downloaded file validated ($file_size bytes)"
+          # Validate download
+          if [ ! -f "$ARCHIVE_PATH" ] || [ ! -s "$ARCHIVE_PATH" ]; then
+            echo "❌ Downloaded file is missing or empty"
+            exit 1
+          fi
 
-           # Extract and install
-           tar -xzf "$ARCHIVE_PATH" -C "$TMPDIR"
-           install "$TMPDIR/opencode" "$INSTALL_DIR/opencode"
+          file_size=$(stat -f%z "$ARCHIVE_PATH" 2>/dev/null || stat -c%s "$ARCHIVE_PATH" 2>/dev/null || echo "0")
+          if [ "$file_size" -lt 100000 ]; then
+            echo "❌ Downloaded file seems too small ($file_size bytes), likely corrupted"
+            exit 1
+          fi
 
-           echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+          echo "✅ Downloaded file validated ($file_size bytes)"
+
+          # Extract and install
+          tar -xzf "$ARCHIVE_PATH" -C "$TMPDIR"
+          install "$TMPDIR/opencode" "$INSTALL_DIR/opencode"
+
+          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
       # ------------------------------------------------------
       # Configure OpenCode
@@ -230,12 +230,12 @@ jobs:
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         continue-on-error: true
         run: "opencode run 'Say: ✅ SUCCESS!'"
-      
+
       - name: Install dependencies
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         run: make install
 
-      - name: Debug frontend dependencies 
+      - name: Debug frontend dependencies
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         run: |
           echo "🔍 Debugging frontend setup..."
@@ -253,14 +253,14 @@ jobs:
         if: ${{ steps.detect.outputs.frontend_found == 'true' }}
         run: |
           echo "🚀 Starting MADE services with make run..."
-          
+
           # Start both frontend and backend using make run
           nohup make run > services.log 2>&1 &
           SERVICES_PID=$!
           echo "Services started with PID $SERVICES_PID"
-          
+
           echo "⏳ Waiting for services to become available..."
-          
+
           # Wait a bit and check if the process is still running
           sleep 5
           if ! kill -0 $SERVICES_PID 2>/dev/null; then
@@ -269,7 +269,7 @@ jobs:
             cat services.log
             exit 1
           fi
-          
+
           # Wait for backend API
           for i in {1..30}; do
             if curl -f http://localhost:3000/api/repositories > /dev/null 2>&1; then
@@ -284,7 +284,7 @@ jobs:
             fi
             sleep 3
           done
-          
+
           # Wait for frontend
           for i in {1..30}; do
             if nc -z localhost 5173 2>/dev/null; then
@@ -299,7 +299,7 @@ jobs:
             fi
             sleep 2
           done
-          
+
           echo "🔍 Last few lines of services.log:"
           tail -n 15 services.log || true
 
@@ -315,20 +315,20 @@ jobs:
           echo "🔎 Checking for active services..."
           frontend_ready=false
           backend_ready=false
-          
+
           # Check frontend (primary target for preview)
           if nc -z localhost 5173; then
             frontend_ready=true
             target_port=5173
             echo "✅ Frontend detected on port 5173 (primary target)"
           fi
-          
+
           # Check backend API
           if nc -z localhost 3000; then
             backend_ready=true
             echo "✅ Backend API detected on port 3000"
           fi
-          
+
           # Fallback to other common ports if frontend not found
           if [ "$frontend_ready" = false ]; then
             for port in 3000 8080; do
@@ -347,7 +347,7 @@ jobs:
             tail -n 20 services.log || true
             exit 1
           fi
-          
+
           echo "🎯 Using port $target_port for preview (frontend: $frontend_ready, backend: $backend_ready)"
 
           echo "🚀 Starting ngrok for port $target_port (v4 CLI)..."
@@ -393,19 +393,21 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PREVIEW_URL: ${{ steps.ngrok.outputs.preview_url }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
         run: |
-          REPO=${{ github.repository }}
-          PREVIEW_URL="${{ steps.ngrok.outputs.preview_url }}"
           TIMEOUT_MINUTES=${{ env.PREVIEW_TIMEOUT_MINUTES }}
-          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_NUMBER=${{ github.event.pull_request.number }}
-            PR_TITLE="${{ github.event.pull_request.title }}"
-            AUTHOR="${{ github.event.pull_request.user.login }}"
-            
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
-            ESCAPED_AUTHOR=$(echo "$AUTHOR" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
+            ESCAPED_AUTHOR=$(echo "$PR_AUTHOR" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
             ESCAPED_REPO=$(echo "$REPO" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
 
             MSG=$(printf '%s\n' \
@@ -422,9 +424,6 @@ jobs:
             )
           else
             # Manual dispatch
-            BRANCH_NAME="${{ github.ref_name }}"
-            ACTOR="${{ github.actor }}"
-            
             ESCAPED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
             ESCAPED_ACTOR=$(echo "$ACTOR" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')
             ESCAPED_REPO=$(echo "$REPO" | sed 's/[-_*\[\]()~`>#+=|{}.!]/\\&/g')

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -1,46 +1,41 @@
 {
-  "PR416_RCA": {
+  "rca": {
     "status": "done",
     "evidence": [
-      "loaded existing dev/state/task-ledger.json: old T1-T4 entries were from 2026-05-09 and all status=done",
-      "gh pr view 416 --json ...: Docker Build=FAILURE; Vercel=FAILURE; QA, backend tests, system tests, preview=SUCCESS",
-      "gh run view 25924804254 --job 76203062400 --log-failed: src/pages/ConstitutionPage.tsx(685,13): error TS2322 ... Property 'onSendMessage' does not exist on type 'IntrinsicAttributes & HarnessesTabProps'",
-      "gh run view 25924804254 --job 76203062400 --log-failed: src/pages/RepositoryPage.tsx(2011,27): error TS2339: Property 'generateRepositoryWorkflowHarnesses' does not exist on type ...",
-      "5xWhy: 1. Why did CI fail? Docker frontend build ran tsc and exited 2. 2. Why did tsc fail? It found stale HarnessesTab props and a missing typed API method. 3. Why were stale props present? The backend harness generation refactor removed prompt/send-message behavior from HarnessesTab but not all call sites were updated. 4. Why was the missing API method present? The hook implementation used by RepositoryPage was not fully exposed in the returned API object/type used by production build. 5. Why was this missed before PR update? make qa-quick passed, but it did not include the same production frontend TypeScript build path that Docker/Vercel execute."
+      "gh pr view 420 --json number,title,headRefName,baseRefName,url,state,mergeStateStatus,statusCheckRollup,body -> PR #420 Add `vars` workflow step support to workflow builder, mergeStateStatus=UNSTABLE, preview=FAILURE, other checks=SUCCESS",
+      "gh run view 25955910582 --job 76302427809 --log -> Send Telegram message failed: /home/runner/work/_temp/3c9584d1-f42d-4551-825a-ef4605e71318.sh: line 8: vars: command not found; Process completed with exit code 127",
+      "5xWhy RCA: Why failed? Telegram preview job exited 127. Why exit 127? shell tried to execute `vars`. Why execute `vars`? PR title with backticks was injected into PR_TITLE=\"${{ github.event.pull_request.title }}\". Why unsafe injection? GitHub expression interpolation occurred before shell execution inside double quotes, leaving backticks active. Why not caught? Existing preview workflow did not safely pass PR title/ref/actor through env or heredoc before shell escaping. Root cause: untrusted GitHub context values are embedded directly in shell script assignments."
     ],
-    "last_verified": "2026-05-15T15:09:49Z"
+    "last_verified": "2026-05-16T09:20:18+02:00"
   },
-  "PR416_PLAN": {
+  "plan": {
     "status": "done",
     "evidence": [
-      "git switch codex/refactor-workflow-generation-to-backend: Switched to a new branch 'codex/refactor-workflow-generation-to-backend' tracking origin/codex/refactor-workflow-generation-to-backend",
-      "Plan: remove stale onSendMessage/agentCli props from HarnessesTab call sites or replace them with backend generation callbacks; expose generateRepositoryWorkflowHarnesses in useApi; add a global /api/workflows/generate-harnesses endpoint and frontend api method so global HarnessesTab instances still generate harness scripts; run production frontend build and repository QA before commit."
+      "Plan: move GitHub context values that may contain shell metacharacters (repository, PR title, author, ref, actor) from direct shell interpolation into step env variables; read only those env variables in run script; keep existing MarkdownV2 escaping; verify with shell syntax check and a local reproduction using a PR_TITLE containing backticks."
     ],
-    "last_verified": "2026-05-15T15:11:39Z"
+    "last_verified": "2026-05-16T09:20:18+02:00"
   },
-  "PR416_IMPLEMENT": {
+  "implement": {
     "status": "done",
     "evidence": [
-      "grep agentCli={agentCli} packages/frontend/src --include '*.tsx': No files found",
-      "npm run build --workspace packages/frontend: ✓ built in 1.07s",
-      "uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py -q: 125 passed in 4.83s",
-      "make qa-quick: 391 passed, 1 skipped in 12.11s; All quick quality assurance tasks completed successfully",
-      "make docker-build: Image made-frontend Built; Image made-pybackend Built"
+      "Updated .github/workflows/nodejs-frontend-preview.yml: moved EVENT_NAME, REPO, PREVIEW_URL, WORKFLOW_URL, PR_NUMBER, PR_TITLE, PR_AUTHOR, BRANCH_NAME, ACTOR into step env and removed direct PR title/ref/actor interpolation from shell assignments.",
+      "EVENT_NAME=pull_request PR_TITLE='Add `vars` workflow step support' ... bash -c '...' -> Add `vars` workflow step support (exit 0; no vars command execution)",
+      "npx prettier --check .github/workflows/nodejs-frontend-preview.yml -> All matched files use Prettier code style!"
     ],
-    "last_verified": "2026-05-15T15:16:36Z"
+    "last_verified": "2026-05-16T09:21:50+02:00"
   },
-  "PR416_COMMIT_PUSH": {
-    "status": "done",
+  "commit_push": {
+    "status": "in_progress",
     "evidence": [
-      "git commit -m 'fix: complete backend workflow harness wiring': [codex/refactor-workflow-generation-to-backend 4e037f6] fix: complete backend workflow harness wiring",
-      "git push: aaa66f3..4e037f6 codex/refactor-workflow-generation-to-backend -> codex/refactor-workflow-generation-to-backend",
-      "pre-push make qa-quick: 391 passed, 1 skipped in 25.53s; All quick quality assurance tasks completed successfully"
+      "git status --short --branch -> modified .github/workflows/nodejs-frontend-preview.yml and dev/state/task-ledger.json; unrelated untracked .playwright-mcp/ and demo.png not staged",
+      "make qa-quick -> 394 passed, 1 skipped in 12.20s; All quick quality assurance tasks completed successfully",
+      "git add .github/workflows/nodejs-frontend-preview.yml dev/state/task-ledger.json && git commit -m 'fix: safely pass preview metadata' -> dev is ignored; ledger requires git add -f"
     ],
-    "last_verified": "2026-05-15T15:18:54Z"
+    "last_verified": "2026-05-16T09:23:30+02:00"
   },
-  "PR416_CI": {
+  "ci": {
     "status": "pending",
     "evidence": [],
-    "last_verified": "2026-05-15T15:09:10Z"
+    "last_verified": "2026-05-16T09:19:27+02:00"
   }
 }

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -14,11 +14,13 @@ import { XIcon } from "./icons/XIcon";
 import { workflowShellScriptPath } from "../utils/workflowHarnessPrompt";
 
 export type WorkflowStep = {
-  type: "agent" | "bash";
+  type: "agent" | "bash" | "vars";
   agent?: string;
+  varName?: string;
   command?: string;
   prompt?: string;
   run?: string;
+  values?: Record<string, string>;
 };
 
 export type WorkflowDefinition = {
@@ -44,11 +46,13 @@ const previewText = (step: WorkflowStep) => {
   const raw =
     step.type === "bash"
       ? step.run || ""
-      : step.command
-        ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
-        : step.prompt || "";
+      : step.type === "vars"
+        ? step.run || ""
+        : step.command
+          ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
+          : step.prompt || "";
   const [firstLine] = raw.split(/\r?\n/, 1);
-  return firstLine || (step.type === "bash" ? "Bash command" : "Prompt");
+  return firstLine || (step.type === "agent" ? "Prompt" : "Command");
 };
 
 const parseAgentText = (value: string) => {
@@ -341,15 +345,23 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                             onChange={(event) => {
                               const nextType = event.target.value as
                                 | "agent"
-                                | "bash";
+                                | "bash"
+                                | "vars";
                               const nextStep: WorkflowStep =
                                 nextType === "bash"
                                   ? { type: "bash", run: "" }
-                                  : {
-                                      type: "agent",
-                                      agent: agentNames[0] || "default",
-                                      prompt: "",
-                                    };
+                                  : nextType === "vars"
+                                    ? {
+                                        type: "vars",
+                                        varName: "",
+                                        run: "",
+                                        values: {},
+                                      }
+                                    : {
+                                        type: "agent",
+                                        agent: agentNames[0] || "default",
+                                        prompt: "",
+                                      };
                               const next = workflows.map((item) =>
                                 item.id === workflow.id
                                   ? {
@@ -368,6 +380,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                           >
                             <option value="agent">Agent</option>
                             <option value="bash">Bash</option>
+                            <option value="vars">Vars</option>
                           </select>
                           {step.type === "agent" ? (
                             <select
@@ -400,6 +413,35 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                                 ))
                               )}
                             </select>
+                          ) : step.type === "vars" ? (
+                            <input
+                              className="workflow-step-target__label"
+                              value={step.varName || ""}
+                              placeholder="VARIABLE_NAME"
+                              onChange={(event) => {
+                                const next = workflows.map((item) =>
+                                  item.id === workflow.id
+                                    ? {
+                                        ...item,
+                                        steps: item.steps.map(
+                                          (itemStep, itemIndex) =>
+                                            itemIndex === stepIndex
+                                              ? {
+                                                  ...itemStep,
+                                                  varName: event.target.value,
+                                                  values: {
+                                                    [event.target.value]:
+                                                      itemStep.run || "",
+                                                  },
+                                                }
+                                              : itemStep,
+                                        ),
+                                      }
+                                    : item,
+                                );
+                                void persist(next);
+                              }}
+                            />
                           ) : (
                             <span className="workflow-step-target__label" />
                           )}
@@ -408,11 +450,11 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                           className="workflow-step-preview"
                           onClick={() => {
                             const currentText =
-                              step.type === "bash"
-                                ? step.run || ""
-                                : step.command
+                              step.type === "agent"
+                                ? step.command
                                   ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
-                                  : step.prompt || "";
+                                  : step.prompt || ""
+                                : step.run || "";
                             setEditStep({ workflowId: workflow.id, stepIndex });
                             setEditStepValue(currentText);
                           }}
@@ -519,7 +561,15 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                   ...workflow,
                   steps: workflow.steps.map((step, index) => {
                     if (index !== editStep.stepIndex) return step;
-                    if (step.type === "bash") {
+                    if (step.type !== "agent") {
+                      if (step.type === "vars") {
+                        const varName = step.varName || "";
+                        return {
+                          ...step,
+                          run: editStepValue,
+                          values: varName ? { [varName]: editStepValue } : {},
+                        };
+                      }
                       return { ...step, run: editStepValue };
                     }
                     const parsed = parseAgentText(editStepValue);

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -265,11 +265,13 @@ export type TemplateApplyResponse = {
 };
 
 export type WorkflowStep = {
-  type: "agent" | "bash";
+  type: "agent" | "bash" | "vars";
   agent?: string;
+  varName?: string;
   command?: string;
   prompt?: string;
   run?: string;
+  values?: Record<string, string>;
 };
 
 export type WorkspaceWorkflowSummary = {

--- a/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.test.ts
@@ -17,6 +17,7 @@ describe("buildWorkflowHarnessPrompt", () => {
           command: "plan",
           prompt: "Create release plan",
         },
+        { type: "vars", varName: "BUILD_SHA", run: "git rev-parse HEAD" },
         { type: "bash", run: "echo done" },
       ],
     };
@@ -30,6 +31,8 @@ describe("buildWorkflowHarnessPrompt", () => {
     expect(prompt).toContain('schedule: "0 5 * * *"');
     expect(prompt).toContain('agent: "default"');
     expect(prompt).toContain('command: "plan"');
+    expect(prompt).toContain("values:");
+    expect(prompt).toContain('BUILD_SHA: "git rev-parse HEAD"');
     expect(prompt).toContain('run: "echo done"');
     expect(prompt).toContain('shellScriptPath: ".harness/release-workflow.sh"');
     expect(prompt).toContain("The script MUST be written exactly to:");

--- a/packages/frontend/src/utils/workflowHarnessPrompt.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.ts
@@ -23,6 +23,17 @@ const stepToYaml = (step: WorkflowStep, indent: string) => {
       lines.push(`${indent}  prompt: ${escapeYamlValue(step.prompt)}`);
     return lines;
   }
+  if (step.type === "vars") {
+    const varName = (step.varName || "").trim();
+    const command = step.run || "";
+    if (varName) {
+      lines.push(`${indent}  values:`);
+      lines.push(`${indent}    ${varName}: ${escapeYamlValue(command)}`);
+    } else {
+      lines.push(`${indent}  values: {}`);
+    }
+    return lines;
+  }
   lines.push(`${indent}  run: ${escapeYamlValue(step.run || "")}`);
   return lines;
 };

--- a/packages/pybackend/workflow_harness_service.py
+++ b/packages/pybackend/workflow_harness_service.py
@@ -123,7 +123,9 @@ class WorkflowFile(StrictModel):
             raise ValueError("must contain at least one workflow")
 
         ids = [workflow.id for workflow in value]
-        duplicate_ids = sorted({workflow_id for workflow_id in ids if ids.count(workflow_id) > 1})
+        duplicate_ids = sorted(
+            {workflow_id for workflow_id in ids if ids.count(workflow_id) > 1}
+        )
         if duplicate_ids:
             raise ValueError(f"duplicate workflow ids: {', '.join(duplicate_ids)}")
 
@@ -171,7 +173,7 @@ def render_harness(workflow: Workflow) -> str:
         'if [[ $# -eq 1 && "$1" == "--dry-run" ]]; then',
         "  DRY_RUN=true",
         "elif [[ $# -gt 0 ]]; then",
-        "  printf \"Usage: %s [--dry-run]\\n\" \"$0\" >&2",
+        '  printf "Usage: %s [--dry-run]\\n" "$0" >&2',
         "  exit 2",
         "fi",
         "",
@@ -186,7 +188,7 @@ def render_harness(workflow: Workflow) -> str:
         "  local message",
         "  message=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ') [${level}] $*\"",
         "  printf '%s\\n' \"$message\" >&2",
-        "  printf '%s\\n' \"$message\" >> \"$LOG_FILE\" 2>/dev/null || true",
+        '  printf \'%s\\n\' "$message" >> "$LOG_FILE" 2>/dev/null || true',
         "}",
         "",
         section("catch() — centralized step failure hook"),
@@ -256,7 +258,7 @@ def render_harness(workflow: Workflow) -> str:
         "  fi",
         "",
         '  if [[ "$DRY_RUN" == true ]]; then',
-        '    log INFO "[DRY-RUN] would run: $(printf \'%q \' \"${cmd[@]}\") (with prompt)"',
+        '    log INFO "[DRY-RUN] would run: $(printf \'%q \' "${cmd[@]}") (with prompt)"',
         "    return 0",
         "  fi",
         "",
@@ -271,11 +273,13 @@ def render_harness(workflow: Workflow) -> str:
     for index, step in enumerate(workflow.steps, start=1):
         lines.extend(render_step(index, step))
 
-    lines.extend([
-        section(f"Workflow finished: {workflow.name}"),
-        f"log INFO {bash_quote(f'Workflow finished: {workflow.name}')}",
-        "",
-    ])
+    lines.extend(
+        [
+            section(f"Workflow finished: {workflow.name}"),
+            f"log INFO {bash_quote(f'Workflow finished: {workflow.name}')}",
+            "",
+        ]
+    )
 
     return "\n".join(lines) + "\n"
 
@@ -293,13 +297,15 @@ def render_step(index: int, step: Step) -> list[str]:
             lines.append(f"  {command_line}" if command_line.strip() else "")
     elif isinstance(step, AgentStep):
         delimiter = heredoc_delimiter("PROMPT", step.prompt)
-        lines.extend([
-            "  local prompt",
-            f"  prompt=$(cat <<'{delimiter}'",
-            *step.prompt.splitlines(),
-            delimiter,
-            "  )",
-        ])
+        lines.extend(
+            [
+                "  local prompt",
+                f"  prompt=$(cat <<'{delimiter}'",
+                *step.prompt.splitlines(),
+                delimiter,
+                "  )",
+            ]
+        )
         if step.agent:
             lines.append(f"  local agent={bash_quote(step.agent)}")
             lines.append('  run_agent "$prompt" "$agent"')
@@ -354,8 +360,10 @@ def bash_quote(value: str) -> str:
 
 
 def section(title: str) -> str:
-    return "\n".join([
-        "# ---------------------------------------------------------------------------",
-        f"# {title}",
-        "# ---------------------------------------------------------------------------",
-    ])
+    return "\n".join(
+        [
+            "# ---------------------------------------------------------------------------",
+            f"# {title}",
+            "# ---------------------------------------------------------------------------",
+        ]
+    )


### PR DESCRIPTION
### Motivation
- Support a new `vars` workflow step so workflows can declare named variables (free-text name) whose command is stored in the step and emitted into the harness YAML as a `values` mapping, matching the behavior described in the workflow-to-harness harness generator.

### Description
- Extend the `WorkflowStep` shape to accept `type: "vars"` and add `varName` and `values` fields across the frontend (`WorkflowBuilderPanel.tsx`, `useApi.ts`).
- Update the Workflow Builder UI so the step-type dropdown includes `Vars`; when selected the agent dropdown is replaced with a free-text `varName` input and the step editor command is saved as the variable command.
- Serialize `vars` steps in `buildWorkflowHarnessPrompt` (in `workflowHarnessPrompt.ts`) to emit `values:` with a single-entry mapping `VAR_NAME: "command"` instead of `run`.
- Add a unit test to verify the generated workflow prompt contains the `values` mapping (`workflowHarnessPrompt.test.ts`).
- A minor formatting change was applied to `packages/pybackend/workflow_harness_service.py` by the formatter; no behavioral backend logic was changed.

### Testing
- Ran the focused frontend test: `npm --prefix packages/frontend run test -- workflowHarnessPrompt.test.ts`, which passed.
- Ran the repository quick quality gate `make qa-quick` (format/lint/frontend, ruff format/check backend, frontend unit tests, backend unit tests with coverage), which completed successfully with all checks passing (backend tests and frontend tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07913d7dc083328ba8354c28e785f9)