### PR TITLE
fix: restore scroll position on initial load and session switch (#460)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -226,4 +226,96 @@ describe("ChatWindow", () => {
     expect(onSaveSession).toHaveBeenCalledTimes(1);
     expect(onClearSession).toHaveBeenCalledTimes(1);
   });
+
+  it("scrolls to the bottom on initial load when chat becomes non-empty", async () => {
+    const chatWindowRef = React.createRef<ChatWindowHandle>();
+    scrollToIndexMock.mockClear();
+
+    render(
+      <ChatWindow
+        chatWindowRef={chatWindowRef}
+        chat={[makeMessage(), makeMessage(), makeMessage()]}
+        loading={false}
+        emptyMessage="empty"
+      />,
+    );
+
+    // Wait for the rAF retry to flush
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Should have been called (at least once) with the last index
+    expect(scrollToIndexMock).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 2, align: "end", behavior: "auto" }),
+    );
+  });
+
+  it("does not repeat initial-scroll when chat grows after first load", async () => {
+    const chatWindowRef = React.createRef<ChatWindowHandle>();
+    const { rerender } = render(
+      <ChatWindow
+        chatWindowRef={chatWindowRef}
+        chat={[makeMessage()]}
+        loading={false}
+        emptyMessage="empty"
+      />,
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    scrollToIndexMock.mockClear();
+
+    // Simulate a streaming message being appended
+    rerender(
+      <ChatWindow
+        chatWindowRef={chatWindowRef}
+        chat={[makeMessage(), makeMessage()]}
+        loading={false}
+        emptyMessage="empty"
+      />,
+    );
+
+    // The initial-scroll effect must NOT fire again (it's guarded by the ref).
+    // followOutput handles streaming updates.
+    expect(scrollToIndexMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: "auto" }),
+    );
+  });
+
+  it("resets initial scroll when sessionId changes", async () => {
+    const chatWindowRef = React.createRef<ChatWindowHandle>();
+    const { rerender } = render(
+      <ChatWindow
+        chatWindowRef={chatWindowRef}
+        chat={[makeMessage()]}
+        sessionId="session-1"
+        loading={false}
+        emptyMessage="empty"
+      />,
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    scrollToIndexMock.mockClear();
+
+    // Switch session with new history
+    rerender(
+      <ChatWindow
+        chatWindowRef={chatWindowRef}
+        chat={[makeMessage(), makeMessage()]}
+        sessionId="session-2"
+        loading={false}
+        emptyMessage="empty"
+      />,
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(scrollToIndexMock).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 1, align: "end", behavior: "auto" }),
+    );
+  });
 });

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -135,6 +135,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
     markdownOptions,
   }) {
     const virtuosoRef = React.useRef<VirtuosoHandle>(null);
+    const initialScrollDoneRef = React.useRef(false);
     const [scrollParent, setScrollParent] =
       React.useState<HTMLDivElement | null>(null);
     const setChatWindowElement = React.useCallback(
@@ -143,6 +144,31 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
       },
       [],
     );
+
+    // When the user switches to a different session, the next non-empty load
+    // should restore to bottom again. Must run before the initial-scroll effect
+    // so the flag is cleared before that effect evaluates it in the same cycle.
+    React.useEffect(() => {
+      initialScrollDoneRef.current = false;
+    }, [sessionId]);
+
+    // Scroll to bottom on initial load: fires once when both the scroll container
+    // and the first batch of messages are ready. Uses "auto" (instant) so the user
+    // never sees a scroll animation on restore. A single rAF retry handles the case
+    // where item heights are still being measured by Virtuoso on first layout.
+    React.useEffect(() => {
+      if (initialScrollDoneRef.current) return;
+      if (!scrollParent || !chat.length || !virtuosoRef.current) return;
+
+      initialScrollDoneRef.current = true;
+      virtuosoRef.current.scrollToIndex({ index: chat.length - 1, align: "end", behavior: "auto" });
+
+      // One retry after the browser has settled the first layout pass.
+      const raf = requestAnimationFrame(() => {
+        virtuosoRef.current?.scrollToIndex({ index: chat.length - 1, align: "end", behavior: "auto" });
+      });
+      return () => cancelAnimationFrame(raf);
+    }, [scrollParent, chat.length]);
 
     const scrollToBottom = React.useCallback(() => {
       if (!virtuosoRef.current || !chat.length) return;

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -161,11 +161,19 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
       if (!scrollParent || !chat.length || !virtuosoRef.current) return;
 
       initialScrollDoneRef.current = true;
-      virtuosoRef.current.scrollToIndex({ index: chat.length - 1, align: "end", behavior: "auto" });
+      virtuosoRef.current.scrollToIndex({
+        index: chat.length - 1,
+        align: "end",
+        behavior: "auto",
+      });
 
       // One retry after the browser has settled the first layout pass.
       const raf = requestAnimationFrame(() => {
-        virtuosoRef.current?.scrollToIndex({ index: chat.length - 1, align: "end", behavior: "auto" });
+        virtuosoRef.current?.scrollToIndex({
+          index: chat.length - 1,
+          align: "end",
+          behavior: "auto",
+        });
       });
       return () => cancelAnimationFrame(raf);
     }, [scrollParent, chat.length]);


### PR DESCRIPTION
## Summary

When a page hosting `ChatWindow` is refreshed or a session history is loaded asynchronously, the chat list renders from the top instead of the bottom. The `followOutput` prop only auto-scrolls when new items arrive while the user is already at the bottom; it does not reliably scroll to the bottom on the very first render of a non-empty `chat` array.

## Root Cause

`customScrollParent` starts as `null` and is populated asynchronously via `useState` callback ref. Virtuoso's `followOutput` initial tick fires against an undefined scroll container, so the auto-scroll is skipped. There was no imperative `scrollToIndex` call guarded by "scroll container ready AND chat non-empty" for the initial load case (removed in commit `807ce84` with the assumption that `followOutput` handles it — which is only true for the streaming case).

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/components/ChatWindow.tsx` | Add `initialScrollDoneRef`, session-reset effect, and initial-scroll effect with rAF retry |
| `packages/frontend/src/components/ChatWindow.test.tsx` | Add 3 test cases: initial load scroll, no-repeat on append, session reset |

## Testing

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 14 ChatWindow unit tests pass
- [x] Lint passes
- [x] Full backend + frontend QA via pre-push hook (404 passed)

## Validation

```bash
cd packages/frontend
npx tsc --noEmit
npx vitest run ChatWindow
npm run lint
```

## Issue

Fixes #460

<details>
<summary>Implementation Details</summary>

### Approach

1. **sessionId reset effect** (runs first, before initial-scroll effect): resets `initialScrollDoneRef.current = false` when session changes, ensuring each new session gets its own bottom-restore.
2. **initial-scroll effect** (deps: `[scrollParent, chat.length]`): fires once when both the measured scroll container and a non-empty chat array are available. Uses `behavior: "auto"` (instant) so no visible scroll animation on restore. A single `requestAnimationFrame` retry covers the case where Virtuoso needs one layout pass to stabilize item heights.
3. **`initialScrollDoneRef`**: plain ref (not state) so the retry causes no extra renders.

### Deviation from plan

Effect order swapped: sessionId-reset effect placed **before** the initial-scroll effect (not after) to ensure the flag is cleared before the initial-scroll effect evaluates it in the same render cycle.

</details>

_Automated implementation from investigation artifact_