### PR TITLE
Normalize vars steps for harness conversion and surface detailed conversion errors

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -323,7 +323,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                     const persisted = await persist(next);
                     if (!persisted) {
                       setConversionError(
-                        "Failed to convert workflow to harness shell script.",
+                        "Failed to save workflow before conversion. Check required fields and try again.",
                       );
                       return;
                     }
@@ -332,9 +332,13 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                       setConversionMessage(
                         `Workflow converted to harness shell script: ${shellScriptPath}`,
                       );
-                    } catch {
+                    } catch (error) {
+                      const message =
+                        error instanceof Error && error.message
+                          ? error.message
+                          : "unknown error";
                       setConversionError(
-                        "Failed to convert workflow to harness shell script.",
+                        `Failed to convert workflow to harness shell script (${message}). Check workflow schema, especially vars values, and try again.`,
                       );
                     }
                   }}

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -337,6 +337,36 @@ export type AgentProcessSummary = {
   workingDirectory?: string | null;
 };
 
+
+function toHarnessCompatibleWorkflowStep(step: WorkflowStep): WorkflowStep {
+  if (step.type !== "vars") return step;
+
+  const values: Record<string, string> = {};
+  if (step.values) {
+    for (const [key, value] of Object.entries(step.values)) {
+      const normalizedKey = key.trim();
+      const normalizedValue = value.trim();
+      if (normalizedKey && normalizedValue) values[normalizedKey] = normalizedValue;
+    }
+  }
+
+  const varName = step.varName?.trim();
+  const run = step.run?.trim();
+  if (varName && run && !(varName in values)) values[varName] = run;
+
+  return {
+    type: "vars",
+    values,
+  };
+}
+
+function toHarnessCompatibleWorkflows(workflows: WorkflowDefinition[]): WorkflowDefinition[] {
+  return workflows.map((workflow) => ({
+    ...workflow,
+    steps: workflow.steps.map((step) => toHarnessCompatibleWorkflowStep(step)),
+  }));
+}
+
 export const api = {
   getDashboard: () =>
     request<{
@@ -574,7 +604,7 @@ export const api = {
       `/repositories/${name}/workflows`,
       {
         method: "PUT",
-        body: JSON.stringify({ workflows }),
+        body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
       },
     ),
   generateRepositoryWorkflowHarnesses: (
@@ -585,7 +615,7 @@ export const api = {
       `/repositories/${name}/workflows/generate-harnesses`,
       {
         method: "POST",
-        body: JSON.stringify({ workflows }),
+        body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
       },
     ),
   getCommands: () => request<{ commands: CommandDefinition[] }>("/commands"),
@@ -627,12 +657,12 @@ export const api = {
   saveWorkflows: (workflows: WorkflowDefinition[]) =>
     request<{ workflows: WorkflowDefinition[] }>("/workflows", {
       method: "PUT",
-      body: JSON.stringify({ workflows }),
+      body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
     }),
   generateWorkflowHarnesses: (workflows: WorkflowDefinition[]) =>
     request<{ written: string[] }>("/workflows/generate-harnesses", {
       method: "POST",
-      body: JSON.stringify({ workflows }),
+      body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
     }),
   getAgents: () => request<{ agents: AvailableAgent[] }>("/agents"),
   getRepositoryAgents: (name: string) =>

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -73,8 +73,6 @@ def test_normalize_payload_keeps_vars_steps():
     assert result["workflows"][0]["steps"] == [
         {
             "type": "vars",
-            "varName": "RELEASE_CHANNEL",
-            "run": "stable",
             "values": {"RELEASE_CHANNEL": "stable"},
         }
     ]

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -63,11 +63,9 @@ def _normalize_step(step: Any) -> dict[str, Any]:
                 normalized_value = _as_string(value)
                 if normalized_key and normalized_value is not None:
                     values[normalized_key] = normalized_value
+        if var_name and run is not None and var_name not in values:
+            values[var_name] = run
         normalized: dict[str, Any] = {"type": "vars"}
-        if var_name:
-            normalized["varName"] = var_name
-        if run is not None:
-            normalized["run"] = run
         if values:
             normalized["values"] = values
         return normalized


### PR DESCRIPTION
### Motivation
- Users were seeing the generic "Failed to convert workflow to harness shell script." error when `vars` steps contained legacy fields (`varName`/`run`) instead of the schema-required `values` map.  
- The change ensures workflows sent to the harness generator are schema-compliant and provides more actionable UI errors when conversion fails.

### Description
- Backend: update workflow normalization in `packages/pybackend/workflow_service.py` to build a `values` map for `vars` steps, backfilling from `varName`/`run` when present and omitting legacy `varName`/`run` fields in the normalized payload.  
- Frontend: add `toHarnessCompatibleWorkflowStep` and `toHarnessCompatibleWorkflows` in `packages/frontend/src/hooks/useApi.ts` and use them when calling save/generate workflow endpoints so the client always posts a harness-compatible shape.  
- Frontend UI: improve conversion error handling in `packages/frontend/src/components/WorkflowBuilderPanel.tsx` to surface save failures and include backend error details in the conversion failure message.  
- Tests: update backend unit test expectations in `packages/pybackend/tests/unit/test_workflow_service.py` to reflect the schema-compliant `vars` normalization.

### Testing
- Ran `pytest -q packages/pybackend/tests/unit/test_workflow_service.py packages/pybackend/tests/unit/test_workflow_harness_service.py`, which could not run to completion in this environment due to missing Python dependencies (`yaml`, `pydantic`) during test collection.  
- Updated unit test assertions to match the new normalized `vars` output (tests will pass once backend test dependencies are installed in CI or a local environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082d442944833299428b969da40765)