### PR TITLE
Verify generated workflow harness scripts with bash syntax and dry-run checks

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -64,7 +64,11 @@ from external_matter_service import read_external_matter, write_external_matter
 from command_service import list_commands
 from harness_service import is_process_running, list_harnesses, run_harness
 from workflow_service import list_workspace_workflows, read_workflows, write_workflows
-from workflow_harness_service import generate_workflow_harnesses, WorkflowParseError
+from workflow_harness_service import (
+    generate_workflow_harnesses,
+    WorkflowParseError,
+    WorkflowVerificationError,
+)
 from cron_service import (
     force_terminate_job,
     get_cron_job_diagnostics,
@@ -841,6 +845,10 @@ def generate_repository_workflow_harnesses(name: str, payload: dict = Body(...))
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc
+    except WorkflowVerificationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
@@ -901,6 +909,10 @@ def generate_global_workflow_harnesses(payload: dict = Body(...)):
         written = generate_workflow_harnesses(payload, get_made_home())
         return {"written": written}
     except WorkflowParseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    except WorkflowVerificationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc

--- a/packages/pybackend/tests/unit/test_workflow_harness_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_harness_service.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
 from workflow_harness_service import (
     WorkflowParseError,
+    WorkflowVerificationError,
     generate_workflow_harnesses,
     parse_workflow_payload,
     render_harness,
@@ -84,3 +86,29 @@ def test_parse_workflow_payload_rejects_duplicate_workflow_ids():
 
     with pytest.raises(WorkflowParseError, match="duplicate workflow ids"):
         parse_workflow_payload(payload)
+
+
+@patch("workflow_harness_service.subprocess.run")
+def test_generate_workflow_harnesses_verifies_bash_and_dry_run(mock_run: Mock, tmp_path: Path):
+    mock_run.side_effect = [
+        Mock(returncode=0, stdout="", stderr=""),
+        Mock(returncode=0, stdout="", stderr=""),
+    ]
+
+    generate_workflow_harnesses(sample_payload(), tmp_path)
+
+    written_script = tmp_path / ".harness/release-flow.sh"
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == ["bash", "-n", str(written_script)]
+    assert mock_run.call_args_list[1].args[0] == [str(written_script), "--dry-run"]
+
+
+@patch("workflow_harness_service.subprocess.run")
+def test_generate_workflow_harnesses_raises_on_dry_run_failure(mock_run: Mock, tmp_path: Path):
+    mock_run.side_effect = [
+        Mock(returncode=0, stdout="", stderr=""),
+        Mock(returncode=1, stdout="", stderr="boom"),
+    ]
+
+    with pytest.raises(WorkflowVerificationError, match="script dry run failed"):
+        generate_workflow_harnesses(sample_payload(), tmp_path)

--- a/packages/pybackend/workflow_harness_service.py
+++ b/packages/pybackend/workflow_harness_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import stat
+import subprocess
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -10,6 +11,10 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 class WorkflowParseError(ValueError):
     """Raised when workflow payload cannot be validated."""
+
+
+class WorkflowVerificationError(ValueError):
+    """Raised when generated harness scripts fail verification checks."""
 
 
 class StrictModel(BaseModel):
@@ -149,9 +154,34 @@ def generate_workflow_harnesses(payload: dict, output_root: Path) -> list[str]:
         output_path.write_text(render_harness(workflow), encoding="utf-8")
         mode = output_path.stat().st_mode
         output_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        _verify_harness_script(output_path)
         written.append(workflow.shell_script_path)
 
     return written
+
+
+def _verify_harness_script(script_path: Path) -> None:
+    verify_process = subprocess.run(
+        ["bash", "-n", str(script_path)],
+        capture_output=True,
+        text=True,
+    )
+    if verify_process.returncode != 0:
+        stderr = (verify_process.stderr or verify_process.stdout or "").strip()
+        raise WorkflowVerificationError(
+            f"bash verify run failed for {script_path}: {stderr}"
+        )
+
+    dry_run_process = subprocess.run(
+        [str(script_path), "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+    if dry_run_process.returncode != 0:
+        stderr = (dry_run_process.stderr or dry_run_process.stdout or "").strip()
+        raise WorkflowVerificationError(
+            f"script dry run failed for {script_path}: {stderr}"
+        )
 
 
 def render_harness(workflow: Workflow) -> str:


### PR DESCRIPTION
### Motivation
- Generated harness scripts must be verified immediately so the workflow builder can guarantee produced scripts are syntactically valid and behave in dry-run mode.
- Verification failures should be returned as actionable errors to the UI so users see script problems directly during harness generation.

### Description
- Added `WorkflowVerificationError` and a `_verify_harness_script` helper in `packages/pybackend/workflow_harness_service.py` that runs `bash -n <script>` and `<script> --dry-run` via `subprocess.run` and raises on failure. 
- Invoked `_verify_harness_script` from `generate_workflow_harnesses` so each generated script is verified before being reported as written. 
- Updated API endpoints in `packages/pybackend/app.py` (repository and global `generate-harnesses`) to catch `WorkflowVerificationError` and return `400` responses so errors surface to the frontend. 
- Added unit tests in `packages/pybackend/tests/unit/test_workflow_harness_service.py` that mock `subprocess.run` to cover the successful verification path and the dry-run failure path. 

### Testing
- Running `pytest -q packages/pybackend/tests/unit/test_workflow_harness_service.py` directly outside the project `uv` environment failed due to missing `pydantic` (environment issue). 
- Running the project quick QA with `make qa-quick` (which sets up the backend `uv` environment) executed formatting, linting, and the full backend unit test suite and completed successfully with the unit tests passing (backend run reported `397 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084472969c83328507be65a785205a)