### PR TITLE
fix(#492): Add signal.aborted guard after await in syncChatHistory to prevent stale-closure race

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1196,6 +1196,8 @@ export const RepositoryPage: React.FC = () => {
           signal,
         );
 
+        if (signal?.aborted) return;
+
         if (!history.messages?.length) {
           console.info("[ChatHistory] Request completed with no new messages");
           return;

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1227,7 +1227,7 @@ export const RepositoryPage: React.FC = () => {
     if (chatAgentProcessing || !name || !sessionId) return;
     const controller = new AbortController();
     syncChatHistory(controller.signal);
-    return () => controller.abort();
+    return () => controller.abort(); // No argument — preserves DOMException('AbortError') shape
   }, [chatAgentProcessing, name, sessionId, syncChatHistory]);
 
   useEffect(() => {
@@ -1246,7 +1246,7 @@ export const RepositoryPage: React.FC = () => {
     tick();
 
     return () => {
-      controller.abort();
+      controller.abort(); // No argument — preserves DOMException('AbortError') shape
       if (timeoutId !== undefined) {
         window.clearTimeout(timeoutId);
       }

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -2277,6 +2277,208 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
     });
   });
 
+  // ── T1–T4: signal.aborted guard (Issue #492) ───────────────────────
+
+  it("T2: syncChatHistory with aborted signal does not render messages (fails: guard missing)", async () => {
+    const origAbortController = globalThis.AbortController;
+    try {
+      vi.stubGlobal(
+        "AbortController",
+        class {
+          signal = { aborted: true } as AbortSignal;
+          abort() {
+            /* no-op */
+          }
+        },
+      );
+
+      const msg: ChatHistoryMessage = {
+        role: "assistant",
+        type: "text",
+        content: "Should not appear",
+        timestamp: "2026-01-01T00:00:00Z",
+      };
+      vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue({
+        sessionId: "session-a",
+        messages: [msg],
+      });
+
+      renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+      await new Promise<void>((r) => setTimeout(r, 500));
+
+      expect(
+        screen.queryByText("Should not appear"),
+        "FAIL (T2): Messages rendered despite aborted signal — guard missing after await",
+      ).not.toBeInTheDocument();
+    } finally {
+      vi.stubGlobal("AbortController", origAbortController);
+    }
+  });
+
+  it("T3: AbortError rejection does not call setChatError (fails: error shown)", async () => {
+    const abortError = new DOMException(
+      "The operation was aborted",
+      "AbortError",
+    );
+    vi.mocked(api.getRepositoryAgentHistory).mockRejectedValue(abortError);
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    await new Promise<void>((r) => setTimeout(r, 500));
+
+    expect(
+      screen.queryByText("Failed to load chat history"),
+      "FAIL (T3): Error appeared despite AbortError — setChatError was called",
+    ).not.toBeInTheDocument();
+  });
+
+  it("T4: syncChatHistory without signal argument processes normally (fails: no messages)", async () => {
+    const msg: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Normal message",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue({
+      sessionId: "session-a",
+      messages: [msg],
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    expect(
+      await screen.findByText("Normal message"),
+      "FAIL (T4): syncChatHistory without valid signal failed to render messages",
+    ).toBeInTheDocument();
+  });
+
+  it("T1: deferred effect call + session switch aborts — stale data not rendered (fails: stale data visible)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const historyA: ChatHistoryResponse = {
+      sessionId: "session-a",
+      messages: [msgA],
+    };
+    const historyB: ChatHistoryResponse = {
+      sessionId: "session-b",
+      messages: [msgB],
+    };
+
+    let resolveDeferred!: (value: ChatHistoryResponse) => void;
+    const deferred = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveDeferred = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockReturnValueOnce(deferred)
+      .mockResolvedValueOnce(historyB);
+
+    renderPage();
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentHistory,
+        "session A fetch should have been dispatched",
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session B"));
+
+    await screen.findByText("Hello from B");
+
+    resolveDeferred!(historyA);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    expect(
+      screen.queryByText("Hello from A"),
+      "FAIL (T1): Stale session A data appeared after session switch — signal.aborted guard missing",
+    ).not.toBeInTheDocument();
+  });
+
+  it("T1-loading: deferred polling call + session switch — stale data not rendered (fails: stale data visible)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A (loading)",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B (loading)",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const historyA: ChatHistoryResponse = {
+      sessionId: "session-a",
+      messages: [msgA],
+    };
+    const historyB: ChatHistoryResponse = {
+      sessionId: "session-b",
+      messages: [msgB],
+    };
+
+    let resolveDeferred!: (value: ChatHistoryResponse) => void;
+    const deferred = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveDeferred = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockReturnValueOnce(deferred);
+
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+    vi.mocked(api.cancelRepositoryAgent).mockResolvedValue(undefined);
+
+    const { router } = renderPageWithRouter([
+      "/repositories/test-repo?tab=agent&sessionId=session-a",
+    ]);
+
+    await screen.findByLabelText("Clear session");
+    await new Promise<void>((r) => setTimeout(r, 500));
+
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentHistory,
+        "session A polling fetch should have been dispatched",
+      ).toHaveBeenCalled();
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory).mockClear();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValueOnce(historyB);
+
+    await router.navigate(
+      "/repositories/test-repo?tab=agent&sessionId=session-b",
+    );
+
+    await screen.findByText("Hello from B (loading)");
+
+    resolveDeferred!(historyA);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    expect(
+      screen.queryByText("Hello from A (loading)"),
+      "FAIL (T1-loading): Stale polling data appeared after session switch — guard missing in loading path",
+    ).not.toBeInTheDocument();
+  });
+
   // ── ADV-1: stale reply then fresh send from new session ───────────────
 
   it("ADV-1: new send from new session works after stale reply is discarded", async () => {

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -2305,12 +2305,12 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
 
       renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
 
-      await new Promise<void>((r) => setTimeout(r, 500));
-
-      expect(
-        screen.queryByText("Should not appear"),
-        "FAIL (T2): Messages rendered despite aborted signal — guard missing after await",
-      ).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Should not appear"),
+          "FAIL (T2): Messages rendered despite aborted signal — guard missing after await",
+        ).not.toBeInTheDocument();
+      });
     } finally {
       vi.stubGlobal("AbortController", origAbortController);
     }
