### PR TITLE
Align harness builder variable-name field with other edit field styles

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -453,7 +453,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                             </select>
                           ) : step.type === "vars" ? (
                             <input
-                              className="workflow-step-target__label"
+                              className="workflow-step-target__input"
                               value={step.varName || ""}
                               placeholder="VARIABLE_NAME"
                               onChange={(event) => {
@@ -488,7 +488,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                               }}
                             />
                           ) : (
-                            <span className="workflow-step-target__label" />
+                            <span className="workflow-step-target__placeholder" />
                           )}
                         </div>
                         <button

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -337,7 +337,6 @@ export type AgentProcessSummary = {
   workingDirectory?: string | null;
 };
 
-
 function toHarnessCompatibleWorkflowStep(step: WorkflowStep): WorkflowStep {
   if (step.type !== "vars") return step;
 
@@ -346,7 +345,8 @@ function toHarnessCompatibleWorkflowStep(step: WorkflowStep): WorkflowStep {
     for (const [key, value] of Object.entries(step.values)) {
       const normalizedKey = key.trim();
       const normalizedValue = value.trim();
-      if (normalizedKey && normalizedValue) values[normalizedKey] = normalizedValue;
+      if (normalizedKey && normalizedValue)
+        values[normalizedKey] = normalizedValue;
     }
   }
 
@@ -360,7 +360,9 @@ function toHarnessCompatibleWorkflowStep(step: WorkflowStep): WorkflowStep {
   };
 }
 
-function toHarnessCompatibleWorkflows(workflows: WorkflowDefinition[]): WorkflowDefinition[] {
+function toHarnessCompatibleWorkflows(
+  workflows: WorkflowDefinition[],
+): WorkflowDefinition[] {
   return workflows.map((workflow) => ({
     ...workflow,
     steps: workflow.steps.map((step) => toHarnessCompatibleWorkflowStep(step)),
@@ -604,7 +606,9 @@ export const api = {
       `/repositories/${name}/workflows`,
       {
         method: "PUT",
-        body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
+        body: JSON.stringify({
+          workflows: toHarnessCompatibleWorkflows(workflows),
+        }),
       },
     ),
   generateRepositoryWorkflowHarnesses: (
@@ -615,7 +619,9 @@ export const api = {
       `/repositories/${name}/workflows/generate-harnesses`,
       {
         method: "POST",
-        body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
+        body: JSON.stringify({
+          workflows: toHarnessCompatibleWorkflows(workflows),
+        }),
       },
     ),
   getCommands: () => request<{ commands: CommandDefinition[] }>("/commands"),
@@ -657,12 +663,16 @@ export const api = {
   saveWorkflows: (workflows: WorkflowDefinition[]) =>
     request<{ workflows: WorkflowDefinition[] }>("/workflows", {
       method: "PUT",
-      body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
+      body: JSON.stringify({
+        workflows: toHarnessCompatibleWorkflows(workflows),
+      }),
     }),
   generateWorkflowHarnesses: (workflows: WorkflowDefinition[]) =>
     request<{ written: string[] }>("/workflows/generate-harnesses", {
       method: "POST",
-      body: JSON.stringify({ workflows: toHarnessCompatibleWorkflows(workflows) }),
+      body: JSON.stringify({
+        workflows: toHarnessCompatibleWorkflows(workflows),
+      }),
     }),
   getAgents: () => request<{ agents: AvailableAgent[] }>("/agents"),
   getRepositoryAgents: (name: string) =>

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -447,10 +447,14 @@
   gap: 0.25rem;
 }
 
-.workflow-step-target__label {
-  border: 1px solid var(--panel-border);
-  border-radius: 6px;
-  padding: 0.4rem 0.5rem;
+.workflow-step-target__input {
+  min-width: 0;
+}
+
+.workflow-step-target__placeholder {
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: var(--surface);
 }
 
 .workflow-step-preview {


### PR DESCRIPTION
### Motivation
- Make the variable-name input in the Harness Builder visually consistent with the other editable fields so the UI is clearer and more uniform.

### Description
- Replace the vars-step field class in `packages/frontend/src/components/WorkflowBuilderPanel.tsx` from `workflow-step-target__label` to `workflow-step-target__input` and use a `workflow-step-target__placeholder` span for non-vars rows. 
- Add corresponding styles in `packages/frontend/src/styles/page.css` to style the new input and placeholder classes to match the standard input tokens used elsewhere. 
- Apply minor non-functional formatting changes in `packages/frontend/src/hooks/useApi.ts` from running the formatter (line-wrapping changes only).

### Testing
- Ran `make qa-quick` which runs formatting, linting, frontend checks and backend unit tests, and the quick QA completed successfully with all automated checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0836676a248332a4e86f1cb7bfb684)