### PR TITLE
Hide vars-only target field in Workflow Builder row

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -513,9 +513,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                                 void persist(next);
                               }}
                             />
-                          ) : (
-                            <span className="workflow-step-target__placeholder" />
-                          )}
+                          ) : null}
                         </div>
                         <button
                           className="workflow-step-preview"


### PR DESCRIPTION
### Motivation
- Remove the extra target placeholder rendered for non-`vars` steps in the Workflow Builder so `bash` steps are represented only by their command content.

### Description
- Update conditional rendering in `packages/frontend/src/components/WorkflowBuilderPanel.tsx` to return `null` instead of rendering `<span className="workflow-step-target__placeholder" />` for non-`vars`/non-`agent` step types.

### Testing
- Ran `make qa-quick` from the repository root and the format, lint, and test suite completed successfully (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08555165308332887af444c4c0834e)