### PR TITLE
Persist workflow 'vars' steps and show harness conversion success/error feedback

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -92,6 +92,10 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [conversionMessage, setConversionMessage] = useState<string | null>(
+    null,
+  );
+  const [conversionError, setConversionError] = useState<string | null>(null);
   const [editStep, setEditStep] = useState<{
     workflowId: string;
     stepIndex: number;
@@ -145,12 +149,14 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
     setError(null);
     try {
       await saveWorkflows({ workflows: nextWorkflows });
+      return true;
     } catch (saveError) {
       const message =
         saveError instanceof Error
           ? saveError.message
           : "Failed to save workflows";
       setError(message);
+      return false;
     } finally {
       setSaving(false);
     }
@@ -200,6 +206,8 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
       </div>
       {loading && <div className="alert">Loading workflows...</div>}
       {saving && <div className="alert">Saving workflows...</div>}
+      {conversionMessage && <div className="alert">{conversionMessage}</div>}
+      {conversionError && <div className="alert error">{conversionError}</div>}
       {error && <div className="alert error">{error}</div>}
       {!loading && workflows.length === 0 && (
         <div className="empty">No workflows yet.</div>
@@ -305,13 +313,30 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                     const shellScriptPath = workflowShellScriptPath(
                       workflow.name,
                     );
+                    setConversionMessage(null);
+                    setConversionError(null);
                     const next = workflows.map((item) =>
                       item.id === workflow.id
                         ? { ...item, shellScriptPath }
                         : item,
                     );
-                    await persist(next);
-                    await onRunWorkflow(next);
+                    const persisted = await persist(next);
+                    if (!persisted) {
+                      setConversionError(
+                        "Failed to convert workflow to harness shell script.",
+                      );
+                      return;
+                    }
+                    try {
+                      await onRunWorkflow(next);
+                      setConversionMessage(
+                        `Workflow converted to harness shell script: ${shellScriptPath}`,
+                      );
+                    } catch {
+                      setConversionError(
+                        "Failed to convert workflow to harness shell script.",
+                      );
+                    }
                   }}
                 >
                   <PlayIcon />

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -50,6 +50,36 @@ def test_normalize_payload_defaults_enabled_false_when_missing():
     assert result["workflows"][0]["enabled"] is False
 
 
+def test_normalize_payload_keeps_vars_steps():
+    payload = {
+        "workflows": [
+            {
+                "id": "wf_1",
+                "name": "Vars Workflow",
+                "steps": [
+                    {
+                        "type": "vars",
+                        "varName": "  RELEASE_CHANNEL  ",
+                        "run": " stable ",
+                        "values": {" RELEASE_CHANNEL ": " stable ", "": "ignore"},
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = _normalize_payload(payload)
+
+    assert result["workflows"][0]["steps"] == [
+        {
+            "type": "vars",
+            "varName": "RELEASE_CHANNEL",
+            "run": "stable",
+            "values": {"RELEASE_CHANNEL": "stable"},
+        }
+    ]
+
+
 def test_normalize_payload_omits_empty_shell_script_path():
     payload = {
         "workflows": [

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -33,7 +33,7 @@ def _as_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
-def _normalize_step(step: Any) -> dict[str, str]:
+def _normalize_step(step: Any) -> dict[str, Any]:
     if not isinstance(step, dict):
         return {}
     step_type = _as_string(step.get("type"))
@@ -52,6 +52,25 @@ def _normalize_step(step: Any) -> dict[str, str]:
         if prompt:
             normalized["prompt"] = prompt
         return normalized
+    if step_type == "vars":
+        var_name = _as_string(step.get("varName"))
+        run = _as_string(step.get("run"))
+        raw_values = step.get("values")
+        values: dict[str, str] = {}
+        if isinstance(raw_values, dict):
+            for key, value in raw_values.items():
+                normalized_key = _as_string(key)
+                normalized_value = _as_string(value)
+                if normalized_key and normalized_value is not None:
+                    values[normalized_key] = normalized_value
+        normalized: dict[str, Any] = {"type": "vars"}
+        if var_name:
+            normalized["varName"] = var_name
+        if run is not None:
+            normalized["run"] = run
+        if values:
+            normalized["values"] = values
+        return normalized
     return {}
 
 
@@ -64,7 +83,7 @@ def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
     schedule = _as_string(workflow.get("schedule"))
     shell_script_path = _as_string(workflow.get("shellScriptPath"))
     raw_steps = workflow.get("steps")
-    steps: list[dict[str, str]] = []
+    steps: list[dict[str, Any]] = []
     if isinstance(raw_steps, list):
         for raw_step in raw_steps:
             step = _normalize_step(raw_step)


### PR DESCRIPTION
### Motivation
- Vars steps in workflows were not being persisted through backend normalization and were dropped when saving workflows.
- The Workflow Builder did not show user feedback when converting a workflow to a harness shell script, making conversions opaque to the user.
- Conversion feedback must reflect whether the workflow save actually succeeded before attempting conversion.

### Description
- Add `vars` handling to backend `_normalize_step` to preserve `varName`, `run`, and a cleaned `values` map, and adjust step typing to allow heterogeneous step shapes (`dict[str, Any]`).
- Update `_normalize_workflow` to collect `vars` steps and keep `shellScriptPath` when present so `vars` steps are written/read correctly.
- Add unit test `test_normalize_payload_keeps_vars_steps` to verify `vars` steps are normalized (trimmed keys/values and invalid entries filtered).
- In the frontend `WorkflowBuilderPanel`, add `conversionMessage`/`conversionError` state, display success/error alerts alongside existing save/loading alerts, and make `persist` return a boolean so the UI only attempts conversion after a successful save and reports success/failure.

### Testing
- Ran the repository quick QA: `make qa-quick`.
- All automated checks completed: linters/formatters ran and backend unit tests passed; test run summary: `395 passed, 1 skipped` and the QA script finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082368c6a0833296daeaddb01c805b)