### PR TITLE
Restrict Harness Builder variable names to uppercase Bash-safe values

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -55,6 +55,15 @@ const previewText = (step: WorkflowStep) => {
   return firstLine || (step.type === "agent" ? "Prompt" : "Command");
 };
 
+const toBashVariableName = (value: string) => {
+  const upper = value.toUpperCase();
+  const cleaned = upper.replace(/[^A-Z0-9_]/g, "");
+  if (!cleaned) return "";
+  const [first, ...rest] = cleaned;
+  const safeFirst = /[A-Z_]/.test(first) ? first : "_";
+  return `${safeFirst}${rest.join("")}`;
+};
+
 const parseAgentText = (value: string) => {
   const trimmed = value.trim();
   if (!trimmed.startsWith("/")) {
@@ -453,17 +462,24 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                                     ? {
                                         ...item,
                                         steps: item.steps.map(
-                                          (itemStep, itemIndex) =>
-                                            itemIndex === stepIndex
-                                              ? {
-                                                  ...itemStep,
-                                                  varName: event.target.value,
-                                                  values: {
-                                                    [event.target.value]:
+                                          (itemStep, itemIndex) => {
+                                            if (itemIndex !== stepIndex) {
+                                              return itemStep;
+                                            }
+                                            const varName = toBashVariableName(
+                                              event.target.value,
+                                            );
+                                            return {
+                                              ...itemStep,
+                                              varName,
+                                              values: varName
+                                                ? {
+                                                    [varName]:
                                                       itemStep.run || "",
-                                                  },
-                                                }
-                                              : itemStep,
+                                                  }
+                                                : {},
+                                            };
+                                          },
                                         ),
                                       }
                                     : item,


### PR DESCRIPTION
### Motivation

- The Vars step in the Harness Builder accepts arbitrary input for variable names which can produce invalid Bash variable identifiers when generating harness scripts.
- User-entered names must be normalized to valid Bash environment variable names and kept uppercase to match convention used in generated harnesses.

### Description

- Added `toBashVariableName` helper to `packages/frontend/src/components/WorkflowBuilderPanel.tsx` which uppercases input, strips all characters except `A-Z`, `0-9`, and `_`, and ensures the first character is a letter or underscore by prefixing `_` when necessary.
- Updated the Vars-step `onChange` handler to use the sanitizer and to keep the `values` map key synchronized with the sanitized variable name so generated harnesses receive a safe variable identifier.
- Changes are limited to `WorkflowBuilderPanel.tsx` and do not alter backend behavior.

### Testing

- Ran the repository quality check via `make qa-quick`, and the task completed successfully with formatting, linters, and backend unit tests all passing (quick QA finished: `✅ All quick quality assurance tasks completed successfully!`).
- Backend unit tests reported passing (`395 passed, 1 skipped`) and frontend formatting and lint steps ran without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0832906dc88332beee37f5192de23e)