### PR TITLE
fix(#491): Restore session-select loading-state UX contract

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.15.13"
+        "@opencode-ai/plugin": "1.17.9"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,19 +87,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.13.tgz",
-      "integrity": "sha512-NFwZGhmxIPijtfz9swPJXDmhOpq4UWP8WjEE7GEMr7FwtJrK/hv6v36nFimed5+OKk+pQCrTJn/vhRW7Io72IA==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.9.tgz",
+      "integrity": "sha512-RvYsX2k90ew0P3c0R/Jrt6UOdA5CYf4GmYuREDKHx31GSJ25WKg9hrTzkcwCfvPPCpaBc53Qq6Fon9aWr+58ag==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.15.13",
-        "effect": "4.0.0-beta.66",
+        "@opencode-ai/sdk": "1.17.9",
+        "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.2.16",
-        "@opentui/keymap": ">=0.2.16",
-        "@opentui/solid": ">=0.2.16"
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.13.tgz",
-      "integrity": "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.9.tgz",
+      "integrity": "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -153,21 +153,21 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
-      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+      "version": "4.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
+      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
@@ -199,12 +199,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -220,12 +220,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
-      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -275,15 +275,19 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             <span>Loading session...</span>
           </div>
         )}
-        {chat.length === 0 && !refreshing && !sessionLoading && agentProcessing && (
-          <div className="loading-indicator">
-            <div className="loading-spinner"></div>
-            <span>Agent is thinking...</span>
-          </div>
-        )}
-        {chat.length === 0 && !refreshing && !sessionLoading && !agentProcessing && (
-          <div className="empty">{emptyMessage}</div>
-        )}
+        {chat.length === 0 &&
+          !refreshing &&
+          !sessionLoading &&
+          agentProcessing && (
+            <div className="loading-indicator">
+              <div className="loading-spinner"></div>
+              <span>Agent is thinking...</span>
+            </div>
+          )}
+        {chat.length === 0 &&
+          !refreshing &&
+          !sessionLoading &&
+          !agentProcessing && <div className="empty">{emptyMessage}</div>}
         {chat.length === 0 && sessionId && (
           <div className="chat-session-id" aria-label="Session ID">
             <span>Session ID: {sessionId}</span>

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -20,6 +20,7 @@ interface ChatWindowProps {
   chat: ChatMessage[];
   chatWindowRef?: React.RefObject<ChatWindowHandle>;
   agentProcessing: boolean;
+  sessionLoading?: boolean;
   refreshing?: boolean;
   emptyMessage: string;
   sessionId?: string | null;
@@ -128,6 +129,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
     chat,
     chatWindowRef,
     agentProcessing,
+    sessionLoading,
     refreshing,
     emptyMessage,
     sessionId,
@@ -267,13 +269,19 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             <span>Refreshing...</span>
           </div>
         )}
-        {chat.length === 0 && !refreshing && agentProcessing && (
+        {chat.length === 0 && !refreshing && sessionLoading && (
+          <div className="loading-indicator">
+            <div className="loading-spinner"></div>
+            <span>Loading session...</span>
+          </div>
+        )}
+        {chat.length === 0 && !refreshing && !sessionLoading && agentProcessing && (
           <div className="loading-indicator">
             <div className="loading-spinner"></div>
             <span>Agent is thinking...</span>
           </div>
         )}
-        {chat.length === 0 && !refreshing && !agentProcessing && (
+        {chat.length === 0 && !refreshing && !sessionLoading && !agentProcessing && (
           <div className="empty">{emptyMessage}</div>
         )}
         {chat.length === 0 && sessionId && (

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -605,6 +605,7 @@ export const RepositoryPage: React.FC = () => {
         return;
       }
       setChatError(null);
+      setChatAgentProcessing(false);
       setChat([]);
       setSessionLoading(true);
       setSessionId(incomingSessionId);
@@ -1185,9 +1186,9 @@ export const RepositoryPage: React.FC = () => {
     async (signal?: AbortSignal) => {
       if (!name || !sessionId) return;
       console.info("[ChatHistory] Request started");
+      const sessionIdAtFetchStart = sessionId;
       try {
         setChatError(null);
-        const sessionIdAtFetchStart = sessionId;
         const currentTimestamp = lastKnownTimestampRef.current;
         const startTimestamp = currentTimestamp
           ? currentTimestamp + 1
@@ -1199,10 +1200,13 @@ export const RepositoryPage: React.FC = () => {
           signal,
         );
 
-        if (signal?.aborted) { setSessionLoading(false); return; }
+        if (signal?.aborted) {
+          if (sessionIdRef.current !== sessionIdAtFetchStart) return;
+          setSessionLoading(false);
+          return;
+        }
 
         if (sessionIdRef.current !== sessionIdAtFetchStart) {
-          setSessionLoading(false);
           return;
         }
 
@@ -1220,6 +1224,7 @@ export const RepositoryPage: React.FC = () => {
         setSessionLoading(false);
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
+          if (sessionIdRef.current !== sessionIdAtFetchStart) return;
           setSessionLoading(false);
           return;
         }

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -440,6 +440,7 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
   const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
+  const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(
@@ -604,8 +605,9 @@ export const RepositoryPage: React.FC = () => {
         return;
       }
       setChatError(null);
-      setSessionId(incomingSessionId);
       setChat([]);
+      setSessionLoading(true);
+      setSessionId(incomingSessionId);
       sendRequestIdRef.current += 1;
       try {
         localStorage.setItem(sessionStorageKey, incomingSessionId);
@@ -1185,6 +1187,7 @@ export const RepositoryPage: React.FC = () => {
       console.info("[ChatHistory] Request started");
       try {
         setChatError(null);
+        const sessionIdAtFetchStart = sessionId;
         const currentTimestamp = lastKnownTimestampRef.current;
         const startTimestamp = currentTimestamp
           ? currentTimestamp + 1
@@ -1196,10 +1199,16 @@ export const RepositoryPage: React.FC = () => {
           signal,
         );
 
-        if (signal?.aborted) return;
+        if (signal?.aborted) { setSessionLoading(false); return; }
+
+        if (sessionIdRef.current !== sessionIdAtFetchStart) {
+          setSessionLoading(false);
+          return;
+        }
 
         if (!history.messages?.length) {
           console.info("[ChatHistory] Request completed with no new messages");
+          setSessionLoading(false);
           return;
         }
 
@@ -1208,8 +1217,10 @@ export const RepositoryPage: React.FC = () => {
           console.info("[ChatHistory] Request completed; merge finished");
           return mergeChatMessages(previousChat, mapped);
         });
+        setSessionLoading(false);
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
+          setSessionLoading(false);
           return;
         }
         console.error("Failed to load chat history", error);
@@ -1218,9 +1229,10 @@ export const RepositoryPage: React.FC = () => {
             ? error.message
             : "Failed to load chat history";
         setChatError(message);
+        setSessionLoading(false);
       }
     },
-    [name, sessionId, setChat, setChatError],
+    [name, sessionId, setChat, setChatError, setSessionLoading],
   );
 
   useEffect(() => {
@@ -1390,7 +1402,9 @@ export const RepositoryPage: React.FC = () => {
 
   const handleSessionSelect = (session: ChatSession) => {
     if (!name) return;
+    if (!session.id) return;
     if (session.id === sessionId) {
+      setSessionLoading(false);
       setSessionModalOpen(false);
       reloadCurrentSession();
       return;
@@ -1400,6 +1414,7 @@ export const RepositoryPage: React.FC = () => {
     setChatAgentProcessing(false);
     setChatError(null);
     setChat([]);
+    setSessionLoading(true);
     setSessionId(session.id);
   };
 
@@ -1998,6 +2013,7 @@ export const RepositoryPage: React.FC = () => {
             chat={chat}
             chatWindowRef={chatWindowRef}
             agentProcessing={chatAgentProcessing}
+            sessionLoading={sessionLoading}
             refreshing={isRefreshing}
             emptyMessage="No conversation yet."
             sessionId={sessionId}

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -2664,10 +2664,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveB: (value: ChatHistoryResponse) => void = () => {};
-    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveB = resolve;
-    });
+    const deferredB = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)
@@ -2875,10 +2872,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveB: (value: ChatHistoryResponse) => void = () => {};
-    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveB = resolve;
-    });
+    const deferredB = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)
@@ -2920,10 +2914,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveB: (value: ChatHistoryResponse) => void = () => {};
-    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveB = resolve;
-    });
+    const deferredB = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)
@@ -2963,10 +2954,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveRefresh: (value: ChatHistoryResponse) => void = () => {};
-    const deferredRefresh = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveRefresh = resolve;
-    });
+    const deferredRefresh = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)
@@ -2986,9 +2974,11 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
     await screen.findByTitle("Session A");
 
     // The third call (re-select) should use deferred — but mockReturnValueOnce was consumed on second call.
-    // Re-configure: only the re-select call is deferred via mockImplementationOnce.
+    // Re-configure: only the re-select call is deferred.
     vi.mocked(api.getRepositoryAgentHistory).mockClear();
-    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(deferredRefresh);
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(
+      deferredRefresh,
+    );
     fireEvent.click(screen.getByTitle("Session A"));
 
     await waitFor(() => {
@@ -3002,16 +2992,11 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
   // ── AC9: Bootstrap path shows loading indicator ────────────────
 
   it("AC9: Bootstrap URL-driven session switch shows loading indicator (fails: setSessionLoading(true) missing in switchSessionIfNeeded)", async () => {
-    let resolveBootstrap: (value: ChatHistoryResponse) => void = () => {};
-    const deferredBootstrap = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveBootstrap = resolve;
-    });
+    const deferredBootstrap = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory).mockReturnValue(deferredBootstrap);
 
-    renderPage([
-      "/repositories/test-repo?tab=agent&sessionId=session-b",
-    ]);
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
 
     await waitFor(() => {
       expect(
@@ -3031,10 +3016,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveB: (value: ChatHistoryResponse) => void = () => {};
-    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveB = resolve;
-    });
+    const deferredB = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)
@@ -3092,10 +3074,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveEmpty: (value: ChatHistoryResponse) => void = () => {};
-    const deferredEmpty = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveEmpty = resolve;
-    });
+    const deferredEmpty = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)
@@ -3295,10 +3274,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       timestamp: "2026-01-01T00:00:00Z",
     };
     const historyA = { sessionId: "session-a", messages: [msgA] };
-    let resolveRefresh: (value: ChatHistoryResponse) => void = () => {};
-    const deferredRefresh = new Promise<ChatHistoryResponse>((resolve) => {
-      resolveRefresh = resolve;
-    });
+    const deferredRefresh = new Promise<ChatHistoryResponse>(() => {});
 
     vi.mocked(api.getRepositoryAgentHistory)
       .mockResolvedValueOnce(historyA)

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -268,7 +268,10 @@ describe("RepositoryPage session selection", () => {
 
     expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
 
-    expect(document.querySelector(".empty")).toBeInTheDocument();
+    expect(
+      document.querySelector(".loading-indicator"),
+      "FAIL (AC490-2): No loading indicator during session switch — sessionLoading state missing",
+    ).toBeInTheDocument();
 
     resolveB(historyB);
 
@@ -2630,5 +2633,708 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
       screen.queryByText("Hello from A (nav stale)"),
       "FAIL (ADV-492): Stale session A data appeared after router navigation — signal.aborted guard missing",
     ).not.toBeInTheDocument();
+  });
+});
+
+// ── Issue #491: session-select loading-state UX contract tests ───────
+
+describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    localStorage.clear();
+  });
+
+  // ── AC1: Loading indicator during session switch ────────────────
+
+  it("AC1: Loading indicator appears when switching sessions (fails: sessionLoading state missing)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    // Load session A
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Click session B (deferred — never resolves in this test)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC1): .loading-indicator not found — sessionLoading is not set to true in handleSessionSelect",
+      ).toBeTruthy();
+      expect(
+        document.querySelector(".empty"),
+        "FAIL (AC1): .empty should be hidden when sessionLoading is active",
+      ).toBeFalsy();
+    });
+  });
+
+  // ── AC2: Loading indicator disappears on success ────────────────
+
+  it("AC2: Loading indicator clears after history resolves with messages (fails: setSessionLoading(false) not called on success)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    const historyB = { sessionId: "session-b", messages: [msgB] };
+    let resolveB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    // Verify loading indicator appears (AC1 prerequisite)
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC2 pre): no loading state to clear — sessionLoading not set",
+      ).toBeTruthy();
+    });
+
+    // Resolve with messages
+    resolveB(historyB);
+    await screen.findByText("Hello from B");
+
+    expect(
+      document.querySelector(".loading-indicator"),
+      "FAIL (AC2): .loading-indicator persists after history resolves — setSessionLoading(false) missing in success path",
+    ).toBeFalsy();
+  });
+
+  // ── AC3: Loading indicator disappears on empty history ──────────
+
+  it("AC3: Loading indicator clears after empty history response (fails: setSessionLoading(false) not called in empty-return)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC3 pre): no loading state to clear — sessionLoading not set",
+      ).toBeTruthy();
+    });
+
+    // Resolve with empty history
+    resolveB({ sessionId: "session-b", messages: [] });
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC3): .loading-indicator persists after empty response — setSessionLoading(false) missing",
+      ).toBeFalsy();
+    });
+
+    expect(
+      document.querySelector(".empty"),
+      "FAIL (AC3): .empty not rendered after empty history",
+    ).toBeTruthy();
+  });
+
+  // ── AC4: Loading indicator disappears on error ─────────────────
+
+  it("AC4: Loading indicator clears after history fetch error (fails: setSessionLoading(false) not called in catch)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let rejectB: (reason: Error) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((_, reject) => {
+      rejectB = reject;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC4 pre): no loading state — sessionLoading not set",
+      ).toBeTruthy();
+    });
+
+    // Reject the deferred
+    rejectB(new Error("Fetch failed"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC4): .loading-indicator persists after error — setSessionLoading(false) missing in catch",
+      ).toBeFalsy();
+      expect(
+        screen.getByText("Fetch failed"),
+        "FAIL (AC4): error message not shown after fetch rejection",
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── AC5: No stale-content flash ────────────────────────────────
+
+  it("AC5: No stale content flashes during session switch (fails: setChat([]) and setSessionLoading(true) not batched)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    // Within one synchronous batch, old content should be gone AND loading visible
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Hello from A"),
+        "FAIL (AC5): stale content visible during session switch — setChat not cleared",
+      ).toBeNull();
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC5): .loading-indicator not visible — setSessionLoading(true) not called",
+      ).toBeTruthy();
+    });
+  });
+
+  // ── AC6: No duplicate fetches ──────────────────────────────────
+
+  it("AC6: One session switch triggers exactly one history fetch (regression guard)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory).mockClear();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentHistory,
+        "FAIL (AC6): more than one history fetch triggered by single session switch",
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── AC7: Same-session re-select unchanged ──────────────────────
+
+  it("AC7: Same-session re-select shows 'Refreshing...' (fails: setSessionLoading interferes)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveRefresh: (value: ChatHistoryResponse) => void = () => {};
+    const deferredRefresh = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredRefresh);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Re-select same session (deferred refresh so "Refreshing..." stays visible)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session A");
+
+    // The third call (re-select) should use deferred — but mockReturnValueOnce was consumed on second call.
+    // Re-configure: only the re-select call is deferred via mockImplementationOnce.
+    vi.mocked(api.getRepositoryAgentHistory).mockClear();
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(deferredRefresh);
+    fireEvent.click(screen.getByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Refreshing..."),
+        "FAIL (AC7): 'Refreshing...' not shown on same-session re-select — sessionLoading may be overriding refreshing priority",
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── AC9: Bootstrap path shows loading indicator ────────────────
+
+  it("AC9: Bootstrap URL-driven session switch shows loading indicator (fails: setSessionLoading(true) missing in switchSessionIfNeeded)", async () => {
+    let resolveBootstrap: (value: ChatHistoryResponse) => void = () => {};
+    const deferredBootstrap = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveBootstrap = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValue(deferredBootstrap);
+
+    renderPage([
+      "/repositories/test-repo?tab=agent&sessionId=session-b",
+    ]);
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (AC9): .loading-indicator not visible during bootstrap session switch — setSessionLoading(true) missing in switchSessionIfNeeded",
+      ).toBeTruthy();
+    });
+  });
+
+  // ── B1-reg: Same-session double-click does not leak loading ────
+
+  it("B1-reg: Same-session double-click after deferred switch shows 'Refreshing...', not stuck loading", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Click session B (deferred)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (B1-reg pre): no loading state on switch",
+      ).toBeTruthy();
+    });
+
+    // Re-click session B (same-session guard should fire)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Refreshing..."),
+        "FAIL (B1-reg): 'Refreshing...' not shown after same-session re-click — setSessionLoading(false) not called in same-session guard",
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── B2-reg: Empty session ID guard ─────────────────────────────
+
+  it("B2-reg: Empty session ID does not cause permanent loading (fails: if (!session.id) return guard missing)", async () => {
+    const emptyIdSession: ChatSession = {
+      id: "",
+      title: "Empty ID",
+      updated: "2026-01-01",
+    };
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveEmpty: (value: ChatHistoryResponse) => void = () => {};
+    const deferredEmpty = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveEmpty = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredEmpty);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Click empty-ID session
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, emptyIdSession],
+    });
+    vi.mocked(api.getRepositoryAgentHistory).mockClear();
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Empty ID");
+    fireEvent.click(screen.getByTitle("Empty ID"));
+
+    // The !session.id guard should return early — no API call, no loading
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    expect(
+      api.getRepositoryAgentHistory,
+      "FAIL (B2-reg): getRepositoryAgentHistory was called for empty session ID — guard missing",
+    ).not.toHaveBeenCalled();
+
+    // No loading indicator should appear
+    expect(
+      document.querySelector(".loading-indicator"),
+      "FAIL (B2-reg): .loading-indicator appeared for empty session ID — guard missing in handleSessionSelect",
+    ).toBeFalsy();
+  });
+
+  // ── B4-reg: Stale sessionIdAtFetchStart guard ─────────────────
+
+  it("B4-reg: Stale deferred fetch after second switch does not overwrite newer session data (fails: sessionIdAtFetchStart guard missing)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    const historyB = { sessionId: "session-b", messages: [msgB] };
+    let resolveFirstB: (value: ChatHistoryResponse) => void = () => {};
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveFirstB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB)
+      .mockResolvedValueOnce(historyB);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Click session B (deferred)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentHistory,
+        "session B fetch should have started",
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    // Quick switch to session B again (same session re-select triggers reloadCurrentSession)
+    // Actually, re-select same session B triggers reloadCurrentSession which fetches historyB
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await screen.findByText("Hello from B");
+
+    // Now resolve the first stale deferred fetch (session B's initial fetch)
+    resolveFirstB(historyB);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    // Session B data should still be rendered (not overwritten)
+    expect(
+      screen.getByText("Hello from B"),
+      "FAIL (B4-reg): stale deferred fetch overwrote newer data — sessionIdAtFetchStart guard missing",
+    ).toBeInTheDocument();
+  });
+
+  // ── Concurrency guard: session change after await ─────────────
+
+  it("B4-concurrency: stale fetch resolves after session switch — sessionIdAtFetchStart guard discards stale data", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const msgC: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from C",
+      timestamp: "2026-01-03T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    const historyB = { sessionId: "session-b", messages: [msgB] };
+    const historyC = { sessionId: "session-c", messages: [msgC] };
+    const sessionC: ChatSession = {
+      id: "session-c",
+      title: "Session C",
+      updated: "2026-01-03",
+    };
+
+    let resolveB!: (value: ChatHistoryResponse) => void;
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB)
+      .mockResolvedValueOnce(historyC);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Click session B (fetch starts and is deferred)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB, sessionC],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(2);
+    });
+
+    // Now switch to session C WHILE session B's fetch is in-flight
+    vi.mocked(api.getRepositoryAgentHistory).mockClear();
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session C");
+    fireEvent.click(screen.getByTitle("Session C"));
+
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(1);
+    });
+    await screen.findByText("Hello from C");
+
+    // Resolve the stale session B fetch
+    resolveB(historyB);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    // Session C content must still be visible, session B must not appear
+    expect(
+      screen.getByText("Hello from C"),
+      "FAIL (B4-concurrency): stale session B fetch overwrote session C after sessionIdAtFetchStart guard — guard missing",
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Hello from B"),
+      "FAIL (B4-concurrency): stale session B content appeared after switch — sessionIdAtFetchStart guard missing",
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Priority-reg: refreshing > sessionLoading > agentProcessing ─
+
+  it("Priority-reg: 'Refreshing...' has priority over 'Loading session...' (fails: priority ordering wrong)", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    let resolveRefresh: (value: ChatHistoryResponse) => void = () => {};
+    const deferredRefresh = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredRefresh);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Simulate: sessionLoading=true from switching to B, then re-select A
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    // First switch to B (triggers sessionLoading)
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    // Now re-select session A (same-session re-select — should show "Refreshing...")
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session A");
+    vi.mocked(api.getRepositoryAgentHistory).mockClear();
+    fireEvent.click(screen.getByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Refreshing..."),
+        "FAIL (Priority-reg): 'Refreshing...' not shown — refreshing must have priority over sessionLoading in ChatWindow",
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -309,7 +309,7 @@ describe("RepositoryPage session selection", () => {
     fireEvent.click(screen.getByTitle("Session B"));
 
     expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
-    expect(document.querySelector(".empty")).toBeInTheDocument();
+    expect(document.querySelector(".loading-indicator")).toBeInTheDocument();
 
     rejectB!(new Error("Fetch failed"));
 
@@ -317,6 +317,7 @@ describe("RepositoryPage session selection", () => {
       expect(screen.getByText("Fetch failed")).toBeInTheDocument();
     });
 
+    expect(document.querySelector(".loading-indicator")).toBeFalsy();
     expect(document.querySelector(".empty")).toBeInTheDocument();
     expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
   });
@@ -352,11 +353,12 @@ describe("RepositoryPage session selection", () => {
     fireEvent.click(screen.getByTitle("Session B"));
 
     expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
-    expect(document.querySelector(".empty")).toBeInTheDocument();
+    expect(document.querySelector(".loading-indicator")).toBeInTheDocument();
 
     resolveB!({ sessionId: "session-b", messages: [] });
-    await new Promise<void>((resolve) => setTimeout(resolve, 50));
-
+    await waitFor(() => {
+      expect(document.querySelector(".loading-indicator")).toBeFalsy();
+    });
     expect(document.querySelector(".empty")).toBeInTheDocument();
     expect(screen.queryByText("Hello from A")).not.toBeInTheDocument();
     expect(document.querySelectorAll(".alert").length).toBe(0);
@@ -2643,6 +2645,7 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
     cleanup();
     document.body.innerHTML = "";
     vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockReset();
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
     vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
       sessions: [sessionA, sessionB],
@@ -3297,14 +3300,15 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
 
     await new Promise<void>((r) => setTimeout(r, 50));
 
-    // Now re-select session A (same-session re-select — should show "Refreshing...")
+    // Simulate switch completes to session B via handleSessionSelect
+    // Now re-select session B (same-session re-select — should show "Refreshing...")
     vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
       sessions: [sessionA, sessionB],
     });
     fireEvent.click(await screen.findByLabelText("Choose a session"));
-    await screen.findByTitle("Session A");
+    await screen.findByTitle("Session B");
     vi.mocked(api.getRepositoryAgentHistory).mockClear();
-    fireEvent.click(screen.getByTitle("Session A"));
+    fireEvent.click(screen.getByTitle("Session B"));
 
     await waitFor(() => {
       expect(

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3313,4 +3313,113 @@ describe("RepositoryPage session-loading UX (AC1-AC9)", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("ADV-rapid-switch: rapid A→B→C preserves loading indicator through stale abort handler", async () => {
+    const msgA: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from A",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const msgB: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from B",
+      timestamp: "2026-01-02T00:00:00Z",
+    };
+    const msgC: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Hello from C",
+      timestamp: "2026-01-03T00:00:00Z",
+    };
+    const historyA = { sessionId: "session-a", messages: [msgA] };
+    const historyB = { sessionId: "session-b", messages: [msgB] };
+    const historyC = { sessionId: "session-c", messages: [msgC] };
+    const sessionC: ChatSession = {
+      id: "session-c",
+      title: "Session C",
+      updated: "2026-01-03",
+    };
+
+    let resolveB!: (value: ChatHistoryResponse) => void;
+    let resolveC!: (value: ChatHistoryResponse) => void;
+    const deferredB = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveB = resolve;
+    });
+    const deferredC = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveC = resolve;
+    });
+
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce(historyA)
+      .mockReturnValueOnce(deferredB)
+      .mockReturnValueOnce(deferredC);
+
+    renderPage();
+
+    // Load session A
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+    await screen.findByText("Hello from A");
+
+    // Click session B (deferred)
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB, sessionC],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session B");
+    fireEvent.click(screen.getByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(2);
+    });
+
+    // Verify loading indicator visible for B
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (ADV-rapid-switch pre): loading not shown for B",
+      ).toBeTruthy();
+    });
+
+    // Immediately click session C WHILE B's fetch is in-flight
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB, sessionC],
+    });
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    await screen.findByTitle("Session C");
+    fireEvent.click(screen.getByTitle("Session C"));
+
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(3);
+    });
+
+    // Loading indicator should still be visible (now for C)
+    await waitFor(() => {
+      expect(
+        document.querySelector(".loading-indicator"),
+        "FAIL (ADV-rapid-switch-1): loading disappeared after rapid B→C switch",
+      ).toBeTruthy();
+    });
+
+    // Resolve B's stale deferred — this triggers signal.aborted guard → setSessionLoading(false)
+    resolveB(historyB);
+    await new Promise<void>((r) => setTimeout(r, 100));
+
+    // ADVERSARIAL: loading indicator should STILL be visible because C is still loading
+    expect(
+      document.querySelector(".loading-indicator"),
+      "FAIL (ADV-rapid-switch-2): B's aborted handler cleared sessionLoading while C was still loading — setSessionLoading(false) in abort path should not clear C's loading state",
+    ).toBeTruthy();
+
+    // Resolve C's deferred — loading should clear
+    resolveC(historyC);
+    await screen.findByText("Hello from C");
+
+    expect(
+      document.querySelector(".loading-indicator"),
+      "FAIL (ADV-rapid-switch-3): loading persisted after C resolved",
+    ).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Closes #491

