### PR TITLE
Hydrate vars steps on load in WorkflowBuilderPanel

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -80,6 +80,30 @@ const parseAgentText = (value: string) => {
   };
 };
 
+const normalizeStep = (step: WorkflowStep): WorkflowStep => {
+  if (step.type !== "vars") {
+    return step;
+  }
+
+  const entries = Object.entries(step.values || {});
+  const [firstVarName = "", firstValue = ""] = entries[0] || [];
+  const varName = step.varName || firstVarName;
+  const run =
+    step.run ?? (varName && firstVarName === varName ? firstValue : "");
+
+  return {
+    ...step,
+    varName,
+    run,
+    values: varName ? { [varName]: run } : {},
+  };
+};
+
+const normalizeWorkflows = (items: WorkflowDefinition[]) =>
+  items.map((workflow) => ({
+    ...workflow,
+    steps: workflow.steps.map(normalizeStep),
+  }));
 const newWorkflow = (): WorkflowDefinition => ({
   id: `wf_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`,
   name: "New workflow",
@@ -126,7 +150,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
         loadWorkflows(),
         listAgents(),
       ]);
-      setWorkflows(workflowData.workflows || []);
+      setWorkflows(normalizeWorkflows(workflowData.workflows || []));
       setAgents(agentData.agents || []);
       setExpandedIds((prev) => {
         const next = { ...prev };


### PR DESCRIPTION
### Motivation
- Saved `vars` steps were not populating the UI fields (`varName` / `run`) because the component expected those top-level fields but persisted data kept values in the `values` map.

### Description
- Add `normalizeStep` to reconstruct `varName`, `run`, and `values` for `vars` steps from persisted `values` entries. 
- Add `normalizeWorkflows` to map the normalization across all workflow steps. 
- Apply normalization during workflow load by calling `setWorkflows(normalizeWorkflows(workflowData.workflows || []))` in `WorkflowBuilderPanel`. 
- Change made in `packages/frontend/src/components/WorkflowBuilderPanel.tsx`.

### Testing
- Ran the repository quick quality gate via `make qa-quick`, which performs formatting, linting, frontend tests, and backend unit tests, and it completed successfully. 
- Backend unit test run used `uv run pytest` and reported `395 passed, 1 skipped`. 
- Frontend formatting and linting completed without errors during `make qa-quick`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084fbec010833281dfebc4d6d8e021)