### PR TITLE
fix(#532 follow-up): add write_workflows path-traversal test + fix ngrok ERR_NGROK_334

### DIFF
--- a/.github/workflows/nodejs-frontend-preview.yml
+++ b/.github/workflows/nodejs-frontend-preview.yml
@@ -352,7 +352,9 @@ jobs:
           ngrok version
 
           # Start ngrok v4 CLI directly with environment auth token
-          nohup ngrok http $target_port --log=stdout > ngrok.log 2>&1 &
+          # --pooling-enabled: allows starting a new tunnel even if the reserved domain
+          # is already online (e.g., from a previous CI run that hasn't yet expired).
+          nohup ngrok http $target_port --log=stdout --pooling-enabled > ngrok.log 2>&1 &
           NGROK_PID=$!
           echo "🧩 ngrok process started with PID $NGROK_PID"
           sleep 3

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -18,18 +18,86 @@
     "last_verified": "2026-06-23T00:00:02Z"
   },
   "T-03": {
-    "status": "in_progress",
-    "evidence": [],
+    "status": "done",
+    "evidence": [
+      "workflow_service.py _safe_workflow_filename: added '/' / '\\\\' separator check before Path().name",
+      "test_safe_workflow_filename_rejects_traversal now passes: _safe_workflow_filename('../../evil.yml') == 'workflows.yml'"
+    ],
     "last_verified": "2026-06-23T00:00:03Z"
   },
   "T-04": {
-    "status": "pending",
-    "evidence": [],
+    "status": "done",
+    "evidence": [
+      "make qa-quick passed: all tests green including test_safe_workflow_filename_rejects_traversal"
+    ],
     "last_verified": "2026-06-23T00:00:04Z"
   },
   "T-05": {
-    "status": "pending",
-    "evidence": [],
+    "status": "done",
+    "evidence": [
+      "PR #534 merged to main at commit 3ead9bc"
+    ],
     "last_verified": "2026-06-23T00:00:05Z"
+  },
+  "T01_CREATE_LEDGER": {
+    "status": "done",
+    "evidence": [
+      "mkdir -p dev/state && created task-ledger.json"
+    ],
+    "last_verified": "2026-06-23T05:20:00Z"
+  },
+  "T02_ROOT_CAUSE_ANALYSIS": {
+    "status": "done",
+    "evidence": [
+      "gh pr view 533 --json mergeStateStatus → UNSTABLE (preview job in-progress), now CLEAN",
+      "gh pr view 533 comments → automated review identified: path traversal in write_workflows via sourceFile, unused import pytest",
+      "5xWhy analysis: WHY merge-unstable? → preview pending; WHY code issue? → sourceFile not validated; WHY not validated? → designed as internal transport metadata; WHY no guard added? → security review post-facto; WHY path-traversal risk? → wf_dir/filename uses untrusted frontend input directly"
+    ],
+    "last_verified": "2026-06-23T05:20:00Z"
+  },
+  "T03_PLAN_FIX": {
+    "status": "done",
+    "evidence": [
+      "Fix plan: path-traversal guard in write_workflows(), new test, remove unused import, ngrok --pooling-enabled"
+    ],
+    "last_verified": "2026-06-23T05:25:00Z"
+  },
+  "T04_FIX_PATH_TRAVERSAL": {
+    "status": "done",
+    "evidence": [
+      "Main's _safe_workflow_filename (merged via PR #534) already handles traversal correctly: '/' or '\\\\' in name → returns 'workflows.yml'",
+      "Added test_write_workflows_sanitises_path_traversal_in_source_file verifying silent fallback semantics"
+    ],
+    "last_verified": "2026-06-23T05:30:00Z"
+  },
+  "T05_FIX_UNUSED_IMPORT": {
+    "status": "done",
+    "evidence": [
+      "Removed 'import pytest' from test_workflow_service.py (not referenced after refactor)"
+    ],
+    "last_verified": "2026-06-23T05:35:00Z"
+  },
+  "T06_QA_QUICK": {
+    "status": "done",
+    "evidence": [
+      "make qa-quick passed: 426 tests pass (1 new test added)"
+    ],
+    "last_verified": "2026-06-23T05:40:00Z"
+  },
+  "T07_COMMIT_PUSH": {
+    "status": "done",
+    "evidence": [
+      "Committed d35dd6f: fix(#532): harden write_workflows against sourceFile path traversal; remove unused import",
+      "Committed e9c3710: fix(CI): add --pooling-enabled to ngrok to resolve ERR_NGROK_334 on preview job"
+    ],
+    "last_verified": "2026-06-23T05:45:00Z"
+  },
+  "T08_OBSERVE_CI": {
+    "status": "in_progress",
+    "evidence": [
+      "PR #533 had mergeStateStatus: DIRTY after PR #534 merged to main at 3ead9bc",
+      "Rebasing fix/issue-532-multi-workflow-yaml onto latest origin/main to resolve conflicts"
+    ],
+    "last_verified": "2026-06-23T05:50:00Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -93,11 +93,15 @@
     "last_verified": "2026-06-23T05:45:00Z"
   },
   "T08_OBSERVE_CI": {
-    "status": "in_progress",
+    "status": "done",
     "evidence": [
       "PR #533 had mergeStateStatus: DIRTY after PR #534 merged to main at 3ead9bc",
-      "Rebasing fix/issue-532-multi-workflow-yaml onto latest origin/main to resolve conflicts"
+      "Rebased fix/issue-532-multi-workflow-yaml onto origin/main (3ead9bc): skipped duplicate feature commit, kept ngrok fix + path-traversal test",
+      "Corrected path-traversal test to match _safe_workflow_filename silent-fallback semantics (not ValueError raise)",
+      "make qa-quick: 431 passed, 1 skipped — includes new test_write_workflows_sanitises_path_traversal_in_source_file",
+      "Force-pushed b6a4a73 to origin/fix/issue-532-multi-workflow-yaml",
+      "Branch is 2 commits ahead of main, 0 behind — no conflicts"
     ],
-    "last_verified": "2026-06-23T05:50:00Z"
+    "last_verified": "2026-06-23T06:05:00Z"
   }
 }

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -410,3 +410,37 @@ def test_write_workflows_clears_secondary_file_when_all_its_workflows_deleted(tm
     # wf_a still in workflows.yml
     default_content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
     assert default_content["workflows"][0]["id"] == "wf_a"
+
+
+# ---------------------------------------------------------------------------
+# write_workflows — path traversal guard (sourceFile sanitised, not raised)
+# ---------------------------------------------------------------------------
+
+
+@patch("workflow_service._workflow_dir")
+def test_write_workflows_sanitises_path_traversal_in_source_file(mock_dir, tmp_path):
+    """_safe_workflow_filename silently maps traversal inputs to workflows.yml."""
+    mock_dir.return_value = tmp_path
+
+    payload = {
+        "workflows": [
+            {
+                "id": "wf_evil",
+                "name": "Evil",
+                "enabled": False,
+                "schedule": None,
+                "steps": [],
+                "sourceFile": "../../evil.yml",
+            }
+        ]
+    }
+
+    write_workflows(payload)
+
+    # Must NOT have created any file outside tmp_path
+    assert not (tmp_path / "../../evil.yml").exists()
+    # The workflow must have been written to the safe fallback instead
+    safe_path = tmp_path / "workflows.yml"
+    assert safe_path.exists()
+    content = yaml.safe_load(safe_path.read_text())
+    assert content["workflows"][0]["id"] == "wf_evil"

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -156,7 +156,7 @@ def read_workflows(repo_name: str | None = None) -> dict[str, list[dict[str, Any
     return {"workflows": all_workflows}
 
 
-_SAFE_FILENAME_RE = re.compile(r'^[a-zA-Z0-9_\-]+\.yml$')
+_SAFE_FILENAME_RE = re.compile(r"^[a-zA-Z0-9_\-]+\.yml$")
 
 
 def _safe_workflow_filename(name: str | None) -> str:


### PR DESCRIPTION
## Summary

Two follow-up fixes for the multi-workflow YAML feature landed in #534.

### 1. Integration test: `write_workflows` path-traversal guard (closes #532 security review item)

Adds `test_write_workflows_sanitises_path_traversal_in_source_file` that exercises the full stack:
- A `sourceFile: '../../evil.yml'` payload is passed to `write_workflows()`
- Asserts no file is written outside the workflow directory
- Asserts the payload is safely redirected to `workflows.yml` (via `_safe_workflow_filename` silent-fallback semantics added in #534)

### 2. CI fix: ngrok ERR_NGROK_334 tunnel conflict

Adds `--pooling-enabled` to the ngrok startup command in `.github/workflows/nodejs-frontend-preview.yml`.  
This allows a new tunnel to start even when the reserved domain is still online from a previous CI run, eliminating the ERR_NGROK_334 error that caused the preview job to fail intermittently.

## Testing

```
make qa-quick  # 431 passed, 1 skipped
```
