### PR TITLE
Fix: call refresh_cron_clock() after harness generation (#529)

### DIFF
--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3168,8 +3168,12 @@ describe("RepositoryPage bootstrap path loading indicator (AC1-AC7)", () => {
     localStorage.clear();
     sessionStorage.clear();
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
-    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({ sessions: [] });
-    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({ processing: false });
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+    });
   });
 
   // ── U1 (AC1): ?sessionId=X → loading visible ─────────────────────────
@@ -3401,7 +3405,9 @@ describe("RepositoryPage bootstrap path loading indicator (AC1-AC7)", () => {
   // ── U10 (AC7): max 2 fetches when processing: true ─────────────────
 
   it("U10 (AC7): max 2 history fetches when processing: true", async () => {
-    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({ processing: true });
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+    });
 
     renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
 
@@ -3518,7 +3524,9 @@ describe("RepositoryPage bootstrap path loading indicator (AC1-AC7)", () => {
 
   // ── U14 (AC1/AC3 concurrent): URL re-edit ?sessionId=A→B ──────────
 
-  function renderPageWithRouter(initialEntries = ["/repositories/test-repo?tab=agent"]) {
+  function renderPageWithRouter(
+    initialEntries = ["/repositories/test-repo?tab=agent"],
+  ) {
     const router = createMemoryRouter(
       [{ path: "/repositories/:name/*", element: <RepositoryPage /> }],
       { initialEntries },

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -843,7 +843,8 @@ def generate_repository_workflow_harnesses(name: str, payload: dict = Body(...))
         _repository_path(name)
         logger.info("Generating harnesses for repository workflows: %s", name)
         written = generate_workflow_harnesses(payload, get_workspace_home() / name)
-        return {"written": written}
+        cron_status = refresh_cron_clock()
+        return {"written": written, "cron": cron_status}
     except WorkflowParseError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
@@ -910,7 +911,8 @@ def generate_global_workflow_harnesses(payload: dict = Body(...)):
     try:
         logger.info("Generating harnesses for global workflows")
         written = generate_workflow_harnesses(payload, get_made_home())
-        return {"written": written}
+        cron_status = refresh_cron_clock()
+        return {"written": written, "cron": cron_status}
     except WorkflowParseError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1499,11 +1499,13 @@ class TestVersionEndpoint:
         assert "commit_sha" in data
         assert "build_date" in data
         assert "environment" in data
+    @patch("app.refresh_cron_clock")
     @patch("app._repository_path")
     @patch("app.generate_workflow_harnesses")
-    def test_generate_repository_workflow_harnesses_success(self, mock_generate, mock_repo_path):
+    def test_generate_repository_workflow_harnesses_success(self, mock_generate, mock_repo_path, mock_refresh):
         mock_repo_path.return_value = "/tmp/sample"
         mock_generate.return_value = [".harness/test.sh"]
+        mock_refresh.return_value = {"running": True, "configuredJobs": 1}
 
         response = client.post(
             "/api/repositories/sample/workflows/generate-harnesses",
@@ -1511,7 +1513,8 @@ class TestVersionEndpoint:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"written": [".harness/test.sh"]}
+        assert response.json() == {"written": [".harness/test.sh"], "cron": {"running": True, "configuredJobs": 1}}
+        mock_refresh.assert_called_once_with()
 
     @patch("app._repository_path")
     @patch("app.generate_workflow_harnesses")
@@ -1528,13 +1531,15 @@ class TestVersionEndpoint:
 
         assert response.status_code == 400
 
+    @patch("app.refresh_cron_clock")
     @patch("app.get_made_home")
     @patch("app.generate_workflow_harnesses")
     def test_generate_global_workflow_harnesses_success(
-        self, mock_generate, mock_made_home
+        self, mock_generate, mock_made_home, mock_refresh
     ):
         mock_made_home.return_value = Path("/tmp/made")
         mock_generate.return_value = [".harness/test.sh"]
+        mock_refresh.return_value = {"running": True, "configuredJobs": 1}
 
         response = client.post(
             "/api/workflows/generate-harnesses",
@@ -1542,8 +1547,9 @@ class TestVersionEndpoint:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"written": [".harness/test.sh"]}
+        assert response.json() == {"written": [".harness/test.sh"], "cron": {"running": True, "configuredJobs": 1}}
         mock_generate.assert_called_once_with({"workflows": []}, Path("/tmp/made"))
+        mock_refresh.assert_called_once_with()
 
     @patch("app.generate_workflow_harnesses")
     def test_generate_global_workflow_harnesses_validation_error(self, mock_generate):

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1477,28 +1477,6 @@ class TestWorkflowEndpoints:
         assert response.status_code == 500
         assert "Cron refresh failed" in response.json()["detail"]
 
-
-class TestVersionEndpoint:
-    """Test the /api/version endpoint."""
-
-    def test_version_returns_version_string(self):
-        """Version endpoint returns a version field."""
-        response = client.get("/api/version")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "version" in data
-        assert isinstance(data["version"], str)
-        assert len(data["version"]) > 0
-
-    def test_version_includes_metadata_fields(self):
-        """Version endpoint returns all required metadata fields."""
-        response = client.get("/api/version")
-
-        data = response.json()
-        assert "commit_sha" in data
-        assert "build_date" in data
-        assert "environment" in data
     @patch("app.refresh_cron_clock")
     @patch("app._repository_path")
     @patch("app.generate_workflow_harnesses")
@@ -1563,3 +1541,26 @@ class TestVersionEndpoint:
         )
 
         assert response.status_code == 400
+
+
+class TestVersionEndpoint:
+    """Test the /api/version endpoint."""
+
+    def test_version_returns_version_string(self):
+        """Version endpoint returns a version field."""
+        response = client.get("/api/version")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert isinstance(data["version"], str)
+        assert len(data["version"]) > 0
+
+    def test_version_includes_metadata_fields(self):
+        """Version endpoint returns all required metadata fields."""
+        response = client.get("/api/version")
+
+        data = response.json()
+        assert "commit_sha" in data
+        assert "build_date" in data
+        assert "environment" in data


### PR DESCRIPTION
## Summary

When saving a workflow for the first time, `refresh_cron_clock()` ran before the harness script existed on disk. The cron scanner skipped the workflow with a warning. The harness generation endpoints wrote the scripts ~290ms later but never re-scanned cron, permanently excluding the workflow until a manual `/api/cron/update` call.

## Root Cause

The harness generation endpoints (`generate_repository_workflow_harnesses` and `generate_global_workflow_harnesses`) wrote harness files to disk but never called `refresh_cron_clock()` afterward. All other state-changing endpoints that affect scheduling already call it — this was omitted when harness generation was moved to a separate API in commit `3148ab5`.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/app.py` | Add `refresh_cron_clock()` after harness generation in repo endpoint (line 846) |
| `packages/pybackend/app.py` | Add `refresh_cron_clock()` after harness generation in global endpoint (line 913) |
| `packages/pybackend/tests/unit/test_api.py` | Update repo harness success test to mock and assert cron refresh |
| `packages/pybackend/tests/unit/test_api.py` | Update global harness success test to mock and assert cron refresh |

## Testing

- [x] Unit tests pass (415 passed, 1 pre-existing skip)
- [x] Lint passes (app.py: no issues)
- [x] Pre-push hook (`make qa-quick`) passes

## Validation

```bash
cd packages/pybackend && uv run python -m pytest tests/unit/test_api.py -k "harness" -v
cd packages/pybackend && uv run ruff check app.py
```

## Issue

Fixes #529

<details>
<summary>Implementation Details</summary>

### Deviations from plan

None — implementation follows the investigation artifact exactly.

</details>

_Automated implementation from investigation artifact_