### PR TITLE
Fix: Replace chat-message margin-bottom with SpacedItem padding (#458)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -19,6 +19,7 @@ interface MockVirtuosoProps {
   data: ChatMessage[];
   itemContent: (index: number, message: ChatMessage) => ReactNode;
   components?: {
+    Item?: ComponentType<React.HTMLAttributes<HTMLDivElement>>;
     Footer?: ComponentType;
   };
 }
@@ -32,11 +33,15 @@ vi.mock("react-virtuoso", async () => {
         ReactModule.useImperativeHandle(ref, () => ({
           scrollToIndex: scrollToIndexMock,
         }));
+        const Item = components?.Item;
         const Footer = components?.Footer;
 
         return (
           <div>
-            {data.map((message, index) => itemContent(index, message))}
+            {data.map((message, index) => {
+              const content = itemContent(index, message);
+              return Item ? <Item key={message.id}>{content}</Item> : content;
+            })}
             {Footer ? <Footer /> : null}
           </div>
         );

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -5,6 +5,16 @@ import { ChatMessage } from "../types/chat";
 import { SaveIcon } from "./icons/SaveIcon";
 import { TrashIcon } from "./icons/TrashIcon";
 
+const SpacedItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  function SpacedItem({ children, ...props }, ref) {
+    return (
+      <div ref={ref} {...props} style={{ paddingBottom: "1rem" }}>
+        {children}
+      </div>
+    );
+  },
+);
+
 interface ChatWindowProps {
   chat: ChatMessage[];
   chatWindowRef?: React.RefObject<ChatWindowHandle>;
@@ -200,7 +210,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
       </>
     );
     const components = React.useMemo(
-      () => ({ Footer: () => footerContent }),
+      () => ({ Item: SpacedItem, Footer: () => footerContent }),
       [footerContent],
     );
 

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -5,15 +5,16 @@ import { ChatMessage } from "../types/chat";
 import { SaveIcon } from "./icons/SaveIcon";
 import { TrashIcon } from "./icons/TrashIcon";
 
-const SpacedItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  function SpacedItem({ children, ...props }, ref) {
-    return (
-      <div ref={ref} {...props} style={{ paddingBottom: "1rem" }}>
-        {children}
-      </div>
-    );
-  },
-);
+const SpacedItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function SpacedItem({ children, ...props }, ref) {
+  return (
+    <div ref={ref} {...props} style={{ paddingBottom: "1rem" }}>
+      {children}
+    </div>
+  );
+});
 
 interface ChatWindowProps {
   chat: ChatMessage[];

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -401,7 +401,6 @@ textarea {
 
 .chat-message {
   background: rgba(59, 130, 246, 0.12);
-  margin-bottom: 1rem;
   padding: 0.75rem 1rem;
   border-radius: 0.9rem;
   box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
@@ -592,11 +591,24 @@ textarea {
   margin: 0.5rem 0;
 }
 
-.chat-message .markdown p:first-child {
+.chat-message .markdown p,
+.chat-message .markdown ul,
+.chat-message .markdown ol,
+.chat-message .markdown blockquote {
+  margin: 0.5em 0;
+}
+
+.chat-message .markdown p:first-child,
+.chat-message .markdown ul:first-child,
+.chat-message .markdown ol:first-child,
+.chat-message .markdown blockquote:first-child {
   margin-top: 0;
 }
 
-.chat-message .markdown p:last-child {
+.chat-message .markdown p:last-child,
+.chat-message .markdown ul:last-child,
+.chat-message .markdown ol:last-child,
+.chat-message .markdown blockquote:last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary

The `.chat-message` CSS class used `margin-bottom: 1rem` for visual spacing between messages. Virtuoso measures item height via `ResizeObserver`, which excludes CSS margins by specification. This caused Virtuoso to underestimate each item's height by `1rem`, preventing `followOutput` and `atBottomStateChange` from reaching the true scroll bottom — leaving a visible gap below the last message.

## Root Cause

`margin-bottom: 1rem` was added in commit `f91e195` ("Fix: Restore chat message spacing #432") to restore visual spacing after Virtuoso replaced direct flex children. The intent was correct but the mechanism was wrong: margins are invisible to Virtuoso's ResizeObserver measurements.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/styles/index.css` | Remove `margin-bottom: 1rem` from `.chat-message` |
| `packages/frontend/src/components/ChatWindow.tsx` | Add module-scope `SpacedItem` forwardRef with `paddingBottom: 1rem`; include `Item: SpacedItem` in Virtuoso `components` memo |
| `packages/frontend/src/styles/index.css` | Normalize `ul`/`ol`/`blockquote` margins inside `.chat-message .markdown` |
| `packages/frontend/src/components/ChatWindow.test.tsx` | Add `Item` to `MockVirtuosoProps` and render through it in the mock |

## Testing

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Unit tests pass (`npx vitest run src/components/ChatWindow.test.tsx` — 11/11)
- [x] Lint passes (`eslint`)
- [x] Full QA gate passes (`make qa-quick` — 404 passed, 0 failures)

## Validation

```bash
cd packages/frontend
npx vitest run src/components/ChatWindow.test.tsx
npm run lint
npx tsc --noEmit
```

## Issue

Fixes #458

<details>
<summary>Implementation Details</summary>

### Approach

Replaced external margin (invisible to ResizeObserver) with internal padding on a Virtuoso `Item` wrapper component (`SpacedItem`). Padding is included in `ResizeObserver.contentRect`, so Virtuoso correctly accounts for the full item height.

`SpacedItem` is defined at module scope to ensure a stable reference — defining it inside the component would cause Virtuoso to remount all items on every render.

### Deviations from plan

None.

</details>

_Automated implementation from investigation artifact_