### PR TITLE
Fix: per-file YAML error handling in read_workflows() (#538)

### DIFF
--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -314,6 +314,32 @@ def test_read_workflows_empty_directory_returns_empty(tmp_path):
     assert result == {"workflows": []}
 
 
+def test_read_workflows_skips_malformed_file(tmp_path):
+    (tmp_path / "workflows.yml").write_text(
+        yaml.safe_dump({"workflows": [{"id": "wf_1", "name": "Good", "enabled": False, "schedule": None, "steps": []}]})
+    )
+    # Write a malformed YAML file alongside the valid one
+    (tmp_path / "bad.yml").write_text("{invalid: yaml: broken", encoding="utf-8")
+
+    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+        result = read_workflows()
+
+    # Good workflow must still be present; malformed file is skipped
+    assert len(result["workflows"]) == 1
+    assert result["workflows"][0]["id"] == "wf_1"
+    assert result["workflows"][0]["sourceFile"] == "workflows.yml"
+
+
+def test_read_workflows_all_malformed_returns_empty(tmp_path):
+    (tmp_path / "workflows.yml").write_text(": broken yaml: [", encoding="utf-8")
+    (tmp_path / "extra.yml").write_text("also: [bad: yaml", encoding="utf-8")
+
+    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+        result = read_workflows()
+
+    assert result == {"workflows": []}
+
+
 # ---------------------------------------------------------------------------
 # write_workflows — per-file write-back
 # ---------------------------------------------------------------------------

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Any
@@ -8,6 +9,8 @@ import yaml
 
 from config import ensure_directory, get_made_directory, get_workspace_home
 from task_service import list_scheduled_tasks
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_WORKFLOW_NAME = "New workflow"
 
@@ -148,7 +151,11 @@ def read_workflows(repo_name: str | None = None) -> dict[str, list[dict[str, Any
     for wf_path in _workflow_paths(repo_name):
         if not wf_path.exists():
             continue
-        data = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+        try:
+            data = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            logger.warning("Skipping malformed workflow file: %s (%s)", wf_path, exc)
+            continue
         payload = _normalize_payload(data)
         for wf in payload.get("workflows", []):
             wf["sourceFile"] = wf_path.name


### PR DESCRIPTION
## Summary

`read_workflows()` in `workflow_service.py:151` called `yaml.safe_load()` with no per-file error handling. A single malformed `.yml` file under `.made/` caused `yaml.YAMLError` to propagate uncaught, blocking all workflows from loading — including those from healthy files. Introduced by the multi-file support in PR #534.

## Root Cause

The for-loop body in `read_workflows()` (lines 148–156) had no try/except around `yaml.safe_load()`. A single malformed file raised `yaml.YAMLError`, which exited the loop immediately and propagated to callers, causing HTTP 500 responses for all workflows.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/workflow_service.py` | Add `import logging` + module-level `logger`; wrap `yaml.safe_load()` in `try/except yaml.YAMLError` with warning log and `continue` |
| `packages/pybackend/tests/unit/test_workflow_service.py` | Add `test_read_workflows_skips_malformed_file` and `test_read_workflows_all_malformed_returns_empty` |

## Testing

- [x] New test: mixed valid + malformed files — healthy workflows still load
- [x] New test: all malformed files — returns empty list without crashing
- [x] Full `test_workflow_service.py` suite passes (25/25)
- [x] `ruff check workflow_service.py` — clean
- [x] Pattern mirrors `command_service.py:47-60` exactly

## Validation

```bash
cd packages/pybackend && uv run python -m pytest tests/unit/test_workflow_service.py -v
cd packages/pybackend && uv run ruff check workflow_service.py
```

## Issue

Fixes #538

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from issue investigation comment

### Deviations from plan:

None — implementation matches the investigation plan exactly.

</details>

_Automated implementation from investigation artifact_