### PR TITLE
Fix: remove sourceFile from workflow schema (#541)

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -252,180 +252,204 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
           const expanded = expandedIds[workflow.id] ?? true;
           return (
             <div key={workflow.id} className="workflow-card">
-                <div className="workflow-card__header">
-                  <button
-                    className="copy-button workflow-icon-button"
-                    onClick={() =>
-                      setExpandedIds((prev) => ({
-                        ...prev,
-                        [workflow.id]: !expanded,
-                      }))
-                    }
-                    title={expanded ? "Collapse workflow" : "Expand workflow"}
-                    aria-label={
-                      expanded ? "Collapse workflow" : "Expand workflow"
+              <div className="workflow-card__header">
+                <button
+                  className="copy-button workflow-icon-button"
+                  onClick={() =>
+                    setExpandedIds((prev) => ({
+                      ...prev,
+                      [workflow.id]: !expanded,
+                    }))
+                  }
+                  title={expanded ? "Collapse workflow" : "Expand workflow"}
+                  aria-label={
+                    expanded ? "Collapse workflow" : "Expand workflow"
+                  }
+                >
+                  <span
+                    className={
+                      expanded
+                        ? "workflow-icon workflow-icon--down"
+                        : "workflow-icon workflow-icon--right"
                     }
                   >
-                    <span
-                      className={
-                        expanded
-                          ? "workflow-icon workflow-icon--down"
-                          : "workflow-icon workflow-icon--right"
-                      }
-                    >
-                      <ArrowDownIcon />
-                    </span>
-                  </button>
-                  <input
-                    className="workflow-name-input"
-                    value={workflow.name}
-                    onChange={(event) => {
-                      const next = workflows.map((item) =>
-                        item.id === workflow.id
-                          ? { ...item, name: event.target.value }
-                          : item,
+                    <ArrowDownIcon />
+                  </span>
+                </button>
+                <input
+                  className="workflow-name-input"
+                  value={workflow.name}
+                  onChange={(event) => {
+                    const next = workflows.map((item) =>
+                      item.id === workflow.id
+                        ? { ...item, name: event.target.value }
+                        : item,
+                    );
+                    void persist(next);
+                  }}
+                />
+                <button
+                  className="copy-button workflow-icon-button"
+                  title={
+                    workflow.enabled ? "Disable workflow" : "Enable workflow"
+                  }
+                  aria-label={
+                    workflow.enabled ? "Disable workflow" : "Enable workflow"
+                  }
+                  onClick={() => {
+                    const next = workflows.map((item) =>
+                      item.id === workflow.id
+                        ? { ...item, enabled: !item.enabled }
+                        : item,
+                    );
+                    void persist(next);
+                  }}
+                >
+                  <span
+                    className={
+                      workflow.enabled
+                        ? "workflow-icon workflow-icon--enabled"
+                        : "workflow-icon"
+                    }
+                  >
+                    <CheckboxIcon checked={workflow.enabled} />
+                  </span>
+                </button>
+                <button
+                  className="copy-button workflow-icon-button"
+                  title={workflow.schedule || "Set schedule"}
+                  aria-label={
+                    workflow.schedule
+                      ? `Edit schedule: ${workflow.schedule}`
+                      : "Set schedule"
+                  }
+                  onClick={() =>
+                    setScheduleEditor({
+                      workflowId: workflow.id,
+                      value: workflow.schedule || "",
+                    })
+                  }
+                >
+                  <ClockIcon />
+                </button>
+                <button
+                  className="copy-button workflow-icon-button"
+                  onClick={() => addStep(workflow.id)}
+                  title="Add step"
+                  aria-label="Add step"
+                >
+                  <PlusIcon />
+                </button>
+                <button
+                  className="copy-button workflow-icon-button"
+                  title="Run workflow"
+                  aria-label="Run workflow"
+                  onClick={async () => {
+                    const shellScriptPath = workflowShellScriptPath(
+                      workflow.name,
+                    );
+                    setConversionMessage(null);
+                    setConversionError(null);
+                    const next = workflows.map((item) =>
+                      item.id === workflow.id
+                        ? { ...item, shellScriptPath }
+                        : item,
+                    );
+                    const persisted = await persist(next);
+                    if (!persisted) {
+                      setConversionError(
+                        "Failed to save workflow before conversion. Check required fields and try again.",
                       );
-                      void persist(next);
-                    }}
-                  />
-                  <button
-                    className="copy-button workflow-icon-button"
-                    title={
-                      workflow.enabled ? "Disable workflow" : "Enable workflow"
+                      return;
                     }
-                    aria-label={
-                      workflow.enabled ? "Disable workflow" : "Enable workflow"
-                    }
-                    onClick={() => {
-                      const next = workflows.map((item) =>
-                        item.id === workflow.id
-                          ? { ...item, enabled: !item.enabled }
-                          : item,
+                    try {
+                      await onRunWorkflow(next);
+                      setConversionMessage(
+                        `Workflow converted to harness shell script: ${shellScriptPath}`,
                       );
-                      void persist(next);
-                    }}
-                  >
-                    <span
-                      className={
-                        workflow.enabled
-                          ? "workflow-icon workflow-icon--enabled"
-                          : "workflow-icon"
-                      }
-                    >
-                      <CheckboxIcon checked={workflow.enabled} />
-                    </span>
-                  </button>
-                  <button
-                    className="copy-button workflow-icon-button"
-                    title={workflow.schedule || "Set schedule"}
-                    aria-label={
-                      workflow.schedule
-                        ? `Edit schedule: ${workflow.schedule}`
-                        : "Set schedule"
-                    }
-                    onClick={() =>
-                      setScheduleEditor({
-                        workflowId: workflow.id,
-                        value: workflow.schedule || "",
-                      })
-                    }
-                  >
-                    <ClockIcon />
-                  </button>
-                  <button
-                    className="copy-button workflow-icon-button"
-                    onClick={() => addStep(workflow.id)}
-                    title="Add step"
-                    aria-label="Add step"
-                  >
-                    <PlusIcon />
-                  </button>
-                  <button
-                    className="copy-button workflow-icon-button"
-                    title="Run workflow"
-                    aria-label="Run workflow"
-                    onClick={async () => {
-                      const shellScriptPath = workflowShellScriptPath(
-                        workflow.name,
+                    } catch (error) {
+                      const message =
+                        error instanceof Error && error.message
+                          ? error.message
+                          : "unknown error";
+                      setConversionError(
+                        `Failed to convert workflow to harness shell script (${message}). Check workflow schema, especially vars values, and try again.`,
                       );
-                      setConversionMessage(null);
-                      setConversionError(null);
-                      const next = workflows.map((item) =>
-                        item.id === workflow.id
-                          ? { ...item, shellScriptPath }
-                          : item,
-                      );
-                      const persisted = await persist(next);
-                      if (!persisted) {
-                        setConversionError(
-                          "Failed to save workflow before conversion. Check required fields and try again.",
-                        );
-                        return;
-                      }
-                      try {
-                        await onRunWorkflow(next);
-                        setConversionMessage(
-                          `Workflow converted to harness shell script: ${shellScriptPath}`,
-                        );
-                      } catch (error) {
-                        const message =
-                          error instanceof Error && error.message
-                            ? error.message
-                            : "unknown error";
-                        setConversionError(
-                          `Failed to convert workflow to harness shell script (${message}). Check workflow schema, especially vars values, and try again.`,
-                        );
-                      }
-                    }}
-                  >
-                    <PlayIcon />
-                  </button>
-                  <button
-                    className="copy-button workflow-icon-button workflow-icon-button--danger"
-                    title="Remove workflow"
-                    aria-label="Remove workflow"
-                    onClick={() =>
-                      void persist(
-                        workflows.filter((item) => item.id !== workflow.id),
-                      )
                     }
-                  >
-                    <TrashIcon />
-                  </button>
-                </div>
-                {expanded && (
-                  <div className="workflow-steps">
-                    {workflow.steps.length === 0 ? (
-                      <div className="empty">No steps yet.</div>
-                    ) : (
-                      workflow.steps.map((step, stepIndex) => (
-                        <div
-                          className="workflow-step-row"
-                          key={`${workflow.id}-${stepIndex}`}
-                        >
-                          <div className="workflow-step-target">
+                  }}
+                >
+                  <PlayIcon />
+                </button>
+                <button
+                  className="copy-button workflow-icon-button workflow-icon-button--danger"
+                  title="Remove workflow"
+                  aria-label="Remove workflow"
+                  onClick={() =>
+                    void persist(
+                      workflows.filter((item) => item.id !== workflow.id),
+                    )
+                  }
+                >
+                  <TrashIcon />
+                </button>
+              </div>
+              {expanded && (
+                <div className="workflow-steps">
+                  {workflow.steps.length === 0 ? (
+                    <div className="empty">No steps yet.</div>
+                  ) : (
+                    workflow.steps.map((step, stepIndex) => (
+                      <div
+                        className="workflow-step-row"
+                        key={`${workflow.id}-${stepIndex}`}
+                      >
+                        <div className="workflow-step-target">
+                          <select
+                            value={step.type}
+                            onChange={(event) => {
+                              const nextType = event.target.value as
+                                | "agent"
+                                | "bash"
+                                | "vars";
+                              const nextStep: WorkflowStep =
+                                nextType === "bash"
+                                  ? { type: "bash", run: "" }
+                                  : nextType === "vars"
+                                    ? {
+                                        type: "vars",
+                                        varName: "",
+                                        run: "",
+                                        values: {},
+                                      }
+                                    : {
+                                        type: "agent",
+                                        agent: agentNames[0] || "default",
+                                        prompt: "",
+                                      };
+                              const next = workflows.map((item) =>
+                                item.id === workflow.id
+                                  ? {
+                                      ...item,
+                                      steps: item.steps.map(
+                                        (itemStep, itemIndex) =>
+                                          itemIndex === stepIndex
+                                            ? nextStep
+                                            : itemStep,
+                                      ),
+                                    }
+                                  : item,
+                              );
+                              void persist(next);
+                            }}
+                          >
+                            <option value="agent">Agent</option>
+                            <option value="bash">Bash</option>
+                            <option value="vars">Vars</option>
+                          </select>
+                          {step.type === "agent" ? (
                             <select
-                              value={step.type}
+                              value={step.agent || "default"}
                               onChange={(event) => {
-                                const nextType = event.target.value as
-                                  | "agent"
-                                  | "bash"
-                                  | "vars";
-                                const nextStep: WorkflowStep =
-                                  nextType === "bash"
-                                    ? { type: "bash", run: "" }
-                                    : nextType === "vars"
-                                      ? {
-                                          type: "vars",
-                                          varName: "",
-                                          run: "",
-                                          values: {},
-                                        }
-                                      : {
-                                          type: "agent",
-                                          agent: agentNames[0] || "default",
-                                          prompt: "",
-                                        };
                                 const next = workflows.map((item) =>
                                   item.id === workflow.id
                                     ? {
@@ -433,7 +457,10 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                                         steps: item.steps.map(
                                           (itemStep, itemIndex) =>
                                             itemIndex === stepIndex
-                                              ? nextStep
+                                              ? {
+                                                  ...itemStep,
+                                                  agent: event.target.value,
+                                                }
                                               : itemStep,
                                         ),
                                       }
@@ -442,157 +469,126 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                                 void persist(next);
                               }}
                             >
-                              <option value="agent">Agent</option>
-                              <option value="bash">Bash</option>
-                              <option value="vars">Vars</option>
+                              {agentNames.length === 0 ? (
+                                <option value="default">default</option>
+                              ) : (
+                                agentNames.map((agentName) => (
+                                  <option key={agentName}>{agentName}</option>
+                                ))
+                              )}
                             </select>
-                            {step.type === "agent" ? (
-                              <select
-                                value={step.agent || "default"}
-                                onChange={(event) => {
-                                  const next = workflows.map((item) =>
-                                    item.id === workflow.id
-                                      ? {
-                                          ...item,
-                                          steps: item.steps.map(
-                                            (itemStep, itemIndex) =>
-                                              itemIndex === stepIndex
+                          ) : step.type === "vars" ? (
+                            <input
+                              className="workflow-step-target__input"
+                              value={step.varName || ""}
+                              placeholder="VARIABLE_NAME"
+                              onChange={(event) => {
+                                const next = workflows.map((item) =>
+                                  item.id === workflow.id
+                                    ? {
+                                        ...item,
+                                        steps: item.steps.map(
+                                          (itemStep, itemIndex) => {
+                                            if (itemIndex !== stepIndex) {
+                                              return itemStep;
+                                            }
+                                            const varName = toBashVariableName(
+                                              event.target.value,
+                                            );
+                                            return {
+                                              ...itemStep,
+                                              varName,
+                                              values: varName
                                                 ? {
-                                                    ...itemStep,
-                                                    agent: event.target.value,
+                                                    [varName]:
+                                                      itemStep.run || "",
                                                   }
-                                                : itemStep,
-                                          ),
-                                        }
-                                      : item,
-                                  );
-                                  void persist(next);
-                                }}
-                              >
-                                {agentNames.length === 0 ? (
-                                  <option value="default">default</option>
-                                ) : (
-                                  agentNames.map((agentName) => (
-                                    <option key={agentName}>{agentName}</option>
-                                  ))
-                                )}
-                              </select>
-                            ) : step.type === "vars" ? (
-                              <input
-                                className="workflow-step-target__input"
-                                value={step.varName || ""}
-                                placeholder="VARIABLE_NAME"
-                                onChange={(event) => {
-                                  const next = workflows.map((item) =>
-                                    item.id === workflow.id
-                                      ? {
-                                          ...item,
-                                          steps: item.steps.map(
-                                            (itemStep, itemIndex) => {
-                                              if (itemIndex !== stepIndex) {
-                                                return itemStep;
-                                              }
-                                              const varName =
-                                                toBashVariableName(
-                                                  event.target.value,
-                                                );
-                                              return {
-                                                ...itemStep,
-                                                varName,
-                                                values: varName
-                                                  ? {
-                                                      [varName]:
-                                                        itemStep.run || "",
-                                                    }
-                                                  : {},
-                                              };
-                                            },
-                                          ),
-                                        }
-                                      : item,
-                                  );
-                                  void persist(next);
-                                }}
-                              />
-                            ) : null}
-                          </div>
+                                                : {},
+                                            };
+                                          },
+                                        ),
+                                      }
+                                    : item,
+                                );
+                                void persist(next);
+                              }}
+                            />
+                          ) : null}
+                        </div>
+                        <button
+                          className="workflow-step-preview"
+                          onClick={() => {
+                            const currentText =
+                              step.type === "agent"
+                                ? step.command
+                                  ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
+                                  : step.prompt || ""
+                                : step.run || "";
+                            setEditStep({
+                              workflowId: workflow.id,
+                              stepIndex,
+                            });
+                            setEditStepValue(currentText);
+                          }}
+                        >
+                          {previewText(step)}
+                        </button>
+                        <div className="workflow-step-controls">
                           <button
-                            className="workflow-step-preview"
+                            className="copy-button workflow-icon-button"
+                            disabled={stepIndex === 0}
+                            title="Move step up"
+                            aria-label="Move step up"
                             onClick={() => {
-                              const currentText =
-                                step.type === "agent"
-                                  ? step.command
-                                    ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
-                                    : step.prompt || ""
-                                  : step.run || "";
-                              setEditStep({
-                                workflowId: workflow.id,
-                                stepIndex,
+                              const next = workflows.map((item) => {
+                                if (item.id !== workflow.id || stepIndex === 0)
+                                  return item;
+                                const steps = [...item.steps];
+                                [steps[stepIndex - 1], steps[stepIndex]] = [
+                                  steps[stepIndex],
+                                  steps[stepIndex - 1],
+                                ];
+                                return { ...item, steps };
                               });
-                              setEditStepValue(currentText);
+                              void persist(next);
                             }}
                           >
-                            {previewText(step)}
+                            <span className="workflow-icon workflow-icon--up">
+                              <ArrowDownIcon />
+                            </span>
                           </button>
-                          <div className="workflow-step-controls">
-                            <button
-                              className="copy-button workflow-icon-button"
-                              disabled={stepIndex === 0}
-                              title="Move step up"
-                              aria-label="Move step up"
-                              onClick={() => {
-                                const next = workflows.map((item) => {
-                                  if (
-                                    item.id !== workflow.id ||
-                                    stepIndex === 0
-                                  )
-                                    return item;
-                                  const steps = [...item.steps];
-                                  [steps[stepIndex - 1], steps[stepIndex]] = [
-                                    steps[stepIndex],
-                                    steps[stepIndex - 1],
-                                  ];
-                                  return { ...item, steps };
-                                });
-                                void persist(next);
-                              }}
-                            >
-                              <span className="workflow-icon workflow-icon--up">
-                                <ArrowDownIcon />
-                              </span>
-                            </button>
-                            <button
-                              className="copy-button workflow-icon-button"
-                              disabled={stepIndex === workflow.steps.length - 1}
-                              title="Move step down"
-                              aria-label="Move step down"
-                              onClick={() => {
-                                const next = workflows.map((item) => {
-                                  if (
-                                    item.id !== workflow.id ||
-                                    stepIndex >= item.steps.length - 1
-                                  )
-                                    return item;
-                                  const steps = [...item.steps];
-                                  [steps[stepIndex + 1], steps[stepIndex]] = [
-                                    steps[stepIndex],
-                                    steps[stepIndex + 1],
-                                  ];
-                                  return { ...item, steps };
-                                });
-                                void persist(next);
-                              }}
-                            >
-                              <span className="workflow-icon workflow-icon--down">
-                                <ArrowDownIcon />
-                              </span>
-                            </button>
-                          </div>
+                          <button
+                            className="copy-button workflow-icon-button"
+                            disabled={stepIndex === workflow.steps.length - 1}
+                            title="Move step down"
+                            aria-label="Move step down"
+                            onClick={() => {
+                              const next = workflows.map((item) => {
+                                if (
+                                  item.id !== workflow.id ||
+                                  stepIndex >= item.steps.length - 1
+                                )
+                                  return item;
+                                const steps = [...item.steps];
+                                [steps[stepIndex + 1], steps[stepIndex]] = [
+                                  steps[stepIndex],
+                                  steps[stepIndex + 1],
+                                ];
+                                return { ...item, steps };
+                              });
+                              void persist(next);
+                            }}
+                          >
+                            <span className="workflow-icon workflow-icon--down">
+                              <ArrowDownIcon />
+                            </span>
+                          </button>
                         </div>
-                       ))
-                     )}
-                   </div>
-                 )}
+                      </div>
+                    ))
+                  )}
+                </div>
+              )}
             </div>
           );
         })}

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -29,7 +29,6 @@ export type WorkflowDefinition = {
   enabled: boolean;
   schedule: string | null;
   shellScriptPath?: string;
-  sourceFile?: string;
   steps: WorkflowStep[];
 };
 
@@ -111,7 +110,6 @@ const newWorkflow = (): WorkflowDefinition => ({
   enabled: false,
   schedule: null,
   steps: [],
-  sourceFile: "workflows.yml",
 });
 
 export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
@@ -250,32 +248,10 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
         <div className="empty">No workflows yet.</div>
       )}
       <div className="workflow-list">
-        {workflows.map((workflow, index) => {
+        {workflows.map((workflow) => {
           const expanded = expandedIds[workflow.id] ?? true;
-          const prevSourceFile =
-            index > 0
-              ? workflows[index - 1].sourceFile || "workflows.yml"
-              : null;
-          const currSourceFile = workflow.sourceFile || "workflows.yml";
-          const showDivider =
-            prevSourceFile !== null && prevSourceFile !== currSourceFile;
           return (
-            <React.Fragment key={workflow.id}>
-              {showDivider && (
-                <div
-                  style={{
-                    borderTop: "1px dashed rgba(255,255,255,0.4)",
-                    margin: "8px 0",
-                    paddingTop: "8px",
-                    textAlign: "center",
-                    fontSize: "0.7rem",
-                    color: "rgba(255,255,255,0.5)",
-                  }}
-                >
-                  {currSourceFile}
-                </div>
-              )}
-              <div className="workflow-card">
+            <div key={workflow.id} className="workflow-card">
                 <div className="workflow-card__header">
                   <button
                     className="copy-button workflow-icon-button"
@@ -613,12 +589,11 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                             </button>
                           </div>
                         </div>
-                      ))
-                    )}
-                  </div>
-                )}
-              </div>
-            </React.Fragment>
+                       ))
+                     )}
+                   </div>
+                 )}
+            </div>
           );
         })}
       </div>

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -332,7 +332,6 @@ export type WorkflowDefinition = {
   enabled: boolean;
   schedule: string | null;
   shellScriptPath?: string;
-  sourceFile?: string;
   steps: WorkflowStep[];
 };
 

