### PR TITLE
fix: add TTL cache to list_commands() to eliminate ~3s load penalty (#444)

### DIFF
--- a/packages/pybackend/command_service.py
+++ b/packages/pybackend/command_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -13,6 +14,8 @@ from config import get_made_home, get_workspace_home
 
 logger = logging.getLogger(__name__)
 _PAREN_COMMENT_PATTERN = re.compile(r"\s*\([^()]*\)\s*$")
+_COMMANDS_CACHE: dict[str, dict] = {}
+_CACHE_TTL_SECONDS = 60
 
 
 def _strip_parenthetical_comment(value: str) -> str:
@@ -98,6 +101,22 @@ def _load_repo_commands(repo_name: str) -> List[Dict[str, Any]]:
 
 
 def list_commands(repo_name: str | None = None) -> List[Dict[str, Any]]:
+    """List available commands with in-memory caching (60s TTL)."""
+    cache_key = repo_name or "__workspace__"
+    now = time.monotonic()
+
+    if cache_key in _COMMANDS_CACHE:
+        entry = _COMMANDS_CACHE[cache_key]
+        if now - entry["timestamp"] < _CACHE_TTL_SECONDS:
+            logger.debug("Returning cached commands for '%s'", cache_key)
+            return entry["data"]
+
+    result = _list_commands_uncached(repo_name)
+    _COMMANDS_CACHE[cache_key] = {"data": result, "timestamp": now}
+    return result
+
+
+def _list_commands_uncached(repo_name: str | None = None) -> List[Dict[str, Any]]:
     commands: List[Dict[str, Any]] = []
     command_roots: List[Tuple[Path, str]] = [
         (get_made_home() / ".made" / "commands", "made"),

--- a/packages/pybackend/tests/unit/test_command_service.py
+++ b/packages/pybackend/tests/unit/test_command_service.py
@@ -158,3 +158,63 @@ def test_list_commands_dedupes_identical_command_paths(tmp_path, monkeypatch):
 
     assert len(commands) == 1
     assert commands[0]["description"] == "Shared command"
+
+
+def test_list_commands_returns_cached_result_within_ttl(temp_env):
+    workspace, made_home, user_home = temp_env
+    repo_path = workspace / "cache-repo"
+    cmd_path = repo_path / ".claude" / "commands" / "cached.md"
+    cmd_path.parent.mkdir(parents=True, exist_ok=True)
+    write_command_file(cmd_path, "Cached command", None, "echo cached")
+
+    from command_service import _COMMANDS_CACHE
+    _COMMANDS_CACHE.clear()
+
+    result1 = list_commands("cache-repo")
+    result2 = list_commands("cache-repo")
+
+    assert len(result1) == 1
+    assert result1 is result2  # same cached object
+
+
+def test_list_commands_cache_expires_after_ttl(temp_env):
+    workspace, made_home, user_home = temp_env
+    repo_path = workspace / "expire-repo"
+    cmd_path = repo_path / ".claude" / "commands" / "first.md"
+    cmd_path.parent.mkdir(parents=True, exist_ok=True)
+    write_command_file(cmd_path, "First", None, "echo first")
+
+    from command_service import _COMMANDS_CACHE
+    _COMMANDS_CACHE.clear()
+
+    result1 = list_commands("expire-repo")
+    assert len(result1) == 1
+
+    # Add a second command file
+    cmd_path2 = repo_path / ".claude" / "commands" / "second.md"
+    write_command_file(cmd_path2, "Second", None, "echo second")
+
+    # Expire the cache entry manually
+    _COMMANDS_CACHE["expire-repo"]["timestamp"] -= 61
+
+    result2 = list_commands("expire-repo")
+    assert len(result2) == 2  # cache refreshed, new file picked up
+
+
+def test_list_commands_different_repos_isolated_in_cache(temp_env):
+    workspace, made_home, user_home = temp_env
+
+    from command_service import _COMMANDS_CACHE
+    _COMMANDS_CACHE.clear()
+
+    for repo in ("repo-a", "repo-b"):
+        cmd = workspace / repo / ".claude" / "commands" / f"{repo}.md"
+        cmd.parent.mkdir(parents=True, exist_ok=True)
+        write_command_file(cmd, f"Command {repo}", None, f"echo {repo}")
+
+    result_a = list_commands("repo-a")
+    result_b = list_commands("repo-b")
+
+    assert result_a[0]["description"] == "Command repo-a"
+    assert result_b[0]["description"] == "Command repo-b"
+    assert result_a is not result_b


### PR DESCRIPTION
## Summary

`list_commands()` scanned 10+ directories via `rglob("*.md")` on every call with no caching. Combined with React StrictMode double-invoking the `useEffect` mount at `RepositoryPage.tsx:839`, this added ~3s of blocking to the critical load path per page visit.

## Root Cause

`command_service.py` lacked a TTL cache while the identical pattern had already been implemented in `agent_service.py` (issue #442) — a design gap from the original implementation.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/command_service.py` | Add `import time`, `_COMMANDS_CACHE` dict, `_CACHE_TTL_SECONDS = 60`; refactor `list_commands()` to check/populate cache keyed by `repo_name`; extract `_list_commands_uncached()` |
| `packages/pybackend/tests/unit/test_command_service.py` | Add 3 cache tests: hit within TTL, expiry, per-repo isolation |

## Testing

- [x] Type check passes
- [x] Unit tests pass (407 passed, 1 skipped)
- [x] Lint passes
- [x] `make qa-quick` ✅

## Validation

```bash
uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_command_service.py -v
make qa-quick
```

## Issue

Fixes #444

<details>
<summary>Implementation Details</summary>

### Pattern mirrored from agent_service.py

```python
_COMMANDS_CACHE: dict[str, dict] = {}
_CACHE_TTL_SECONDS = 60

def list_commands(repo_name: str | None = None) -> List[Dict[str, Any]]:
    cache_key = repo_name or "__workspace__"
    now = time.monotonic()
    if cache_key in _COMMANDS_CACHE:
        entry = _COMMANDS_CACHE[cache_key]
        if now - entry["timestamp"] < _CACHE_TTL_SECONDS:
            return entry["data"]
    result = _list_commands_uncached(repo_name)
    _COMMANDS_CACHE[cache_key] = {"data": result, "timestamp": now}
    return result
```

### Deviations from plan

None — implementation follows the investigation artifact exactly.

</details>

_Automated implementation from investigation artifact_