### PR TITLE
fix(#483): ChatWindow: rename loading prop to agentProcessing for semantic clarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -86,6 +87,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -188,7 +190,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -237,7 +238,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1321,7 +1321,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1370,7 +1371,6 @@
       "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1388,7 +1388,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1400,7 +1399,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1446,7 +1444,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1870,7 +1867,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1921,6 +1917,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2591,7 +2588,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -2840,7 +2838,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4291,7 +4288,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4729,6 +4725,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5377,6 +5374,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5392,6 +5390,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5443,7 +5442,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5456,7 +5454,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5470,7 +5467,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "6.30.4",
@@ -5755,7 +5753,6 @@
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -5876,9 +5873,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6438,7 +6435,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6524,7 +6520,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -284,6 +284,63 @@ describe("ChatWindow", () => {
     );
   });
 
+  it("toggles loading indicator when agentProcessing changes at runtime (empty chat)", () => {
+    const { rerender } = render(
+      <ChatWindow chat={[]} agentProcessing={false} emptyMessage="No messages" />,
+    );
+
+    expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
+    expect(screen.getByText("No messages")).toBeInTheDocument();
+
+    rerender(
+      <ChatWindow chat={[]} agentProcessing emptyMessage="No messages" />,
+    );
+
+    expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
+    expect(screen.queryByText("No messages")).not.toBeInTheDocument();
+
+    rerender(
+      <ChatWindow chat={[]} agentProcessing={false} emptyMessage="No messages" />,
+    );
+
+    expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
+    expect(screen.getByText("No messages")).toBeInTheDocument();
+  });
+
+  it("toggles loading indicator in Virtuoso footer when agentProcessing changes (non-empty chat)", () => {
+    const { rerender } = render(
+      <ChatWindow chat={[makeMessage()]} agentProcessing={false} emptyMessage="No messages" />,
+    );
+
+    expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
+
+    rerender(
+      <ChatWindow chat={[makeMessage()]} agentProcessing emptyMessage="No messages" />,
+    );
+
+    expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
+
+    rerender(
+      <ChatWindow chat={[makeMessage()]} agentProcessing={false} emptyMessage="No messages" />,
+    );
+
+    expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
+  });
+
+  it("shows loading indicator across empty-to-non-empty transition while agentProcessing remains true", () => {
+    const { rerender } = render(
+      <ChatWindow chat={[]} agentProcessing emptyMessage="No messages" />,
+    );
+
+    expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
+
+    rerender(
+      <ChatWindow chat={[makeMessage()]} agentProcessing emptyMessage="No messages" />,
+    );
+
+    expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
+  });
+
   it("resets initial scroll when sessionId changes", async () => {
     const chatWindowRef = React.createRef<ChatWindowHandle>();
     const { rerender } = render(

--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -67,7 +67,13 @@ describe("ChatWindow", () => {
   });
 
   it("shows empty message when chat is empty", () => {
-    render(<ChatWindow chat={[]} agentProcessing={false} emptyMessage="No messages" />);
+    render(
+      <ChatWindow
+        chat={[]}
+        agentProcessing={false}
+        emptyMessage="No messages"
+      />,
+    );
     expect(screen.getByText("No messages")).toBeInTheDocument();
   });
 
@@ -78,7 +84,11 @@ describe("ChatWindow", () => {
 
   it("renders loading indicator in the virtualized footer for non-empty chat", () => {
     render(
-      <ChatWindow chat={[makeMessage()]} agentProcessing emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
@@ -286,7 +296,11 @@ describe("ChatWindow", () => {
 
   it("toggles loading indicator when agentProcessing changes at runtime (empty chat)", () => {
     const { rerender } = render(
-      <ChatWindow chat={[]} agentProcessing={false} emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[]}
+        agentProcessing={false}
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
@@ -300,7 +314,11 @@ describe("ChatWindow", () => {
     expect(screen.queryByText("No messages")).not.toBeInTheDocument();
 
     rerender(
-      <ChatWindow chat={[]} agentProcessing={false} emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[]}
+        agentProcessing={false}
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
@@ -309,19 +327,31 @@ describe("ChatWindow", () => {
 
   it("toggles loading indicator in Virtuoso footer when agentProcessing changes (non-empty chat)", () => {
     const { rerender } = render(
-      <ChatWindow chat={[makeMessage()]} agentProcessing={false} emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing={false}
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
 
     rerender(
-      <ChatWindow chat={[makeMessage()]} agentProcessing emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
 
     rerender(
-      <ChatWindow chat={[makeMessage()]} agentProcessing={false} emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing={false}
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
@@ -335,7 +365,11 @@ describe("ChatWindow", () => {
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
 
     rerender(
-      <ChatWindow chat={[makeMessage()]} agentProcessing emptyMessage="No messages" />,
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing
+        emptyMessage="No messages"
+      />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();

--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -67,18 +67,18 @@ describe("ChatWindow", () => {
   });
 
   it("shows empty message when chat is empty", () => {
-    render(<ChatWindow chat={[]} loading={false} emptyMessage="No messages" />);
+    render(<ChatWindow chat={[]} agentProcessing={false} emptyMessage="No messages" />);
     expect(screen.getByText("No messages")).toBeInTheDocument();
   });
 
   it("shows loading indicator", () => {
-    render(<ChatWindow chat={[]} loading emptyMessage="No messages" />);
+    render(<ChatWindow chat={[]} agentProcessing emptyMessage="No messages" />);
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
   });
 
   it("renders loading indicator in the virtualized footer for non-empty chat", () => {
     render(
-      <ChatWindow chat={[makeMessage()]} loading emptyMessage="No messages" />,
+      <ChatWindow chat={[makeMessage()]} agentProcessing emptyMessage="No messages" />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe("ChatWindow", () => {
     render(
       <ChatWindow
         chat={[makeMessage({ text: "**Hello**" })]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -103,7 +103,7 @@ describe("ChatWindow", () => {
       <ChatWindow
         chatWindowRef={chatWindowRef}
         chat={[makeMessage()]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -128,7 +128,7 @@ describe("ChatWindow", () => {
       <ChatWindow
         chatWindowRef={chatWindowRef}
         chat={[]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -151,7 +151,7 @@ describe("ChatWindow", () => {
     render(
       <ChatWindow
         chat={[makeMessage()]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -164,7 +164,7 @@ describe("ChatWindow", () => {
     render(
       <ChatWindow
         chat={[makeMessage({ text: "---\ntitle: Test\n---\nVisible" })]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -177,7 +177,7 @@ describe("ChatWindow", () => {
     render(
       <ChatWindow
         chat={[makeMessage({ text: "" })]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -192,7 +192,7 @@ describe("ChatWindow", () => {
     render(
       <ChatWindow
         chat={[makeMessage({ text: "---\ntitle: Test\n---\nVisible" })]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
       />,
     );
@@ -208,7 +208,7 @@ describe("ChatWindow", () => {
     render(
       <ChatWindow
         chat={[]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="No messages"
         sessionId="session-1"
         onClearSession={onClearSession}
@@ -235,7 +235,7 @@ describe("ChatWindow", () => {
       <ChatWindow
         chatWindowRef={chatWindowRef}
         chat={[makeMessage(), makeMessage(), makeMessage()]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="empty"
       />,
     );
@@ -257,7 +257,7 @@ describe("ChatWindow", () => {
       <ChatWindow
         chatWindowRef={chatWindowRef}
         chat={[makeMessage()]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="empty"
       />,
     );
@@ -272,7 +272,7 @@ describe("ChatWindow", () => {
       <ChatWindow
         chatWindowRef={chatWindowRef}
         chat={[makeMessage(), makeMessage()]}
-        loading={false}
+        agentProcessing={false}
         emptyMessage="empty"
       />,
     );
@@ -291,7 +291,7 @@ describe("ChatWindow", () => {
         chatWindowRef={chatWindowRef}
         chat={[makeMessage()]}
         sessionId="session-1"
-        loading={false}
+        agentProcessing={false}
         emptyMessage="empty"
       />,
     );
@@ -306,7 +306,7 @@ describe("ChatWindow", () => {
         chatWindowRef={chatWindowRef}
         chat={[makeMessage(), makeMessage()]}
         sessionId="session-2"
-        loading={false}
+        agentProcessing={false}
         emptyMessage="empty"
       />,
     );

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -19,7 +19,7 @@ const SpacedItem = React.forwardRef<
 interface ChatWindowProps {
   chat: ChatMessage[];
   chatWindowRef?: React.RefObject<ChatWindowHandle>;
-  loading: boolean;
+  agentProcessing: boolean;
   emptyMessage: string;
   sessionId?: string | null;
   onClearSession?: () => void;
@@ -126,7 +126,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
   function ChatWindow({
     chat,
     chatWindowRef,
-    loading,
+    agentProcessing,
     emptyMessage,
     sessionId,
     onClearSession,
@@ -208,7 +208,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
               Item: SpacedItem,
               Footer: () => (
                 <>
-                  {loading && (
+                  {agentProcessing && (
                     <div className="loading-indicator">
                       <div className="loading-spinner"></div>
                       <span>Agent is thinking...</span>
@@ -253,13 +253,13 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             style={{ height: "auto" }}
           />
         )}
-        {chat.length === 0 && loading && (
+        {chat.length === 0 && agentProcessing && (
           <div className="loading-indicator">
             <div className="loading-spinner"></div>
             <span>Agent is thinking...</span>
           </div>
         )}
-        {chat.length === 0 && !loading && (
+        {chat.length === 0 && !agentProcessing && (
           <div className="empty">{emptyMessage}</div>
         )}
         {chat.length === 0 && sessionId && (

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -723,7 +723,7 @@ export const ConstitutionPage: React.FC = () => {
             <ChatWindow
               chat={chat}
               chatWindowRef={chatWindowRef}
-              loading={chatLoading}
+              agentProcessing={chatLoading}
               emptyMessage="Start a conversation to discuss this constitution."
               sessionId={sessionId}
               onClearSession={() => setClearSessionModalOpen(true)}

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -109,7 +109,7 @@ export const ConstitutionPage: React.FC = () => {
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
-  const [chatLoading, setChatLoading] = useState(false);
+  const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
@@ -175,7 +175,7 @@ export const ConstitutionPage: React.FC = () => {
 
       setSessionId(incomingSessionId);
       setChat([]);
-      setChatLoading(true);
+      setChatAgentProcessing(true);
       try {
         const history = await api.getConstitutionAgentHistory(
           name,
@@ -195,7 +195,7 @@ export const ConstitutionPage: React.FC = () => {
         setAgentStatus(message);
       } finally {
         if (!cancelled) {
-          setChatLoading(false);
+          setChatAgentProcessing(false);
         }
       }
     };
@@ -299,7 +299,7 @@ export const ConstitutionPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     if (!sessionId) {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       return false;
     }
     try {
@@ -308,7 +308,7 @@ export const ConstitutionPage: React.FC = () => {
         sessionId || undefined,
       );
       if (sessionIdRef.current !== sessionId) return false;
-      setChatLoading(status.processing);
+      setChatAgentProcessing(status.processing);
       setAgentStatus(
         status.processing
           ? "Agent is still processing the previous message."
@@ -395,7 +395,7 @@ export const ConstitutionPage: React.FC = () => {
       if (options?.clearPrompt) {
         setPrompt("");
       }
-      setChatLoading(true);
+      setChatAgentProcessing(true);
       try {
         const promptWithPolicy = appendRestrictedAccessPolicy(
           userMessage.text,
@@ -421,8 +421,8 @@ export const ConstitutionPage: React.FC = () => {
         setActiveTab("agent");
         setAgentStatus(null);
 
-        // Keep chatLoading=true if processing (triggers existing polling)
-        if (!reply.processing) setChatLoading(false);
+        // Keep chatAgentProcessing=true if processing (triggers existing polling)
+        if (!reply.processing) setChatAgentProcessing(false);
       } catch (error) {
         console.error("Failed to contact agent", error);
         const errorMessage = error instanceof Error ? error.message : "";
@@ -434,7 +434,7 @@ export const ConstitutionPage: React.FC = () => {
         );
         const processing = await refreshAgentStatus();
         if (!processing) {
-          setChatLoading(false);
+          setChatAgentProcessing(false);
         }
       }
     },
@@ -446,7 +446,7 @@ export const ConstitutionPage: React.FC = () => {
       setActiveTab,
       setAgentStatus,
       setChat,
-      setChatLoading,
+      setChatAgentProcessing,
       setPrompt,
       setSessionId,
     ],
@@ -476,7 +476,7 @@ export const ConstitutionPage: React.FC = () => {
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setAgentStatus(null);
     setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
@@ -485,7 +485,7 @@ export const ConstitutionPage: React.FC = () => {
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setAgentStatus(null);
     setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
@@ -498,7 +498,7 @@ export const ConstitutionPage: React.FC = () => {
     setSessionModalOpen(false);
     setChat([]);
     setSessionId(session.id);
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     try {
       const history = await api.getConstitutionAgentHistory(name, session.id);
       const mapped = mapHistoryToMessages(history.messages || []);
@@ -512,7 +512,7 @@ export const ConstitutionPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
     }
   };
 
@@ -521,7 +521,7 @@ export const ConstitutionPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
     try {
@@ -542,11 +542,18 @@ export const ConstitutionPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, isExternal, setChat, setChatLoading, setAgentStatus]);
+  }, [
+    name,
+    sessionId,
+    isExternal,
+    setChat,
+    setChatAgentProcessing,
+    setAgentStatus,
+  ]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;
@@ -687,7 +694,7 @@ export const ConstitutionPage: React.FC = () => {
                     onClick={reloadCurrentSession}
                     aria-label="Refresh current session"
                     title="Refresh current session"
-                    disabled={chatLoading || isRefreshing}
+                    disabled={chatAgentProcessing || isRefreshing}
                   >
                     <RefreshIcon />
                   </button>
@@ -723,7 +730,7 @@ export const ConstitutionPage: React.FC = () => {
             <ChatWindow
               chat={chat}
               chatWindowRef={chatWindowRef}
-              agentProcessing={chatLoading}
+              agentProcessing={chatAgentProcessing}
               emptyMessage="Start a conversation to discuss this constitution."
               sessionId={sessionId}
               onClearSession={() => setClearSessionModalOpen(true)}
@@ -747,11 +754,11 @@ export const ConstitutionPage: React.FC = () => {
                   selectId="agent-select"
                   selectedAgent={normalizedSelectedAgent}
                   onChange={setSelectedAgent}
-                  disabled={chatLoading}
+                  disabled={chatAgentProcessing}
                 />
               </div>
               <div className="chat-controls__right">
-                {chatLoading ? (
+                {chatAgentProcessing ? (
                   <button className="danger" onClick={handleCancel}>
                     Cancel
                   </button>

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -735,7 +735,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
           <ChatWindow
             chat={chat}
             chatWindowRef={chatWindowRef}
-            loading={chatLoading}
+            agentProcessing={chatLoading}
             emptyMessage="Start a conversation to collaborate with agents."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -107,7 +107,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
-  const [chatLoading, setChatLoading] = useState(false);
+  const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
@@ -173,7 +173,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
 
       setSessionId(incomingSessionId);
       setChat([]);
-      setChatLoading(true);
+      setChatAgentProcessing(true);
       try {
         const history = await api.getKnowledgeAgentHistory(
           name,
@@ -193,7 +193,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
         setAgentStatus(message);
       } finally {
         if (!cancelled) {
-          setChatLoading(false);
+          setChatAgentProcessing(false);
         }
       }
     };
@@ -297,7 +297,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     if (!sessionId) {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       return false;
     }
     try {
@@ -306,7 +306,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
         sessionId || undefined,
       );
       if (sessionIdRef.current !== sessionId) return false;
-      setChatLoading(status.processing);
+      setChatAgentProcessing(status.processing);
       setAgentStatus(
         status.processing
           ? "Agent is still processing the previous message."
@@ -393,7 +393,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       if (options?.clearPrompt) {
         setPrompt("");
       }
-      setChatLoading(true);
+      setChatAgentProcessing(true);
       try {
         const promptWithPolicy = appendRestrictedAccessPolicy(
           userMessage.text,
@@ -419,8 +419,8 @@ export const KnowledgeArtefactPage: React.FC = () => {
         setActiveTab("agent");
         setAgentStatus(null);
 
-        // Keep chatLoading=true if processing (triggers existing polling)
-        if (!reply.processing) setChatLoading(false);
+        // Keep chatAgentProcessing=true if processing (triggers existing polling)
+        if (!reply.processing) setChatAgentProcessing(false);
       } catch (error) {
         console.error("Failed to contact agent", error);
         const errorMessage = error instanceof Error ? error.message : "";
@@ -432,7 +432,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
         );
         const processing = await refreshAgentStatus();
         if (!processing) {
-          setChatLoading(false);
+          setChatAgentProcessing(false);
         }
       }
     },
@@ -444,7 +444,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       setActiveTab,
       setAgentStatus,
       setChat,
-      setChatLoading,
+      setChatAgentProcessing,
       setPrompt,
       setSessionId,
     ],
@@ -474,7 +474,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setAgentStatus(null);
     setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
@@ -483,7 +483,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setAgentStatus(null);
     setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
@@ -496,7 +496,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     setSessionModalOpen(false);
     setChat([]);
     setSessionId(session.id);
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     try {
       const history = await api.getKnowledgeAgentHistory(name, session.id);
       const mapped = mapHistoryToMessages(history.messages || []);
@@ -510,7 +510,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
     }
   };
 
@@ -519,7 +519,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
     try {
@@ -537,11 +537,18 @@ export const KnowledgeArtefactPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, isExternal, setChat, setChatLoading, setAgentStatus]);
+  }, [
+    name,
+    sessionId,
+    isExternal,
+    setChat,
+    setChatAgentProcessing,
+    setAgentStatus,
+  ]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;
@@ -699,7 +706,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
                   onClick={reloadCurrentSession}
                   aria-label="Refresh current session"
                   title="Refresh current session"
-                  disabled={chatLoading || isRefreshing}
+                  disabled={chatAgentProcessing || isRefreshing}
                 >
                   <RefreshIcon />
                 </button>
@@ -735,7 +742,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
           <ChatWindow
             chat={chat}
             chatWindowRef={chatWindowRef}
-            agentProcessing={chatLoading}
+            agentProcessing={chatAgentProcessing}
             emptyMessage="Start a conversation to collaborate with agents."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}
@@ -759,11 +766,11 @@ export const KnowledgeArtefactPage: React.FC = () => {
                 selectId="agent-select"
                 selectedAgent={normalizedSelectedAgent}
                 onChange={setSelectedAgent}
-                disabled={chatLoading}
+                disabled={chatAgentProcessing}
               />
             </div>
             <div className="chat-controls__right">
-              {chatLoading ? (
+              {chatAgentProcessing ? (
                 <button className="danger" onClick={handleCancel}>
                   Cancel
                 </button>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1995,7 +1995,7 @@ export const RepositoryPage: React.FC = () => {
           <ChatWindow
             chat={chat}
             chatWindowRef={chatWindowRef}
-            loading={chatLoading || isRefreshing}
+            agentProcessing={chatLoading || isRefreshing /* Intentionally includes isRefreshing — both trigger the spinner */}
             emptyMessage="No conversation yet."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -439,7 +439,7 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedModel = selectedModel ?? "default";
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
-  const [chatLoading, setChatLoading] = useState(false);
+  const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(
@@ -1153,7 +1153,7 @@ export const RepositoryPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     if (!sessionId) {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       return false;
     }
     try {
@@ -1162,7 +1162,7 @@ export const RepositoryPage: React.FC = () => {
         sessionId || undefined,
       );
       if (sessionIdRef.current !== sessionId) return false;
-      setChatLoading(status.processing);
+      setChatAgentProcessing(status.processing);
       setChatError(
         status.processing
           ? "Agent is still processing the previous message."
@@ -1222,14 +1222,14 @@ export const RepositoryPage: React.FC = () => {
   );
 
   useEffect(() => {
-    if (chatLoading || !name || !sessionId) return;
+    if (chatAgentProcessing || !name || !sessionId) return;
     const controller = new AbortController();
     syncChatHistory(controller.signal);
     return () => controller.abort();
-  }, [chatLoading, name, sessionId, syncChatHistory]);
+  }, [chatAgentProcessing, name, sessionId, syncChatHistory]);
 
   useEffect(() => {
-    if (!chatLoading || !name || !sessionId) return;
+    if (!chatAgentProcessing || !name || !sessionId) return;
 
     const controller = new AbortController();
     let timeoutId: number | undefined;
@@ -1249,7 +1249,7 @@ export const RepositoryPage: React.FC = () => {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [chatLoading, name, sessionId, syncChatHistory]);
+  }, [chatAgentProcessing, name, sessionId, syncChatHistory]);
 
   const reloadCurrentSession = useCallback(async () => {
     if (!name || !sessionId || isRefreshingRef.current) return;
@@ -1301,7 +1301,7 @@ export const RepositoryPage: React.FC = () => {
     lastSentPromptRef.current = pendingPrompt;
     setChat((prev) => [...prev, userMessage]);
     setPendingPrompt("");
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     try {
       const model =
         normalizedSelectedModel === "default"
@@ -1328,8 +1328,8 @@ export const RepositoryPage: React.FC = () => {
       setChatError(null);
       setActiveTab("agent");
 
-      // Keep chatLoading=true if processing (triggers existing polling)
-      if (!reply.processing) setChatLoading(false);
+      // Keep chatAgentProcessing=true if processing (triggers existing polling)
+      if (!reply.processing) setChatAgentProcessing(false);
     } catch (error) {
       if (sendRequestIdRef.current !== sendRequestId) return;
       const messageText = error instanceof Error ? error.message : "";
@@ -1342,7 +1342,7 @@ export const RepositoryPage: React.FC = () => {
       console.error("Failed to send agent message", error);
       const processing = await refreshAgentStatus();
       if (!processing) {
-        setChatLoading(false);
+        setChatAgentProcessing(false);
       }
     }
   };
@@ -1366,7 +1366,7 @@ export const RepositoryPage: React.FC = () => {
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setChatError(null);
     setPendingPrompt(lastSentPromptRef.current);
     lastSentPromptRef.current = "";
@@ -1377,7 +1377,7 @@ export const RepositoryPage: React.FC = () => {
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setChatError(null);
     setPendingPrompt(lastSentPromptRef.current);
     lastSentPromptRef.current = "";
@@ -1395,7 +1395,7 @@ export const RepositoryPage: React.FC = () => {
     }
     sendRequestIdRef.current += 1;
     setSessionModalOpen(false);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setChatError(null);
     setChat([]);
     setSessionId(session.id);
@@ -1959,7 +1959,7 @@ export const RepositoryPage: React.FC = () => {
                   onClick={reloadCurrentSession}
                   aria-label="Refresh current session"
                   title="Refresh current session"
-                  disabled={chatLoading || isRefreshing}
+                  disabled={chatAgentProcessing || isRefreshing}
                 >
                   <RefreshIcon />
                 </button>
@@ -1995,7 +1995,10 @@ export const RepositoryPage: React.FC = () => {
           <ChatWindow
             chat={chat}
             chatWindowRef={chatWindowRef}
-            agentProcessing={chatLoading || isRefreshing /* Intentionally includes isRefreshing — both trigger the spinner */}
+            agentProcessing={
+              chatAgentProcessing ||
+              isRefreshing /* Intentionally includes isRefreshing — both trigger the spinner */
+            }
             emptyMessage="No conversation yet."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}
@@ -2021,7 +2024,7 @@ export const RepositoryPage: React.FC = () => {
                 selectId="agent-select"
                 selectedAgent={normalizedSelectedAgent}
                 onChange={setSelectedAgent}
-                disabled={chatLoading}
+                disabled={chatAgentProcessing}
                 repositoryName={name || undefined}
               />
               <label className="model-select" htmlFor="agent-model-select">
@@ -2029,7 +2032,7 @@ export const RepositoryPage: React.FC = () => {
                   id="agent-model-select"
                   value={normalizedSelectedModel}
                   onChange={(event) => setSelectedModel(event.target.value)}
-                  disabled={chatLoading}
+                  disabled={chatAgentProcessing}
                   aria-label="Model"
                 >
                   {MODEL_OPTIONS.map((option) => (
@@ -2045,7 +2048,7 @@ export const RepositoryPage: React.FC = () => {
               </label>
             </div>
             <div className="chat-controls__right">
-              {chatLoading ? (
+              {chatAgentProcessing ? (
                 <button className="danger" onClick={handleCancelAgent}>
                   Cancel
                 </button>

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -676,7 +676,7 @@ export const TaskPage: React.FC = () => {
                 <ChatWindow
                   chat={chat}
                   chatWindowRef={chatWindowRef}
-                  loading={chatLoading}
+                  agentProcessing={chatLoading}
                   emptyMessage="Start a conversation to discuss this task."
                   sessionId={sessionId}
                   onClearSession={() => setClearSessionModalOpen(true)}

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -97,7 +97,7 @@ export const TaskPage: React.FC = () => {
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
-  const [chatLoading, setChatLoading] = useState(false);
+  const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
@@ -157,7 +157,7 @@ export const TaskPage: React.FC = () => {
 
       setSessionId(incomingSessionId);
       setChat([]);
-      setChatLoading(true);
+      setChatAgentProcessing(true);
       try {
         const history = await api.getTaskAgentHistory(name, incomingSessionId);
         if (cancelled) return;
@@ -174,7 +174,7 @@ export const TaskPage: React.FC = () => {
         setAgentStatus(message);
       } finally {
         if (!cancelled) {
-          setChatLoading(false);
+          setChatAgentProcessing(false);
         }
       }
     };
@@ -259,13 +259,13 @@ export const TaskPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     if (!sessionId) {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       return false;
     }
     try {
       const status = await api.getTaskAgentStatus(name, sessionId || undefined);
       if (sessionIdRef.current !== sessionId) return false;
-      setChatLoading(status.processing);
+      setChatAgentProcessing(status.processing);
       setAgentStatus(
         status.processing
           ? "Agent is still processing the previous message."
@@ -328,7 +328,7 @@ export const TaskPage: React.FC = () => {
       if (options?.clearPrompt) {
         setPrompt("");
       }
-      setChatLoading(true);
+      setChatAgentProcessing(true);
       try {
         const promptWithPolicy = appendRestrictedAccessPolicy(
           userMessage.text,
@@ -354,8 +354,8 @@ export const TaskPage: React.FC = () => {
         setActiveTab("agent");
         setAgentStatus(null);
 
-        // Keep chatLoading=true if processing (triggers existing polling)
-        if (!reply.processing) setChatLoading(false);
+        // Keep chatAgentProcessing=true if processing (triggers existing polling)
+        if (!reply.processing) setChatAgentProcessing(false);
       } catch (error) {
         console.error("Failed to contact agent", error);
         const errorMessage = error instanceof Error ? error.message : "";
@@ -367,7 +367,7 @@ export const TaskPage: React.FC = () => {
         );
         const processing = await refreshAgentStatus();
         if (!processing) {
-          setChatLoading(false);
+          setChatAgentProcessing(false);
         }
       }
     },
@@ -379,7 +379,7 @@ export const TaskPage: React.FC = () => {
       setActiveTab,
       setAgentStatus,
       setChat,
-      setChatLoading,
+      setChatAgentProcessing,
       setPrompt,
       setSessionId,
     ],
@@ -409,7 +409,7 @@ export const TaskPage: React.FC = () => {
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setAgentStatus(null);
     setSelectedAgent(DEFAULT_AGENT_VALUE);
     setClearSessionModalOpen(false);
@@ -418,7 +418,7 @@ export const TaskPage: React.FC = () => {
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    setChatLoading(false);
+    setChatAgentProcessing(false);
     setAgentStatus(null);
     setSelectedAgent(DEFAULT_AGENT_VALUE);
     setChat([]);
@@ -431,7 +431,7 @@ export const TaskPage: React.FC = () => {
     setSessionModalOpen(false);
     setChat([]);
     setSessionId(session.id);
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     try {
       const history = await api.getTaskAgentHistory(name, session.id);
       const mapped = mapHistoryToMessages(history.messages || []);
@@ -445,7 +445,7 @@ export const TaskPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
     }
   };
 
@@ -454,7 +454,7 @@ export const TaskPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
-    setChatLoading(true);
+    setChatAgentProcessing(true);
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
     try {
@@ -472,11 +472,11 @@ export const TaskPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatLoading(false);
+      setChatAgentProcessing(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, setChat, setChatLoading, setAgentStatus]);
+  }, [name, sessionId, setChat, setChatAgentProcessing, setAgentStatus]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;
@@ -633,7 +633,7 @@ export const TaskPage: React.FC = () => {
                         onClick={reloadCurrentSession}
                         aria-label="Refresh current session"
                         title="Refresh current session"
-                        disabled={chatLoading || isRefreshing}
+                        disabled={chatAgentProcessing || isRefreshing}
                       >
                         <RefreshIcon />
                       </button>
@@ -676,7 +676,7 @@ export const TaskPage: React.FC = () => {
                 <ChatWindow
                   chat={chat}
                   chatWindowRef={chatWindowRef}
-                  agentProcessing={chatLoading}
+                  agentProcessing={chatAgentProcessing}
                   emptyMessage="Start a conversation to discuss this task."
                   sessionId={sessionId}
                   onClearSession={() => setClearSessionModalOpen(true)}
@@ -700,11 +700,11 @@ export const TaskPage: React.FC = () => {
                       selectId="agent-select"
                       selectedAgent={normalizedSelectedAgent}
                       onChange={setSelectedAgent}
-                      disabled={chatLoading}
+                      disabled={chatAgentProcessing}
                     />
                   </div>
                   <div className="chat-controls__right">
-                    {chatLoading ? (
+                    {chatAgentProcessing ? (
                       <button className="danger" onClick={handleCancel}>
                         Cancel
                       </button>

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1493,7 +1493,7 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("ADV-5: ChatWindow receives loading={chatLoading || isRefreshing} during refresh", async () => {
+  it("ADV-5: ChatWindow receives agentProcessing={chatLoading || isRefreshing} during refresh", async () => {
     let resolveFetch!: (value: ChatHistoryResponse) => void;
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(
       new Promise<ChatHistoryResponse>((resolve) => {
@@ -1518,7 +1518,7 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
     // (ChatWindow renders its content inside the Virtuoso mock)
     expect(
       screen.getByText(/Agent is thinking|Loading/),
-      "FAIL (ADV-5): loading indicator not visible — isRefreshing not wired to ChatWindow loading prop",
+      "FAIL (ADV-5): loading indicator not visible — isRefreshing not wired to ChatWindow agentProcessing prop",
     ).toBeInTheDocument();
 
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -415,7 +415,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
 
   // ── AC496-1 ────────────────────────────────────────────────────────────
 
-  it("AC496-1: clearSessionOnly resets chatLoading when loading (fails: setChatLoading(false) missing)", async () => {
+  it("AC496-1: clearSessionOnly resets chatAgentProcessing when loading (fails: setChatAgentProcessing(false) missing)", async () => {
     vi.mocked(api.sendAgentMessage).mockReturnValue(
       new Promise<AgentReply>(() => {}),
     );
@@ -427,7 +427,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: /cancel/i }),
-        "Cancel button should appear (chatLoading=true)",
+        "Cancel button should appear (chatAgentProcessing=true)",
       ).toBeInTheDocument();
     });
 
@@ -439,7 +439,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
     await waitFor(() => {
       expect(
         screen.queryByRole("button", { name: /cancel/i }),
-        "FAIL: Cancel remains — handleClearSessionOnly missing setChatLoading(false)",
+        "FAIL: Cancel remains — handleClearSessionOnly missing setChatAgentProcessing(false)",
       ).not.toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /send/i }),
@@ -450,7 +450,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
 
   // ── AC496-2 ────────────────────────────────────────────────────────────
 
-  it("AC496-2: clearSessionAndHistory resets chatLoading when loading (fails: setChatLoading(false) missing)", async () => {
+  it("AC496-2: clearSessionAndHistory resets chatAgentProcessing when loading (fails: setChatAgentProcessing(false) missing)", async () => {
     vi.mocked(api.sendAgentMessage).mockReturnValue(
       new Promise<AgentReply>(() => {}),
     );
@@ -462,7 +462,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: /cancel/i }),
-        "Cancel button should appear (chatLoading=true)",
+        "Cancel button should appear (chatAgentProcessing=true)",
       ).toBeInTheDocument();
     });
 
@@ -474,7 +474,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
     await waitFor(() => {
       expect(
         screen.queryByRole("button", { name: /cancel/i }),
-        "FAIL: Cancel remains — handleClearSessionAndHistory missing setChatLoading(false)",
+        "FAIL: Cancel remains — handleClearSessionAndHistory missing setChatAgentProcessing(false)",
       ).not.toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /send/i }),
@@ -489,7 +489,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
 
   // ── AC496-3 idempotent ────────────────────────────────────────────────
 
-  it("AC496-3: clearSessionOnly idempotent when chatLoading already false", async () => {
+  it("AC496-3: clearSessionOnly idempotent when chatAgentProcessing already false", async () => {
     await renderAndWaitForClearButton();
 
     vi.mocked(api.getRepositoryAgentHistory).mockClear();
@@ -504,7 +504,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
     });
   });
 
-  it("AC496-3: clearSessionAndHistory idempotent when chatLoading already false", async () => {
+  it("AC496-3: clearSessionAndHistory idempotent when chatAgentProcessing already false", async () => {
     await renderAndWaitForClearButton();
 
     vi.mocked(api.getRepositoryAgentHistory).mockClear();
@@ -594,7 +594,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
     await waitFor(() => {
       expect(
         screen.queryByText("Agent is thinking..."),
-        "FAIL: 'Agent is thinking...' remains — handleClearSessionOnly missing setChatLoading(false)",
+        "FAIL: 'Agent is thinking...' remains — handleClearSessionOnly missing setChatAgentProcessing(false)",
       ).not.toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /send/i }),
@@ -777,7 +777,7 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
 
   // ── U1: AC1+AC3 ──────────────────────────────────────────────────────
 
-  it("U1 (AC1+AC3): refreshAgentStatus skips API call and does not re-stick chatLoading after clear", async () => {
+  it("U1 (AC1+AC3): refreshAgentStatus skips API call and does not re-stick chatAgentProcessing after clear", async () => {
     await renderAndWaitForClearButton();
 
     const textarea = screen.getByPlaceholderText(
@@ -812,7 +812,7 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
 
     expect(
       screen.queryByRole("button", { name: /cancel/i }),
-      "FAIL (AC1): Cancel button remains after clear — refreshAgentStatus re-stuck chatLoading via effect re-fire",
+      "FAIL (AC1): Cancel button remains after clear — refreshAgentStatus re-stuck chatAgentProcessing via effect re-fire",
     ).not.toBeInTheDocument();
 
     expect(
@@ -856,7 +856,7 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
     await waitFor(() => {
       expect(
         screen.queryByRole("button", { name: /cancel/i }),
-        "FAIL (AC2): Cancel remains after clear — !sessionId guard missing or setChatLoading(false) missing in handler",
+        "FAIL (AC2): Cancel remains after clear — !sessionId guard missing or setChatAgentProcessing(false) missing in handler",
       ).not.toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /send/i }),
@@ -891,14 +891,14 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: /cancel/i }),
-        "FAIL (U4 regression): Cancel should appear — refreshAgentStatus should setChatLoading(true) when session is active",
+        "FAIL (U4 regression): Cancel should appear — refreshAgentStatus should setChatAgentProcessing(true) when session is active",
       ).toBeInTheDocument();
     });
   });
 
   // ── D1: AC6 stale-closure guard ──────────────────────────────────────
 
-  it("D1 (AC6): stale in-flight refreshAgentStatus promise does not re-stick chatLoading after clear", async () => {
+  it("D1 (AC6): stale in-flight refreshAgentStatus promise does not re-stick chatAgentProcessing after clear", async () => {
     let resolveStatus!: (value: {
       processing: boolean;
       startedAt: string | null;
@@ -928,7 +928,7 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
     await screen.findByRole("button", { name: /^no$/i });
     confirmClearOnly();
 
-    // Session cleared — Cancel should not be visible (setChatLoading(false) called)
+    // Session cleared — Cancel should not be visible (setChatAgentProcessing(false) called)
     await waitFor(() => {
       expect(
         screen.queryByRole("button", { name: /cancel/i }),
@@ -937,10 +937,10 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
     });
 
     // Now resolve the stale in-flight promise with processing: true.
-    // Without the stale-closure guard, setChatLoading(true) would fire
+    // Without the stale-closure guard, setChatAgentProcessing(true) would fire
     // and Cancel would re-appear. With the guard, sessionIdRef.current
     // (null after clear) !== sessionId at closure time (session-a) → guard
-    // returns false and chatLoading stays false.
+    // returns false and chatAgentProcessing stays false.
     resolveStatus!({
       processing: true,
       startedAt: new Date().toISOString(),
@@ -1399,7 +1399,7 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("ADV-3: Refresh disabled while chatLoading=true (agent processing)", async () => {
+  it("ADV-3: Refresh disabled while chatAgentProcessing=true (agent processing)", async () => {
     const msgA: ChatHistoryMessage = {
       role: "assistant",
       type: "text",
@@ -1418,7 +1418,7 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
     fireEvent.click(await screen.findByTitle("Session A"));
     await screen.findByText("Hello from A");
 
-    // Simulate chatLoading=true (agent processing)
+    // Simulate chatAgentProcessing=true (agent processing)
     vi.mocked(api.sendAgentMessage).mockResolvedValue({
       messageId: "m1",
       sent: new Date().toISOString(),
@@ -1442,7 +1442,7 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
     const refreshBtn = await screen.findByLabelText("Refresh current session");
     expect(
       refreshBtn,
-      "FAIL (ADV-3): Refresh button not disabled while chatLoading=true",
+      "FAIL (ADV-3): Refresh button not disabled while chatAgentProcessing=true",
     ).toBeDisabled();
   });
 
@@ -1493,7 +1493,7 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("ADV-5: ChatWindow receives agentProcessing={chatLoading || isRefreshing} during refresh", async () => {
+  it("ADV-5: ChatWindow receives agentProcessing={chatAgentProcessing || isRefreshing} during refresh", async () => {
     let resolveFetch!: (value: ChatHistoryResponse) => void;
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(
       new Promise<ChatHistoryResponse>((resolve) => {
@@ -1799,7 +1799,7 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
 
   // ── U6: AC495-3 reply.processing=true ───────────────────────────────
 
-  it("U6 (AC495-3): reply.processing=true keeps chatLoading true", async () => {
+  it("U6 (AC495-3): reply.processing=true keeps chatAgentProcessing true", async () => {
     vi.mocked(api.sendAgentMessage).mockResolvedValue({
       messageId: "m1",
       sent: new Date().toISOString(),
@@ -1812,7 +1812,7 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
     await screen.findByLabelText("Clear session");
 
     // After initial mount, mock status to processing:true so refreshAgentStatus
-    // effect doesn't wrongly clear chatLoading after the send resolves
+    // effect doesn't wrongly clear chatAgentProcessing after the send resolves
     vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
       processing: true,
       startedAt: new Date().toISOString(),
@@ -1829,7 +1829,7 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
     const sendBtn = screen.queryByRole("button", { name: /send/i });
     expect(
       sendBtn,
-      "F-AC495-3c: Send button re-enabled when reply.processing=true — setChatLoading(false) was incorrectly called",
+      "F-AC495-3c: Send button re-enabled when reply.processing=true — setChatAgentProcessing(false) was incorrectly called",
     ).toBeNull();
   });
 
@@ -2025,7 +2025,7 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
       ).toBeInTheDocument();
     });
 
-    // Switch session to reset chatLoading so send button is available again
+    // Switch session to reset chatAgentProcessing so send button is available again
     vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
       sessions: [sessionA, sessionB],
     });
@@ -2038,7 +2038,7 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Second send (after session switch resets chatLoading)
+    // Second send (after session switch resets chatAgentProcessing)
     fireEvent.change(textarea, { target: { value: "second" } });
     fireEvent.click(screen.getByRole("button", { name: /send/i }));
 


### PR DESCRIPTION
Closes #483

## Summary

Mechanical rename of `loading` prop to `agentProcessing` on `<ChatWindow>` for semantic clarity — the prop indicates whether the agent is actively computing, not a generic loading state.

## Scope

- **5 production files**: `ChatWindow.tsx` (interface, destructure, 3 body refs), 4 consuming pages (RepositoryPage, ConstitutionPage, KnowledgeArtefactPage, TaskPage)
- **2 test files**: `ChatWindow.test.tsx` (14 prop renames + 3 new transition tests), `RepositoryPage.test.tsx` (description + assertion updates)
- **1 lockfile update**: shell-quote CVE fix via `npm audit fix`

## Implementation

- **TDD commit** (`cca7b75`): Tests + production rename
- **Adversarial tests** (`5702e66`): 3 new runtime transition tests
- **Fixer commit** (`10987d15`): 
  - M1: `chatLoading` → `chatAgentProcessing` in all 4 pages
  - M2: eslint verified clean
  - CI1: shell-quote CVE patched

## Validation

| Check | Result |
|-------|--------|
| TypeScript (`tsc --noEmit`) | PASS |
| Lint (`npm run lint`) | PASS |
| Tests (vitest) | PASS (159 tests, 22 files) |
| Build (vite) | PASS |

## Reviews

- Implementation review: no blocking issues found
- Maintainer review: approved, no blocking findings
- Adversarial review: no failures, 3 transition tests added
- Fixer: resolved M1, M2, CI1; H1 deferred

## Follow-up Issues

- [#507](https://github.com/tbrandenburg/made/issues/507) — Decouple `isRefreshing` from `agentProcessing` on RepositoryPage (H1)

## Residual Risks

- **H1 (deferred)**: RepositoryPage spinner shows "Agent is thinking..." during refreshes — tracked as #507
- **L1 (excluded)**: CSS class names `loading-indicator`/`loading-spinner` unchanged per spec

## CI

All CI checks pass. Branch is up to date with `main`.
