### PR TITLE
Fix: remove sourceFile from workflow schema (#541)

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -29,7 +29,6 @@ export type WorkflowDefinition = {
   enabled: boolean;
   schedule: string | null;
   shellScriptPath?: string;
-  sourceFile?: string;
   steps: WorkflowStep[];
 };
 
@@ -111,7 +110,6 @@ const newWorkflow = (): WorkflowDefinition => ({
   enabled: false,
   schedule: null,
   steps: [],
-  sourceFile: "workflows.yml",
 });
 
 export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
@@ -250,31 +248,10 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
         <div className="empty">No workflows yet.</div>
       )}
       <div className="workflow-list">
-        {workflows.map((workflow, index) => {
+        {workflows.map((workflow) => {
           const expanded = expandedIds[workflow.id] ?? true;
-          const prevSourceFile =
-            index > 0
-              ? workflows[index - 1].sourceFile || "workflows.yml"
-              : null;
-          const currSourceFile = workflow.sourceFile || "workflows.yml";
-          const showDivider =
-            prevSourceFile !== null && prevSourceFile !== currSourceFile;
           return (
             <React.Fragment key={workflow.id}>
-              {showDivider && (
-                <div
-                  style={{
-                    borderTop: "1px dashed rgba(255,255,255,0.4)",
-                    margin: "8px 0",
-                    paddingTop: "8px",
-                    textAlign: "center",
-                    fontSize: "0.7rem",
-                    color: "rgba(255,255,255,0.5)",
-                  }}
-                >
-                  {currSourceFile}
-                </div>
-              )}
               <div className="workflow-card">
                 <div className="workflow-card__header">
                   <button

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -332,7 +332,6 @@ export type WorkflowDefinition = {
   enabled: boolean;
   schedule: string | null;
   shellScriptPath?: string;
-  sourceFile?: string;
   steps: WorkflowStep[];
 };
 

--- a/packages/pybackend/tests/unit/test_workflow_harness_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_harness_service.py
@@ -112,3 +112,12 @@ def test_generate_workflow_harnesses_raises_on_dry_run_failure(mock_run: Mock, t
 
     with pytest.raises(WorkflowVerificationError, match="script dry run failed"):
         generate_workflow_harnesses(sample_payload(), tmp_path)
+
+
+def test_parse_workflow_payload_rejects_sourceFile_field():
+    """sourceFile must never reach the harness service — guard/sentinel test."""
+    payload = sample_payload()
+    payload["workflows"][0]["sourceFile"] = "workflows.yml"
+
+    with pytest.raises(WorkflowParseError):
+        parse_workflow_payload(payload)

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import yaml
 
-from workflow_service import _normalize_payload, _normalize_workflow, _safe_workflow_filename, _workflow_paths, list_workspace_workflows, read_workflows, write_workflows
+from workflow_service import _normalize_payload, _normalize_workflow, _workflow_paths, list_workspace_workflows, read_workflows, write_workflows
 
 
 def test_normalize_payload_keeps_shell_script_path():
@@ -245,32 +245,6 @@ def test_workflow_paths_no_yml_files_returns_empty(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _normalize_workflow — sourceFile passthrough
-# ---------------------------------------------------------------------------
-
-
-def test_normalize_workflow_preserves_source_file():
-    wf = {
-        "id": "wf_1",
-        "name": "Test",
-        "enabled": True,
-        "schedule": None,
-        "steps": [],
-        "sourceFile": "my-team.yml",
-    }
-    result = _normalize_workflow(wf, 0)
-    assert result is not None
-    assert result["sourceFile"] == "my-team.yml"
-
-
-def test_normalize_workflow_no_source_file_omitted():
-    wf = {"id": "wf_1", "name": "Test", "enabled": False, "schedule": None, "steps": []}
-    result = _normalize_workflow(wf, 0)
-    assert result is not None
-    assert "sourceFile" not in result
-
-
-# ---------------------------------------------------------------------------
 # read_workflows — multi-file aggregation
 # ---------------------------------------------------------------------------
 
@@ -290,10 +264,6 @@ def test_read_workflows_aggregates_multiple_files(tmp_path):
     assert "wf_a" in ids
     assert "wf_b" in ids
 
-    sources = {wf["id"]: wf["sourceFile"] for wf in result["workflows"]}
-    assert sources["wf_a"] == "workflows.yml"
-    assert sources["wf_b"] == "team.yml"
-
 
 def test_read_workflows_single_file_backward_compat(tmp_path):
     (tmp_path / "workflows.yml").write_text(
@@ -305,7 +275,6 @@ def test_read_workflows_single_file_backward_compat(tmp_path):
 
     assert len(result["workflows"]) == 1
     assert result["workflows"][0]["id"] == "wf_1"
-    assert result["workflows"][0]["sourceFile"] == "workflows.yml"
 
 
 def test_read_workflows_empty_directory_returns_empty(tmp_path):
@@ -327,7 +296,6 @@ def test_read_workflows_skips_malformed_file(tmp_path):
     # Good workflow must still be present; malformed file is skipped
     assert len(result["workflows"]) == 1
     assert result["workflows"][0]["id"] == "wf_1"
-    assert result["workflows"][0]["sourceFile"] == "workflows.yml"
 
 
 def test_read_workflows_all_malformed_returns_empty(tmp_path):
@@ -345,26 +313,21 @@ def test_read_workflows_all_malformed_returns_empty(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_write_workflows_per_file_writeback(tmp_path):
+def test_write_workflows_writes_all_to_workflows_yml(tmp_path):
     payload = {
         "workflows": [
-            {"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": [], "sourceFile": "workflows.yml"},
-            {"id": "wf_b", "name": "B", "enabled": False, "schedule": None, "steps": [], "sourceFile": "team.yml"},
+            {"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": []},
+            {"id": "wf_b", "name": "B", "enabled": False, "schedule": None, "steps": []},
         ]
     }
 
     with patch("workflow_service._workflow_dir", return_value=tmp_path):
         write_workflows(payload)
 
-    default_content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
-    team_content = yaml.safe_load((tmp_path / "team.yml").read_text())
-
-    assert [wf["id"] for wf in default_content["workflows"]] == ["wf_a"]
-    assert [wf["id"] for wf in team_content["workflows"]] == ["wf_b"]
-
-    # sourceFile must NOT appear in the written YAML
-    assert "sourceFile" not in default_content["workflows"][0]
-    assert "sourceFile" not in team_content["workflows"][0]
+    content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
+    assert [wf["id"] for wf in content["workflows"]] == ["wf_a", "wf_b"]
+    assert "sourceFile" not in content["workflows"][0]
+    assert "sourceFile" not in content["workflows"][1]
 
 
 def test_write_workflows_defaults_to_workflows_yml_when_no_source_file(tmp_path):
@@ -383,47 +346,20 @@ def test_write_workflows_defaults_to_workflows_yml_when_no_source_file(tmp_path)
 
 
 # ---------------------------------------------------------------------------
-# _safe_workflow_filename — path traversal guard
-# ---------------------------------------------------------------------------
-
-
-def test_safe_workflow_filename_rejects_traversal():
-    assert _safe_workflow_filename("../../evil.yml") == "workflows.yml"
-    assert _safe_workflow_filename("/etc/cron.d/evil") == "workflows.yml"
-    assert _safe_workflow_filename("../sibling/hack.yml") == "workflows.yml"
-
-
-def test_safe_workflow_filename_rejects_non_yml():
-    assert _safe_workflow_filename("evil.sh") == "workflows.yml"
-    assert _safe_workflow_filename("evil.yaml") == "workflows.yml"
-
-
-def test_safe_workflow_filename_accepts_valid_names():
-    assert _safe_workflow_filename("team-a.yml") == "team-a.yml"
-    assert _safe_workflow_filename("workflows.yml") == "workflows.yml"
-    assert _safe_workflow_filename("my_workflows_2.yml") == "my_workflows_2.yml"
-
-
-def test_safe_workflow_filename_defaults_for_none_or_empty():
-    assert _safe_workflow_filename(None) == "workflows.yml"
-    assert _safe_workflow_filename("") == "workflows.yml"
-
-
-# ---------------------------------------------------------------------------
 # write_workflows — clears orphaned secondary files on delete
 # ---------------------------------------------------------------------------
 
 
-def test_write_workflows_clears_secondary_file_when_all_its_workflows_deleted(tmp_path):
+def test_write_workflows_empties_secondary_yml_files(tmp_path):
     # Pre-existing team.yml on disk
     (tmp_path / "team.yml").write_text(
         yaml.safe_dump({"workflows": [{"id": "wf_b", "name": "B", "enabled": False, "schedule": None, "steps": []}]})
     )
 
-    # Payload only contains wf_a — wf_b was deleted by user
+    # Payload only contains wf_a — wf_b was deleted by user; no sourceFile in payload
     payload = {
         "workflows": [
-            {"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": [], "sourceFile": "workflows.yml"},
+            {"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": []},
         ]
     }
 
@@ -436,40 +372,6 @@ def test_write_workflows_clears_secondary_file_when_all_its_workflows_deleted(tm
     # wf_a still in workflows.yml
     default_content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
     assert default_content["workflows"][0]["id"] == "wf_a"
-
-
-# ---------------------------------------------------------------------------
-# write_workflows — path traversal guard (sourceFile sanitised, not raised)
-# ---------------------------------------------------------------------------
-
-
-@patch("workflow_service._workflow_dir")
-def test_write_workflows_sanitises_path_traversal_in_source_file(mock_dir, tmp_path):
-    """_safe_workflow_filename silently maps traversal inputs to workflows.yml."""
-    mock_dir.return_value = tmp_path
-
-    payload = {
-        "workflows": [
-            {
-                "id": "wf_evil",
-                "name": "Evil",
-                "enabled": False,
-                "schedule": None,
-                "steps": [],
-                "sourceFile": "../../evil.yml",
-            }
-        ]
-    }
-
-    write_workflows(payload)
-
-    # Must NOT have created any file outside tmp_path
-    assert not (tmp_path / "../../evil.yml").exists()
-    # The workflow must have been written to the safe fallback instead
-    safe_path = tmp_path / "workflows.yml"
-    assert safe_path.exists()
-    content = yaml.safe_load(safe_path.read_text())
-    assert content["workflows"][0]["id"] == "wf_evil"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -14,15 +14,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_WORKFLOW_NAME = "New workflow"
 
 
-def _workflow_path(repo_name: str | None = None) -> Path:
-    if repo_name:
-        base_path = get_workspace_home() / repo_name
-    else:
-        base_path = get_made_directory()
-    workflow_dir = ensure_directory(base_path / ".made") if repo_name else base_path
-    return workflow_dir / "workflows.yml"
-
-
 def _workflow_dir(repo_name: str | None = None) -> Path:
     """Return the .made directory path for global or per-repo context (does not create)."""
     if repo_name:

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from typing import Any
 
@@ -129,10 +128,6 @@ def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
     if isinstance(max_runtime_minutes, int) and max_runtime_minutes > 0:
         normalized_workflow["maxRuntimeMinutes"] = max_runtime_minutes
 
-    source_file = _as_string(workflow.get("sourceFile"))
-    if source_file:
-        normalized_workflow["sourceFile"] = source_file
-
     return normalized_workflow
 
 
@@ -157,29 +152,8 @@ def read_workflows(repo_name: str | None = None) -> dict[str, list[dict[str, Any
             logger.warning("Skipping malformed workflow file: %s (%s)", wf_path, exc)
             continue
         payload = _normalize_payload(data)
-        for wf in payload.get("workflows", []):
-            wf["sourceFile"] = wf_path.name
-            all_workflows.append(wf)
+        all_workflows.extend(payload.get("workflows", []))
     return {"workflows": all_workflows}
-
-
-_SAFE_FILENAME_RE = re.compile(r"^[a-zA-Z0-9_\-]+\.yml$")
-
-
-def _safe_workflow_filename(name: str | None) -> str:
-    """Return a sanitized workflow filename, defaulting to workflows.yml.
-
-    Rejects any input that contains path separators (prevents ../../ traversal)
-    and enforces the *.yml extension with an allowlist character set.
-    """
-    if not name:
-        return "workflows.yml"
-    # Reject any input containing path separators — prevents ../../ traversal
-    if "/" in name or "\\" in name:
-        return "workflows.yml"
-    if _SAFE_FILENAME_RE.match(name):
-        return name
-    return "workflows.yml"
 
 
 def write_workflows(
@@ -188,49 +162,32 @@ def write_workflows(
     normalized = _normalize_payload(workflows_payload)
     wf_dir = _workflow_dir(repo_name)
 
-    # Group workflows by sourceFile; sanitize each filename (path traversal guard)
-    by_file: dict[str, list[dict[str, Any]]] = {}
-    for wf in normalized.get("workflows", []):
-        safe_name = _safe_workflow_filename(wf.get("sourceFile"))
-        by_file.setdefault(safe_name, []).append(wf)
+    # Always write to the single canonical file
+    wf_path = wf_dir / "workflows.yml"
+    ensure_directory(wf_path.parent)
+    wf_path.write_text(
+        yaml.safe_dump(
+            {"workflows": normalized.get("workflows", [])},
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
 
-    # Determine complete set of files to write:
-    # - All groups from the incoming payload
-    # - Any existing *.yml files NOT in the payload → write empty list
-    #   (handles the case where all workflows were deleted from a secondary file)
-    # NOTE: Only *.yml files that contain a top-level "workflows" key are treated
-    # as workflow files and eligible for orphan-cleanup. Non-workflow YAML files
-    # (e.g. .made/agents.yml) are never read here and will never be overwritten.
-    files_to_write: dict[str, list[dict[str, Any]]] = dict(by_file)
+    # Migrate: empty any secondary workflow yml files left from multi-file experiment
     if wf_dir.exists():
         for existing_path in wf_dir.glob("*.yml"):
-            if existing_path.name not in files_to_write:
-                try:
-                    data = yaml.safe_load(existing_path.read_text(encoding="utf-8"))
-                    if isinstance(data, dict) and "workflows" in data:
-                        files_to_write[existing_path.name] = []
-                except Exception:
-                    pass  # Unreadable or non-YAML file — skip silently
-
-    if not files_to_write:
-        # No workflows and no existing files — write an empty workflows.yml
-        default_path = wf_dir / "workflows.yml"
-        ensure_directory(default_path.parent)
-        default_path.write_text(
-            yaml.safe_dump({"workflows": []}, sort_keys=False, allow_unicode=True),
-            encoding="utf-8",
-        )
-        return normalized
-
-    for filename, workflows in files_to_write.items():
-        wf_path = wf_dir / filename
-        ensure_directory(wf_path.parent)
-        # Strip sourceFile before writing — it is pipeline metadata, not YAML schema
-        cleaned = [{k: v for k, v in w.items() if k != "sourceFile"} for w in workflows]
-        wf_path.write_text(
-            yaml.safe_dump({"workflows": cleaned}, sort_keys=False, allow_unicode=True),
-            encoding="utf-8",
-        )
+            if existing_path == wf_path:
+                continue
+            try:
+                data = yaml.safe_load(existing_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict) and "workflows" in data:
+                    existing_path.write_text(
+                        yaml.safe_dump({"workflows": []}, sort_keys=False, allow_unicode=True),
+                        encoding="utf-8",
+                    )
+            except Exception:
+                pass  # Unreadable or non-YAML file — skip silently
 
     return normalized
 


### PR DESCRIPTION
## Summary

`sourceFile` was internal bookkeeping metadata from the experimental multi-file workflow feature (#532). It leaked from `read_workflows()` into the API response, and from the frontend's `toHarnessCompatibleWorkflows()` into the harness-generation payload. Because `workflow_harness_service.Workflow` uses `extra="forbid"` (via `StrictModel`) and has no `sourceFile` field, any harness generation request that includes `sourceFile` raises `ValidationError` → `WorkflowParseError` → HTTP 400.

## Root Cause

`sourceFile` was injected by `read_workflows()` at line 161 (`wf["sourceFile"] = wf_path.name`), preserved through `_normalize_workflow()` at lines 132-134, declared in both TypeScript type definitions, hardcoded in the `newWorkflow()` factory, and never stripped before the harness generation boundary.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/workflow_service.py` | Remove `sourceFile` passthrough from `_normalize_workflow()`; remove `sourceFile` tagging from `read_workflows()`; delete `_safe_workflow_filename()`, `_SAFE_FILENAME_RE`, `import re`; simplify `write_workflows()` to single canonical file with migration loop |
| `packages/frontend/src/hooks/useApi.ts` | Remove `sourceFile?: string` from `WorkflowDefinition` type |
| `packages/frontend/src/components/WorkflowBuilderPanel.tsx` | Remove `sourceFile?: string` from local type, remove from `newWorkflow()` factory, remove file-group divider UI logic |
| `packages/pybackend/tests/unit/test_workflow_service.py` | Remove `_safe_workflow_filename` import, delete sourceFile-related tests, rewrite write tests for single-file behaviour |
| `packages/pybackend/tests/unit/test_workflow_harness_service.py` | Add sentinel test confirming sourceFile is rejected by harness service |

## Testing

- [x] Frontend TypeScript type check passes (`tsc --noEmit`)
- [x] Frontend ESLint passes
- [x] All sourceFile references removed from production code
- [x] Sentinel test added: `test_parse_workflow_payload_rejects_sourceFile_field`
- [ ] Backend pytest (uv not available in this environment — verified manually via code review)

## Validation

```bash
# Backend tests
cd packages/pybackend && uv run python -m pytest tests/unit/test_workflow_service.py tests/unit/test_workflow_harness_service.py -v

# Frontend typecheck
cd packages/frontend && npx tsc --noEmit

# Full QA gate
make qa-quick
```

## Manual Verification

1. `GET /api/workflows` should return workflows without `sourceFile` field
2. `POST /api/workflows/generate-harnesses` with a valid payload should succeed (200, not 400)
3. The workflow builder UI renders without the sourceFile file-group divider

## Issue

Fixes #541

<details>
<summary>Implementation Details</summary>

### Implementation followed investigation plan from issue #541 comments

Second investigation comment (2026-06-23T22:00:00Z) was used as primary plan.

### Deviations from plan

- Kept `_workflow_paths()` and `_workflow_dir()` as specified by second plan (OUT OF SCOPE)
- Did not modify `workflow_harness_service.py` service code (OUT OF SCOPE per second plan); only added a test
- `import re` was also removed since its only use (`_SAFE_FILENAME_RE`) was deleted

</details>

_Automated implementation from investigation artifact_