### PR TITLE
Fix: pass sessionId to status/cancel API endpoints (#471)

### DIFF
--- a/packages/frontend/src/hooks/useApi.test.ts
+++ b/packages/frontend/src/hooks/useApi.test.ts
@@ -183,3 +183,75 @@ describe("GET request deduplication", () => {
     expect(result).toEqual({ agents: [{ name: "agent-2" }] });
   });
 });
+
+describe("sessionId forwarding for status and cancel endpoints", () => {
+  const originalFetch = window.fetch;
+
+  afterAll(() => {
+    window.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should include session_id query param in getRepositoryAgentStatus when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ processing: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.getRepositoryAgentStatus("my-repo", "ses_abc123");
+
+    expect(window.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("session_id=ses_abc123"),
+      expect.anything(),
+    );
+  });
+
+  it("should omit session_id query param in getRepositoryAgentStatus when not provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ processing: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.getRepositoryAgentStatus("my-repo");
+
+    expect(window.fetch).toHaveBeenCalledWith(
+      expect.not.stringContaining("session_id"),
+      expect.anything(),
+    );
+  });
+
+  it("should include sessionId in request body for cancelRepositoryAgent when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.cancelRepositoryAgent("my-repo", "ses_xyz");
+
+    const [, init] = (window.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ sessionId: "ses_xyz" });
+  });
+
+  it("should send cancel without body when sessionId is not provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.cancelRepositoryAgent("my-repo");
+
+    const [, init] = (window.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.body).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/hooks/useApi.test.ts
+++ b/packages/frontend/src/hooks/useApi.test.ts
@@ -254,4 +254,94 @@ describe("sessionId forwarding for status and cancel endpoints", () => {
     const [, init] = (window.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(init.body).toBeUndefined();
   });
+
+  it("should include session_id query param in getKnowledgeAgentStatus when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ processing: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.getKnowledgeAgentStatus("my-doc.md", "ses_k1");
+
+    expect(window.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("session_id=ses_k1"),
+      expect.anything(),
+    );
+  });
+
+  it("should include sessionId in request body for cancelKnowledgeAgent when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.cancelKnowledgeAgent("my-doc.md", "ses_k1");
+
+    const [, init] = (window.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ sessionId: "ses_k1" });
+  });
+
+  it("should include session_id query param in getConstitutionAgentStatus when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ processing: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.getConstitutionAgentStatus("my-const.md", "ses_c1");
+
+    expect(window.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("session_id=ses_c1"),
+      expect.anything(),
+    );
+  });
+
+  it("should include sessionId in request body for cancelConstitutionAgent when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.cancelConstitutionAgent("my-const.md", "ses_c1");
+
+    const [, init] = (window.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ sessionId: "ses_c1" });
+  });
+
+  it("should include session_id query param in getTaskAgentStatus when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ processing: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.getTaskAgentStatus("my-task.md", "ses_t1");
+
+    expect(window.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("session_id=ses_t1"),
+      expect.anything(),
+    );
+  });
+
+  it("should include sessionId in request body for cancelTaskAgent when provided", async () => {
+    window.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await api.cancelTaskAgent("my-task.md", "ses_t1");
+
+    const [, init] = (window.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ sessionId: "ses_t1" });
+  });
 });

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -482,10 +482,17 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ message, sessionId, model, agent }),
     }),
-  getRepositoryAgentStatus: (name: string) =>
-    request<AgentStatus>(`/repositories/${name}/agent/status`),
-  cancelRepositoryAgent: (name: string) =>
-    request(`/repositories/${name}/agent/cancel`, { method: "POST" }),
+  getRepositoryAgentStatus: (name: string, sessionId?: string) => {
+    const params = sessionId
+      ? `?session_id=${encodeURIComponent(sessionId)}`
+      : "";
+    return request<AgentStatus>(`/repositories/${name}/agent/status${params}`);
+  },
+  cancelRepositoryAgent: (name: string, sessionId?: string) =>
+    request(`/repositories/${name}/agent/cancel`, {
+      method: "POST",
+      ...(sessionId && { body: JSON.stringify({ sessionId }) }),
+    }),
   getRepositoryAgentHistory: (
     name: string,
     sessionId: string,
@@ -720,10 +727,17 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ message, sessionId, model, agent }),
     }),
-  getKnowledgeAgentStatus: (name: string) =>
-    request<AgentStatus>(`/knowledge/${name}/agent/status`),
-  cancelKnowledgeAgent: (name: string) =>
-    request(`/knowledge/${name}/agent/cancel`, { method: "POST" }),
+  getKnowledgeAgentStatus: (name: string, sessionId?: string) => {
+    const params = sessionId
+      ? `?session_id=${encodeURIComponent(sessionId)}`
+      : "";
+    return request<AgentStatus>(`/knowledge/${name}/agent/status${params}`);
+  },
+  cancelKnowledgeAgent: (name: string, sessionId?: string) =>
+    request(`/knowledge/${name}/agent/cancel`, {
+      method: "POST",
+      ...(sessionId && { body: JSON.stringify({ sessionId }) }),
+    }),
   listConstitutions: () =>
     request<{ constitutions: ArtefactSummary[] }>("/constitutions"),
   getConstitution: (name: string) =>
