### PR TITLE
Fix: merge Virtuoso-injected style in SpacedItem (#462)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -10,7 +10,7 @@ const SpacedItem = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement>
 >(function SpacedItem({ children, ...props }, ref) {
   return (
-    <div ref={ref} {...props} style={{ paddingBottom: "1rem" }}>
+    <div ref={ref} {...props} style={{ ...props.style, paddingBottom: "1rem" }}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

`SpacedItem` spread `{...props}` before an explicit `style` attribute, causing JSX to overwrite any `style` Virtuoso passes via `ItemProps<Data>.style`. Virtuoso may pass positioning/height styles critical for correct virtualization, so discarding them can cause scroll miscalculations — defeating the purpose of the fix in #461.

## Root Cause

JSX resolves props left-to-right; a later `style` prop overwrites an earlier `props.style`. The `SpacedItem` component in `ChatWindow.tsx:13` placed the explicit `style` after the spread, so `props.style` was always discarded.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/components/ChatWindow.tsx` | Spread `props.style` inside the style object so Virtuoso-managed styles are preserved while `paddingBottom` always takes precedence |

## Testing

- [x] Type check passes
- [x] Unit tests pass (404 passed)
- [x] Lint passes
- [x] `make qa-quick` green

## Validation

```bash
make qa-quick
```

## Issue

Fixes #462

_Automated implementation from investigation artifact_