### PR TITLE
Run harness scripts from repository root context

### DIFF
--- a/packages/pybackend/harness_service.py
+++ b/packages/pybackend/harness_service.py
@@ -89,14 +89,12 @@ def run_harness(
         raise FileNotFoundError("Harness script not found")
 
     command = ["bash", str(resolved_path), *(_parse_harness_args(args))]
+
     execution_cwd = resolved_path.parent
-    for ancestor in resolved_path.parents:
-        if ancestor.name == ".harness":
-            execution_cwd = ancestor.parent
-            break
-        if ancestor.name == "harness" and ancestor.parent.name == ".opencode":
-            execution_cwd = ancestor.parent.parent
-            break
+    if repo_name:
+        candidate_repo_path = get_workspace_home() / repo_name
+        if candidate_repo_path.exists() and candidate_repo_path.is_dir():
+            execution_cwd = candidate_repo_path
 
     process = subprocess.Popen(
         command,

--- a/packages/pybackend/tests/unit/test_harness_service.py
+++ b/packages/pybackend/tests/unit/test_harness_service.py
@@ -116,5 +116,19 @@ def test_run_harness_uses_repository_root_as_working_directory(temp_env):
     assert output_path.read_text(encoding="utf-8").strip() == str(repo_path)
 
 
+def test_run_harness_in_hidden_harness_directory_uses_repository_root(temp_env):
+    workspace, _, _ = temp_env
+    repo_path = workspace / "runner"
+    harness_path = repo_path / ".codex" / "harness" / "pwd.sh"
+    output_path = repo_path / "pwd_codex.txt"
+    harness_path.parent.mkdir(parents=True, exist_ok=True)
+    write_harness_file(harness_path, f'pwd > "{output_path}"')
+
+    result = run_harness("runner", str(harness_path))
+
+    os.waitpid(result["pid"], 0)
+    assert output_path.read_text(encoding="utf-8").strip() == str(repo_path)
+
+
 def test_is_process_running_handles_invalid_pid():
     assert is_process_running(-1) is False


### PR DESCRIPTION
### Motivation
- Ensure harness shell scripts execute in the repository root context so scripts can rely on repository-relative paths rather than the directory where the harness files are stored.

### Description
- Change `run_harness` to prefer `get_workspace_home() / <repo_name>` as the `cwd` when `repo_name` is provided and the repository directory exists, with the script parent remaining as the fallback.
- Remove the previous special-case ancestor checks that inferred the working directory from `.harness` or `.opencode/harness` locations.
- Add a unit test `test_run_harness_in_hidden_harness_directory_uses_repository_root` to verify scripts in hidden harness directories (e.g. `.codex/harness`) run with the repository root as `cwd`.

### Testing
- Ran `pytest -q packages/pybackend/tests/unit/test_harness_service.py`, which passed (`7 passed`).
- Ran `make qa-quick` (format, linters and full backend unit test suite), which completed successfully (`398 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088f59d44c83328581607062208e8e)