@@ -748,10 +762,17 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ message, sessionId, model, agent }),
     }),
-  getConstitutionAgentStatus: (name: string) =>
-    request<AgentStatus>(`/constitutions/${name}/agent/status`),
-  cancelConstitutionAgent: (name: string) =>
-    request(`/constitutions/${name}/agent/cancel`, { method: "POST" }),
+  getConstitutionAgentStatus: (name: string, sessionId?: string) => {
+    const params = sessionId
+      ? `?session_id=${encodeURIComponent(sessionId)}`
+      : "";
+    return request<AgentStatus>(`/constitutions/${name}/agent/status${params}`);
+  },
+  cancelConstitutionAgent: (name: string, sessionId?: string) =>
+    request(`/constitutions/${name}/agent/cancel`, {
+      method: "POST",
+      ...(sessionId && { body: JSON.stringify({ sessionId }) }),
+    }),
   listTasks: () => request<{ tasks: ArtefactSummary[] }>("/tasks"),
   getTask: (name: string) => request<MatterFile>(`/tasks/${name}`),
   deleteTask: (name: string) =>
@@ -774,10 +795,17 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ message, sessionId, model, agent }),
     }),
-  getTaskAgentStatus: (name: string) =>
-    request<AgentStatus>(`/tasks/${name}/agent/status`),
-  cancelTaskAgent: (name: string) =>
-    request(`/tasks/${name}/agent/cancel`, { method: "POST" }),
+  getTaskAgentStatus: (name: string, sessionId?: string) => {
+    const params = sessionId
+      ? `?session_id=${encodeURIComponent(sessionId)}`
+      : "";
+    return request<AgentStatus>(`/tasks/${name}/agent/status${params}`);
+  },
+  cancelTaskAgent: (name: string, sessionId?: string) =>
+    request(`/tasks/${name}/agent/cancel`, {
+      method: "POST",
+      ...(sessionId && { body: JSON.stringify({ sessionId }) }),
+    }),
   getTaskAgentHistory: (
     name: string,
     sessionId: string,

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -263,7 +263,7 @@ export const ConstitutionPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     try {
-      const status = await api.getConstitutionAgentStatus(name);
+      const status = await api.getConstitutionAgentStatus(name, sessionId || undefined);
       setChatLoading(status.processing);
       setAgentStatus(
         status.processing
@@ -275,7 +275,7 @@ export const ConstitutionPage: React.FC = () => {
       console.error("Failed to load agent status", error);
       return false;
     }
-  }, [isExternal, name]);
+  }, [isExternal, name, sessionId]);
 
   useEffect(() => {
     refreshAgentStatus();
@@ -414,7 +414,7 @@ export const ConstitutionPage: React.FC = () => {
   const handleCancel = async () => {
     if (!name) return;
     try {
-      await api.cancelConstitutionAgent(name);
+      await api.cancelConstitutionAgent(name, sessionId || undefined);
     } catch (error) {
       console.error("Failed to cancel agent request", error);
       setAgentStatus("Unable to cancel the agent request.");

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -263,7 +263,10 @@ export const ConstitutionPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     try {
-      const status = await api.getConstitutionAgentStatus(name, sessionId || undefined);
+      const status = await api.getConstitutionAgentStatus(
+        name,
+        sessionId || undefined,
+      );
       setChatLoading(status.processing);
       setAgentStatus(
         status.processing

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -261,7 +261,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     try {
-      const status = await api.getKnowledgeAgentStatus(name, sessionId || undefined);
+      const status = await api.getKnowledgeAgentStatus(
+        name,
+        sessionId || undefined,
+      );
       setChatLoading(status.processing);
       setAgentStatus(
         status.processing

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -261,7 +261,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     try {
-      const status = await api.getKnowledgeAgentStatus(name);
+      const status = await api.getKnowledgeAgentStatus(name, sessionId || undefined);
       setChatLoading(status.processing);
       setAgentStatus(
         status.processing
@@ -273,7 +273,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       console.error("Failed to load agent status", error);
       return false;
     }
-  }, [isExternal, name]);
+  }, [isExternal, name, sessionId]);
 
   useEffect(() => {
     refreshAgentStatus();
@@ -412,7 +412,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const handleCancel = async () => {
     if (!name || isExternal) return;
     try {
-      await api.cancelKnowledgeAgent(name);
+      await api.cancelKnowledgeAgent(name, sessionId || undefined);
     } catch (error) {
       console.error("Failed to cancel agent request", error);
       setAgentStatus("Unable to cancel the agent request.");

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1140,7 +1140,10 @@ export const RepositoryPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     try {
-      const status = await api.getRepositoryAgentStatus(name, sessionId || undefined);
+      const status = await api.getRepositoryAgentStatus(
+        name,
+        sessionId || undefined,
+      );
       setChatLoading(status.processing);
       setChatError(
         status.processing

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1140,7 +1140,7 @@ export const RepositoryPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     try {
-      const status = await api.getRepositoryAgentStatus(name);
+      const status = await api.getRepositoryAgentStatus(name, sessionId || undefined);
       setChatLoading(status.processing);
       setChatError(
         status.processing
@@ -1152,7 +1152,7 @@ export const RepositoryPage: React.FC = () => {
       console.error("Failed to load agent status", error);
       return false;
     }
-  }, [name]);
+  }, [name, sessionId]);
 
   useEffect(() => {
     refreshAgentStatus();
@@ -1284,7 +1284,7 @@ export const RepositoryPage: React.FC = () => {
   const handleCancelAgent = async () => {
     if (!name) return;
     try {
-      await api.cancelRepositoryAgent(name);
+      await api.cancelRepositoryAgent(name, sessionId || undefined);
     } catch (error) {
       console.error("Failed to cancel agent request", error);
       setChatError("Unable to cancel the agent request.");

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -223,7 +223,7 @@ export const TaskPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     try {
-      const status = await api.getTaskAgentStatus(name);
+      const status = await api.getTaskAgentStatus(name, sessionId || undefined);
       setChatLoading(status.processing);
       setAgentStatus(
         status.processing
@@ -235,7 +235,7 @@ export const TaskPage: React.FC = () => {
       console.error("Failed to load agent status", error);
       return false;
     }
-  }, [name]);
+  }, [name, sessionId]);
 
   useEffect(() => {
     refreshAgentStatus();
@@ -350,7 +350,7 @@ export const TaskPage: React.FC = () => {
   const handleCancel = async () => {
     if (!name) return;
     try {
-      await api.cancelTaskAgent(name);
+      await api.cancelTaskAgent(name, sessionId || undefined);
     } catch (error) {
       console.error("Failed to cancel agent request", error);
       setAgentStatus("Unable to cancel the agent request.");


### PR DESCRIPTION
## Summary

The frontend never forwarded `sessionId` to the 8 agent status/cancel API functions in `useApi.ts`, so the backend's per-session isolation from PR #468 had no effect in the UI. This caused the Send/Cancel button toggle to reflect channel-level state instead of session-level state, producing false loading states and enabling channel-wide cancellation.

## Root Cause

PR #468 added optional `session_id`/`sessionId` parameters to the backend status and cancel endpoints. The companion frontend change was never made: 8 function signatures in `useApi.ts` were not updated and 4 consumer page components never forwarded their `sessionId` state to these calls.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/hooks/useApi.ts` | Add optional `sessionId` param to all 4 status + 4 cancel functions; forward to URL query/POST body |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Pass `sessionId` in `refreshAgentStatus` and `handleCancelAgent`; update `useCallback` deps |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Pass `sessionId` in `refreshAgentStatus` and `handleCancel`; update `useCallback` deps |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Pass `sessionId` in `refreshAgentStatus` and `handleCancel`; update `useCallback` deps |
| `packages/frontend/src/pages/TaskPage.tsx` | Pass `sessionId` in `refreshAgentStatus` and `handleCancel`; update `useCallback` deps |
| `packages/frontend/src/hooks/useApi.test.ts` | Add 4 unit tests verifying `session_id` query param and `sessionId` body forwarding |

## Testing

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Frontend unit tests pass — 14/14 (`npx vitest run src/hooks/useApi.test.ts`)
- [x] Backend unit tests pass — 415/415 (pre-push hook `make qa-quick`)
- [x] ESLint passes (`npm run lint`)

## Validation

```bash
# Frontend
npx tsc --noEmit --prefix packages/frontend
npx vitest run packages/frontend/src/hooks/useApi.test.ts
npm run lint --prefix packages/frontend

# Full stack
make qa-quick
```

## Issue

Fixes #471

<details>
<summary>Implementation Details</summary>

### Patterns followed

- Status: `?session_id=${encodeURIComponent(sessionId)}` (matches `getRepositoryAgentHistory` pattern)
- Cancel: `...(sessionId && { body: JSON.stringify({ sessionId }) })` (matches `sendRepositoryAgent` body pattern)
- Callers: `sessionId || undefined` to convert `null` from `usePersistentString` to `undefined` (safe fallback to channel key)

### Deviations from plan

None — implementation follows the artifact exactly.

</details>

_Automated implementation from investigation artifact_