## Summary

Restores the session-select loading-state UX contract when switching sessions in the repository page. Adds a `sessionLoading` boolean state in `RepositoryPage.tsx`, wires set/clear into all five `syncChatHistory` exit paths and the `switchSessionIfNeeded` bootstrap path, and updates `ChatWindow.tsx` rendering priority (`refreshing > sessionLoading > agentProcessing > empty`). Three blocking defects (B1: double-click leak, B2: empty-ID guard, B4: stale-closure race) identified during spec review are addressed. All fixer findings resolved.

## Artifact Chain

| Artifact | Status |
|----------|--------|
| spec-approved | present |
| tests-created | present |
| implementation-done | present |
| implementation-review-findings | present |
| maintainer-review-findings | present |
| adversarial-review-findings | present |
| residual-gap-findings | present |
| pr-seeded | present |
| e2e-evidence | present |
| fixer-summary | present |

## CI Status

green

## Changes

- `packages/frontend/src/pages/RepositoryPage.tsx` (+24/−3) — `sessionLoading` state, `sessionIdAtFetchStart` guard, set/clear in all paths, `!session.id` guard, `setChatAgentProcessing(false)` in bootstrap
- `packages/frontend/src/components/ChatWindow.tsx` (+17/−5) — `sessionLoading` prop, correct rendering priority
- `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` (+800/−5) — AC1-AC9 tests, B1/B2/B4 regression tests, Priority-reg, ADV-rapid-switch
- `.opencode/package-lock.json` (±0 net) — dependency metadata bump

## Follow-up Issues

None

## Unresolved Risks

- `try/finally` refactor for guaranteed `setSessionLoading(false)` teardown — deferred as MVP hardening
- No session-idle timeout for hanging fetch — accepted MVP gap per spec (R6)
- No error-recovery (restore previous session on failure) — accepted MVP gap per spec

---

_This PR body was automatically generated by GHAR's pr-finalizer._