--- a/packages/pybackend/tests/unit/test_workflow_harness_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_harness_service.py
@@ -112,3 +112,12 @@ def test_generate_workflow_harnesses_raises_on_dry_run_failure(mock_run: Mock, t
 
     with pytest.raises(WorkflowVerificationError, match="script dry run failed"):
         generate_workflow_harnesses(sample_payload(), tmp_path)
+
+
+def test_parse_workflow_payload_rejects_source_file():
+    """Regression test for #541: sourceFile in payload must raise WorkflowParseError."""
+    payload = sample_payload()
+    payload["workflows"][0]["sourceFile"] = "workflows.yml"
+
+    with pytest.raises(WorkflowParseError, match="sourceFile"):
+        parse_workflow_payload(payload)

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import yaml
 
-from workflow_service import _normalize_payload, _normalize_workflow, _safe_workflow_filename, _workflow_paths, list_workspace_workflows, read_workflows, write_workflows
+from workflow_service import _normalize_payload, list_workspace_workflows, read_workflows, write_workflows
 
 
 def test_normalize_payload_keeps_shell_script_path():
@@ -215,278 +215,66 @@ def test_list_workspace_workflows_includes_scheduled_tasks(
 
 
 # ---------------------------------------------------------------------------
-# _workflow_paths
+# read_workflows — single-file
 # ---------------------------------------------------------------------------
 
 
-def test_workflow_paths_workflows_yml_first(tmp_path):
-    (tmp_path / "b-team.yml").write_text("workflows: []")
-    (tmp_path / "workflows.yml").write_text("workflows: []")
-    (tmp_path / "a-team.yml").write_text("workflows: []")
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
-        paths = _workflow_paths()
-
-    names = [p.name for p in paths]
-    assert names[0] == "workflows.yml"
-    assert names[1:] == sorted(names[1:])
-
-
-def test_workflow_paths_no_directory_returns_empty(tmp_path):
-    missing = tmp_path / "nonexistent"
-    with patch("workflow_service._workflow_dir", return_value=missing):
-        assert _workflow_paths() == []
-
-
-def test_workflow_paths_no_yml_files_returns_empty(tmp_path):
-    (tmp_path / "readme.md").write_text("hi")
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
-        assert _workflow_paths() == []
-
-
-# ---------------------------------------------------------------------------
-# _normalize_workflow — sourceFile passthrough
-# ---------------------------------------------------------------------------
-
-
-def test_normalize_workflow_preserves_source_file():
-    wf = {
-        "id": "wf_1",
-        "name": "Test",
-        "enabled": True,
-        "schedule": None,
-        "steps": [],
-        "sourceFile": "my-team.yml",
-    }
-    result = _normalize_workflow(wf, 0)
-    assert result is not None
-    assert result["sourceFile"] == "my-team.yml"
-
-
-def test_normalize_workflow_no_source_file_omitted():
-    wf = {"id": "wf_1", "name": "Test", "enabled": False, "schedule": None, "steps": []}
-    result = _normalize_workflow(wf, 0)
-    assert result is not None
-    assert "sourceFile" not in result
-
-
-# ---------------------------------------------------------------------------
-# read_workflows — multi-file aggregation
-# ---------------------------------------------------------------------------
-
-
-def test_read_workflows_aggregates_multiple_files(tmp_path):
+def test_read_workflows_does_not_expose_source_file(tmp_path):
+    """Regression test for #541: sourceFile must never appear in API response."""
     (tmp_path / "workflows.yml").write_text(
-        yaml.safe_dump({"workflows": [{"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": []}]})
+        yaml.safe_dump({"workflows": [{"id": "wf_1", "name": "Solo", "enabled": False, "schedule": None, "steps": []}]})
     )
-    (tmp_path / "team.yml").write_text(
-        yaml.safe_dump({"workflows": [{"id": "wf_b", "name": "B", "enabled": False, "schedule": None, "steps": []}]})
-    )
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
         result = read_workflows()
-
-    ids = [wf["id"] for wf in result["workflows"]]
-    assert "wf_a" in ids
-    assert "wf_b" in ids
-
-    sources = {wf["id"]: wf["sourceFile"] for wf in result["workflows"]}
-    assert sources["wf_a"] == "workflows.yml"
-    assert sources["wf_b"] == "team.yml"
+    assert "sourceFile" not in result["workflows"][0]
 
 
-def test_read_workflows_single_file_backward_compat(tmp_path):
+def test_read_workflows_single_file(tmp_path):
     (tmp_path / "workflows.yml").write_text(
         yaml.safe_dump({"workflows": [{"id": "wf_1", "name": "Solo", "enabled": False, "schedule": None, "steps": []}]})
     )
 
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
         result = read_workflows()
 
     assert len(result["workflows"]) == 1
     assert result["workflows"][0]["id"] == "wf_1"
-    assert result["workflows"][0]["sourceFile"] == "workflows.yml"
 
 
-def test_read_workflows_empty_directory_returns_empty(tmp_path):
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+def test_read_workflows_missing_file_returns_empty(tmp_path):
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
         result = read_workflows()
     assert result == {"workflows": []}
 
 
-def test_read_workflows_skips_malformed_file(tmp_path):
-    (tmp_path / "workflows.yml").write_text(
-        yaml.safe_dump({"workflows": [{"id": "wf_1", "name": "Good", "enabled": False, "schedule": None, "steps": []}]})
-    )
-    # Write a malformed YAML file alongside the valid one
-    (tmp_path / "bad.yml").write_text("{invalid: yaml: broken", encoding="utf-8")
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
-        result = read_workflows()
-
-    # Good workflow must still be present; malformed file is skipped
-    assert len(result["workflows"]) == 1
-    assert result["workflows"][0]["id"] == "wf_1"
-    assert result["workflows"][0]["sourceFile"] == "workflows.yml"
-
-
-def test_read_workflows_all_malformed_returns_empty(tmp_path):
+def test_read_workflows_malformed_file_returns_empty(tmp_path):
     (tmp_path / "workflows.yml").write_text(": broken yaml: [", encoding="utf-8")
-    (tmp_path / "extra.yml").write_text("also: [bad: yaml", encoding="utf-8")
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
         result = read_workflows()
-
     assert result == {"workflows": []}
 
 
 # ---------------------------------------------------------------------------
-# write_workflows — per-file write-back
+# write_workflows — single-file
 # ---------------------------------------------------------------------------
 
 
-def test_write_workflows_per_file_writeback(tmp_path):
-    payload = {
-        "workflows": [
-            {"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": [], "sourceFile": "workflows.yml"},
-            {"id": "wf_b", "name": "B", "enabled": False, "schedule": None, "steps": [], "sourceFile": "team.yml"},
-        ]
-    }
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
-        write_workflows(payload)
-
-    default_content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
-    team_content = yaml.safe_load((tmp_path / "team.yml").read_text())
-
-    assert [wf["id"] for wf in default_content["workflows"]] == ["wf_a"]
-    assert [wf["id"] for wf in team_content["workflows"]] == ["wf_b"]
-
-    # sourceFile must NOT appear in the written YAML
-    assert "sourceFile" not in default_content["workflows"][0]
-    assert "sourceFile" not in team_content["workflows"][0]
-
-
-def test_write_workflows_defaults_to_workflows_yml_when_no_source_file(tmp_path):
+def test_write_workflows_writes_to_workflows_yml(tmp_path):
     payload = {
         "workflows": [
             {"id": "wf_1", "name": "Solo", "enabled": False, "schedule": None, "steps": []},
         ]
     }
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
         write_workflows(payload)
-
     content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
     assert content["workflows"][0]["id"] == "wf_1"
-    assert not (tmp_path / "team.yml").exists()
+    assert "sourceFile" not in content["workflows"][0]
 
 
-# ---------------------------------------------------------------------------
-# _safe_workflow_filename — path traversal guard
-# ---------------------------------------------------------------------------
-
-
-def test_safe_workflow_filename_rejects_traversal():
-    assert _safe_workflow_filename("../../evil.yml") == "workflows.yml"
-    assert _safe_workflow_filename("/etc/cron.d/evil") == "workflows.yml"
-    assert _safe_workflow_filename("../sibling/hack.yml") == "workflows.yml"
-
-
-def test_safe_workflow_filename_rejects_non_yml():
-    assert _safe_workflow_filename("evil.sh") == "workflows.yml"
-    assert _safe_workflow_filename("evil.yaml") == "workflows.yml"
-
-
-def test_safe_workflow_filename_accepts_valid_names():
-    assert _safe_workflow_filename("team-a.yml") == "team-a.yml"
-    assert _safe_workflow_filename("workflows.yml") == "workflows.yml"
-    assert _safe_workflow_filename("my_workflows_2.yml") == "my_workflows_2.yml"
-
-
-def test_safe_workflow_filename_defaults_for_none_or_empty():
-    assert _safe_workflow_filename(None) == "workflows.yml"
-    assert _safe_workflow_filename("") == "workflows.yml"
-
-
-# ---------------------------------------------------------------------------
-# write_workflows — clears orphaned secondary files on delete
-# ---------------------------------------------------------------------------
-
-
-def test_write_workflows_clears_secondary_file_when_all_its_workflows_deleted(tmp_path):
-    # Pre-existing team.yml on disk
-    (tmp_path / "team.yml").write_text(
-        yaml.safe_dump({"workflows": [{"id": "wf_b", "name": "B", "enabled": False, "schedule": None, "steps": []}]})
-    )
-
-    # Payload only contains wf_a — wf_b was deleted by user
-    payload = {
-        "workflows": [
-            {"id": "wf_a", "name": "A", "enabled": False, "schedule": None, "steps": [], "sourceFile": "workflows.yml"},
-        ]
-    }
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
-        write_workflows(payload)
-
-    # team.yml must exist but be empty
-    team_content = yaml.safe_load((tmp_path / "team.yml").read_text())
-    assert team_content["workflows"] == []
-    # wf_a still in workflows.yml
-    default_content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
-    assert default_content["workflows"][0]["id"] == "wf_a"
-
-
-# ---------------------------------------------------------------------------
-# write_workflows — path traversal guard (sourceFile sanitised, not raised)
-# ---------------------------------------------------------------------------
-
-
-@patch("workflow_service._workflow_dir")
-def test_write_workflows_sanitises_path_traversal_in_source_file(mock_dir, tmp_path):
-    """_safe_workflow_filename silently maps traversal inputs to workflows.yml."""
-    mock_dir.return_value = tmp_path
-
-    payload = {
-        "workflows": [
-            {
-                "id": "wf_evil",
-                "name": "Evil",
-                "enabled": False,
-                "schedule": None,
-                "steps": [],
-                "sourceFile": "../../evil.yml",
-            }
-        ]
-    }
-
-    write_workflows(payload)
-
-    # Must NOT have created any file outside tmp_path
-    assert not (tmp_path / "../../evil.yml").exists()
-    # The workflow must have been written to the safe fallback instead
-    safe_path = tmp_path / "workflows.yml"
-    assert safe_path.exists()
-    content = yaml.safe_load(safe_path.read_text())
-    assert content["workflows"][0]["id"] == "wf_evil"
-
-
-# ---------------------------------------------------------------------------
-# write_workflows — non-workflow .yml files must never be touched
-# ---------------------------------------------------------------------------
-
-
-def test_write_workflows_does_not_overwrite_non_workflow_yml(tmp_path):
-    """A *.yml file without a top-level 'workflows' key must never be modified."""
-    original_content = {"agents": [{"name": "codex"}]}
-    (tmp_path / "agents.yml").write_text(yaml.safe_dump(original_content))
-
+def test_write_workflows_empty_payload_writes_empty_list(tmp_path):
     payload = {"workflows": []}
-
-    with patch("workflow_service._workflow_dir", return_value=tmp_path):
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
         write_workflows(payload)
-
-    # agents.yml must be completely untouched
-    result = yaml.safe_load((tmp_path / "agents.yml").read_text())
-    assert result == original_content
+    content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
+    assert content["workflows"] == []

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from typing import Any
 
@@ -22,29 +21,6 @@ def _workflow_path(repo_name: str | None = None) -> Path:
         base_path = get_made_directory()
     workflow_dir = ensure_directory(base_path / ".made") if repo_name else base_path
     return workflow_dir / "workflows.yml"
-
-
-def _workflow_dir(repo_name: str | None = None) -> Path:
-    """Return the .made directory path for global or per-repo context (does not create)."""
-    if repo_name:
-        return get_workspace_home() / repo_name / ".made"
-    return get_made_directory()
-
-
-def _workflow_paths(repo_name: str | None = None) -> list[Path]:
-    """Return ordered list of *.yml paths under the .made directory.
-
-    workflows.yml is always first for backward compatibility.
-    Remaining files are sorted alphabetically.
-    """
-    wf_dir = _workflow_dir(repo_name)
-    if not wf_dir.exists():
-        return []
-    default = wf_dir / "workflows.yml"
-    others = sorted(p for p in wf_dir.glob("*.yml") if p != default)
-    if default.exists():
-        return [default, *others]
-    return others
 
 
 def _as_string(value: Any) -> str | None:
@@ -129,10 +105,6 @@ def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
     if isinstance(max_runtime_minutes, int) and max_runtime_minutes > 0:
         normalized_workflow["maxRuntimeMinutes"] = max_runtime_minutes
 
-    source_file = _as_string(workflow.get("sourceFile"))
-    if source_file:
-        normalized_workflow["sourceFile"] = source_file
-
     return normalized_workflow
 
 
@@ -147,91 +119,31 @@ def _normalize_payload(payload: Any) -> dict[str, list[dict[str, Any]]]:
 
 
 def read_workflows(repo_name: str | None = None) -> dict[str, list[dict[str, Any]]]:
-    all_workflows: list[dict[str, Any]] = []
-    for wf_path in _workflow_paths(repo_name):
-        if not wf_path.exists():
-            continue
-        try:
-            data = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            logger.warning("Skipping malformed workflow file: %s (%s)", wf_path, exc)
-            continue
-        payload = _normalize_payload(data)
-        for wf in payload.get("workflows", []):
-            wf["sourceFile"] = wf_path.name
-            all_workflows.append(wf)
-    return {"workflows": all_workflows}
-
-
-_SAFE_FILENAME_RE = re.compile(r"^[a-zA-Z0-9_\-]+\.yml$")
-
-
-def _safe_workflow_filename(name: str | None) -> str:
-    """Return a sanitized workflow filename, defaulting to workflows.yml.
-
-    Rejects any input that contains path separators (prevents ../../ traversal)
-    and enforces the *.yml extension with an allowlist character set.
-    """
-    if not name:
-        return "workflows.yml"
-    # Reject any input containing path separators — prevents ../../ traversal
-    if "/" in name or "\\" in name:
-        return "workflows.yml"
-    if _SAFE_FILENAME_RE.match(name):
-        return name
-    return "workflows.yml"
+    wf_path = _workflow_path(repo_name)
+    if not wf_path.exists():
+        return {"workflows": []}
+    try:
+        data = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        logger.warning("Malformed workflow file: %s (%s)", wf_path, exc)
+        return {"workflows": []}
+    return _normalize_payload(data)
 
 
 def write_workflows(
     workflows_payload: dict[str, Any], repo_name: str | None = None
 ) -> dict[str, list[dict[str, Any]]]:
     normalized = _normalize_payload(workflows_payload)
-    wf_dir = _workflow_dir(repo_name)
-
-    # Group workflows by sourceFile; sanitize each filename (path traversal guard)
-    by_file: dict[str, list[dict[str, Any]]] = {}
-    for wf in normalized.get("workflows", []):
-        safe_name = _safe_workflow_filename(wf.get("sourceFile"))
-        by_file.setdefault(safe_name, []).append(wf)
-
-    # Determine complete set of files to write:
-    # - All groups from the incoming payload
-    # - Any existing *.yml files NOT in the payload → write empty list
-    #   (handles the case where all workflows were deleted from a secondary file)
-    # NOTE: Only *.yml files that contain a top-level "workflows" key are treated
-    # as workflow files and eligible for orphan-cleanup. Non-workflow YAML files
-    # (e.g. .made/agents.yml) are never read here and will never be overwritten.
-    files_to_write: dict[str, list[dict[str, Any]]] = dict(by_file)
-    if wf_dir.exists():
-        for existing_path in wf_dir.glob("*.yml"):
-            if existing_path.name not in files_to_write:
-                try:
-                    data = yaml.safe_load(existing_path.read_text(encoding="utf-8"))
-                    if isinstance(data, dict) and "workflows" in data:
-                        files_to_write[existing_path.name] = []
-                except Exception:
-                    pass  # Unreadable or non-YAML file — skip silently
-
-    if not files_to_write:
-        # No workflows and no existing files — write an empty workflows.yml
-        default_path = wf_dir / "workflows.yml"
-        ensure_directory(default_path.parent)
-        default_path.write_text(
-            yaml.safe_dump({"workflows": []}, sort_keys=False, allow_unicode=True),
-            encoding="utf-8",
-        )
-        return normalized
-
-    for filename, workflows in files_to_write.items():
-        wf_path = wf_dir / filename
-        ensure_directory(wf_path.parent)
-        # Strip sourceFile before writing — it is pipeline metadata, not YAML schema
-        cleaned = [{k: v for k, v in w.items() if k != "sourceFile"} for w in workflows]
-        wf_path.write_text(
-            yaml.safe_dump({"workflows": cleaned}, sort_keys=False, allow_unicode=True),
-            encoding="utf-8",
-        )
-
+    wf_path = _workflow_path(repo_name)
+    ensure_directory(wf_path.parent)
+    wf_path.write_text(
+        yaml.safe_dump(
+            {"workflows": normalized.get("workflows", [])},
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
     return normalized
 
 


### PR DESCRIPTION
## Summary

`sourceFile` is internal multi-file routing metadata injected by `read_workflows()` into every workflow in API responses. The frontend receives it and includes it in harness generation payloads. Pydantic's `StrictModel(extra="forbid")` in `workflow_harness_service.py` then rejects the unknown field with a 400 ValidationError — silently breaking the **Run** button for all users.

## Root Cause

`read_workflows()` iterates over all `.yml` files in the `.made` directory and injects `wf["sourceFile"] = wf_path.name` into each workflow dict before returning it via the API. The frontend `WorkflowDefinition` type accepted this field and passed it through to the harness generation endpoint, where the strict Pydantic model rejects it.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/workflow_service.py` | Removed `_workflow_dir`, `_workflow_paths`, `_SAFE_FILENAME_RE`, `_safe_workflow_filename`; stripped `sourceFile` from `_normalize_workflow`; simplified `read_workflows` and `write_workflows` to single-file |
| `packages/frontend/src/hooks/useApi.ts` | Removed `sourceFile?: string` from `WorkflowDefinition` type |
| `packages/frontend/src/components/WorkflowBuilderPanel.tsx` | Removed `sourceFile` from local type, `newWorkflow()`, and file-group divider JSX |
| `packages/pybackend/tests/unit/test_workflow_service.py` | Removed multi-file/sourceFile tests; added regression test verifying `sourceFile` is absent from API response |
| `packages/pybackend/tests/unit/test_workflow_harness_service.py` | Added regression test documenting that `sourceFile` in payload raises `WorkflowParseError` |

## Testing

- [x] Frontend ESLint passes (`npm run lint`)
- [x] Frontend TypeScript build passes (`npm run build:frontend`) — zero type errors
- [x] Backend tests updated: multi-file/sourceFile tests removed, regression tests added
- [x] Regression test: `test_read_workflows_does_not_expose_source_file` — verifies field is absent
- [x] Regression test: `test_parse_workflow_payload_rejects_source_file` — documents the root failure

## Validation

```bash
# Backend unit tests
cd packages/pybackend && uv run python -m pytest tests/unit/test_workflow_service.py tests/unit/test_workflow_harness_service.py -v

# Full QA gate
make qa-quick
```

## Issue

Fixes #541

<details>
<summary>Implementation Details</summary>

### Deviations from plan

None — implementation followed the investigation artifact exactly.

### Note on secondary .yml files

Users who had secondary workflow `.yml` files (e.g. `team.yml`) under `.made/` will no longer see those workflows in the UI after this change. This is accepted — the multi-file feature was introduced in PR #532 and immediately required two hotfixes; there is no user journey to create secondary files, and no migration is provided.

</details>

_Automated implementation from investigation comment on issue #541_