### PR TITLE
Use success styling for workflow conversion message

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -215,7 +215,9 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
       </div>
       {loading && <div className="alert">Loading workflows...</div>}
       {saving && <div className="alert">Saving workflows...</div>}
-      {conversionMessage && <div className="alert">{conversionMessage}</div>}
+      {conversionMessage && (
+        <div className="alert success">{conversionMessage}</div>
+      )}
       {conversionError && <div className="alert error">{conversionError}</div>}
       {error && <div className="alert error">{error}</div>}
       {!loading && workflows.length === 0 && (


### PR DESCRIPTION
### Motivation
- Ensure successful workflow conversion feedback is visually consistent and appears greenish by reusing the app's existing success alert style.

### Description
- Update `packages/frontend/src/components/WorkflowBuilderPanel.tsx` to render `conversionMessage` inside `<div className="alert success">` instead of the default alert so it uses the established success styling.

### Testing
- Ran `make qa-quick` (format, lint and backend unit tests) and the quick QA tasks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084fed57008332a4f6f1dc22095b4d)