@@ -2325,15 +2325,15 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
 
     renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
 
-    await new Promise<void>((r) => setTimeout(r, 500));
-
-    expect(
-      screen.queryByText("Failed to load chat history"),
-      "FAIL (T3): Error appeared despite AbortError — setChatError was called",
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Failed to load chat history"),
+        "FAIL (T3): Error appeared despite AbortError — setChatError was called",
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it("T4: syncChatHistory without signal argument processes normally (fails: no messages)", async () => {
+  it("T4: syncChatHistory normal flow — messages rendered (fails: no messages)", async () => {
     const msg: ChatHistoryMessage = {
       role: "assistant",
       type: "text",

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -2575,4 +2575,61 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("ADV-492-nav-race: stale non-polling syncChatHistory deferred resolves AFTER router navigation to new session — guard catches stale data", async () => {
+    let resolveStale!: (value: ChatHistoryResponse) => void;
+    const deferredStale = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveStale = resolve;
+    });
+
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A (nav stale)",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B (nav fresh)",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const historyA: ChatHistoryResponse = {
+      sessionId: "session-a",
+      messages: [msgA],
+    };
+    const historyB: ChatHistoryResponse = {
+      sessionId: "session-b",
+      messages: [msgB],
+    };
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockReturnValueOnce(deferredStale)
+      .mockResolvedValueOnce(historyB);
+
+    const { router } = renderPageWithRouter([
+      "/repositories/test-repo?tab=agent&sessionId=session-a",
+    ]);
+
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentHistory,
+        "session A fetch should have been dispatched",
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    await router.navigate(
+      "/repositories/test-repo?tab=agent&sessionId=session-b",
+    );
+
+    await screen.findByText("Hello from B (nav fresh)");
+
+    resolveStale!(historyA);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    expect(
+      screen.queryByText("Hello from A (nav stale)"),
+      "FAIL (ADV-492): Stale session A data appeared after router navigation — signal.aborted guard missing",
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #492

## Scope

Add `signal.aborted` guard after `await` in `syncChatHistory` to prevent stale-content flash when switching agent sessions under race conditions.

## Implementation

- **Guard line**: `if (signal?.aborted) return;` inserted at `RepositoryPage.tsx:1198` — immediately after the `await api.getRepositoryAgentHistory(...)` and before the `if (!history.messages?.length)` check
- **Comments**: `// No argument — preserves DOMException('AbortError') shape` on both `controller.abort()` calls (lines 1230, 1249)
- **Test coverage**: 7 tests (T1, T1-loading, T2, T3, T4, ADV-492-nav-race, ADV-1)

## TDD Commit Ordering

1. `5c77529` — Test commit: 5 TDD tests + ADV-1 (202 lines)
2. `9100a55` — Implementation: guard line (1 line)
3. `8ca0941` — Adversarial test: ADV-492-nav-race
4. `bd3e254` — Fixer: comments + test determinism improvements

## Checks

- **Tests**: 23 files, 181 tests passed
- **Lint**: Clean
- **TypeScript**: Clean (pre-existing deprecated-option warnings only)
- **Build**: Successful

## Reviews

- Spec-approved, implementation-review, maintainer-review, adversarial-review, residual-gap-review all completed
- All review findings resolved by fixer commit `bd3e254`

## CI

All 7 GitHub check runs: ✅ success

## Follow-up Issues

None — all gaps resolved or deferrals documented.
