### PR TITLE
Fix: reset chatLoading on session switch to prevent stale spinner (#490)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -620,7 +620,14 @@ export const RepositoryPage: React.FC = () => {
       textarea?.focus();
       textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
     });
-  }, [name, searchParams, sessionId, setSearchParams, setSessionId, setChatError]);
+  }, [
+    name,
+    searchParams,
+    sessionId,
+    setSearchParams,
+    setSessionId,
+    setChatError,
+  ]);
 
   useEffect(() => {
     const tab = searchParams.get("tab");
@@ -1298,6 +1305,7 @@ export const RepositoryPage: React.FC = () => {
       return;
     }
     setSessionModalOpen(false);
+    setChatLoading(false);
     setChatError(null);
     setChat([]);
     setSessionId(session.id);

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -5,7 +5,38 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { RepositoryPage } from "../RepositoryPage";
-import { api, ChatSession } from "../../hooks/useApi";
+import {
+  api,
+  ChatHistoryMessage,
+  ChatHistoryResponse,
+  ChatSession,
+} from "../../hooks/useApi";
+
+vi.mock("react-virtuoso", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react");
+  return {
+    Virtuoso: ReactModule.forwardRef<
+      { scrollToIndex: (opts: unknown) => void },
+      {
+        data: unknown[];
+        itemContent: (i: number, d: unknown) => React.ReactNode;
+      }
+    >(function MockVirtuoso({ data, itemContent }, ref) {
+      ReactModule.useImperativeHandle(ref, () => ({ scrollToIndex: vi.fn() }));
+      return ReactModule.createElement(
+        "div",
+        { "data-testid": "virtuoso" },
+        data.map((item, i) =>
+          ReactModule.createElement(
+            ReactModule.Fragment,
+            { key: i },
+            itemContent(i, item),
+          ),
+        ),
+      );
+    }),
+  };
+});
 
 class ResizeObserverStub {
   observe() {}
@@ -16,7 +47,9 @@ vi.stubGlobal("ResizeObserver", ResizeObserverStub);
 
 vi.mock("../../hooks/useApi", async () => {
   const actual =
-    await vi.importActual<typeof import("../../hooks/useApi")>("../../hooks/useApi");
+    await vi.importActual<typeof import("../../hooks/useApi")>(
+      "../../hooks/useApi",
+    );
   return {
     ...actual,
     api: {
@@ -169,5 +202,57 @@ describe("RepositoryPage session selection", () => {
 
     const sessionBtn = await screen.findByTitle("Empty ID Session");
     expect(() => fireEvent.click(sessionBtn)).not.toThrow();
+  });
+
+  it("clears stale content, shows empty transient state, then renders new session messages on switch (AC490-1/2/3)", async () => {
+    const sessionAMsg: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const sessionBMsg: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [sessionAMsg] };
+    const historyB = { sessionId: "session-b", messages: [sessionBMsg] };
+    let resolveB: (value: ChatHistoryResponse) => void;
+    const promise = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockResolvedValueOnce(promise);
+
+    renderPage();
+
+    // Select session A
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Select session B
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    // AC490-1: Old content absent from DOM after clicking new session
+    expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
+
+    // AC490-2: Empty-state container present while fetch pending (no stale content)
+    expect(document.querySelector(".empty")).toBeInTheDocument();
+
+    // Resolve B's fetch
+    resolveB!(historyB);
+
+    // AC490-3: New session content rendered after fetch resolves
+    expect(await screen.findByText("Hello from B")).toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -255,4 +255,88 @@ describe("RepositoryPage session selection", () => {
     // AC490-3: New session content rendered after fetch resolves
     expect(await screen.findByText("Hello from B")).toBeInTheDocument();
   });
+
+  it("adversarial: deferred promise rejection on session switch shows error and preserves empty state", async () => {
+    const sessionAMsg: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [sessionAMsg] };
+    let rejectB: (reason: Error) => void;
+    const promise = new Promise<ChatHistoryResponse>((_, reject) => {
+      rejectB = reject;
+    });
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockResolvedValueOnce(promise);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
+    expect(document.querySelector(".empty")).toBeInTheDocument();
+
+    rejectB!(new Error("Fetch failed"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Fetch failed")).toBeInTheDocument();
+    });
+
+    expect(document.querySelector(".empty")).toBeInTheDocument();
+    expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
+  });
+
+  it("adversarial: empty history response on session switch preserves empty state without error", async () => {
+    const sessionAMsg: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [sessionAMsg] };
+    let resolveB: (value: ChatHistoryResponse) => void;
+    const promise = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockResolvedValueOnce(promise);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
+    expect(document.querySelector(".empty")).toBeInTheDocument();
+
+    resolveB!({ sessionId: "session-b", messages: [] });
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    expect(document.querySelector(".empty")).toBeInTheDocument();
+    expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
+    expect(document.querySelectorAll(".alert").length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #490. Adds a behavior test guarding the visible session-switch transition in `RepositoryPage` and a small production fix to clear `chatLoading` when switching sessions, so stale "Agent is thinking..." state does not linger from the previous session.

## Scope

- `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx`
  - behavior test for stale-content clearing, loading state, and final selected-session content
  - adversarial coverage for deferred rejection and empty history
- `packages/frontend/src/pages/RepositoryPage.tsx`
  - reset `chatLoading` during session switch

## TDD Commit Order

1. `264e221` - test: add behavior test for stale-content and loading during session switch (AC490-1/2/3)
2. `066dcf3` - test: add adversarial tests for deferred rejection and empty history on session switch
3. `570e50e` - fix: reset chatLoading on session switch to prevent stale 'Agent is thinking...' spinner

## Validation

- `make qa-quick` ✅
- Backend unit tests: 415 passed, 1 skipped
- Frontend unit tests: 115/115 passed

## Notes

The change is intentionally narrow: it protects the user-visible session-switch flow without broadening scope beyond the regression reported in #490.