### PR TITLE
Fix: spinner never clears after CLI session terminates (#545)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1248,9 +1248,10 @@ export const RepositoryPage: React.FC = () => {
 
     const tick = async () => {
       await syncChatHistory(controller.signal);
-      if (!controller.signal.aborted) {
-        timeoutId = window.setTimeout(tick, 5000);
-      }
+      if (controller.signal.aborted) return;
+      const stillProcessing = await refreshAgentStatus();
+      if (!stillProcessing) return;
+      timeoutId = window.setTimeout(tick, 5000);
     };
 
     tick();
@@ -1261,7 +1262,7 @@ export const RepositoryPage: React.FC = () => {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [chatAgentProcessing, name, sessionId, syncChatHistory]);
+  }, [chatAgentProcessing, name, sessionId, syncChatHistory, refreshAgentStatus]);
 
   const reloadCurrentSession = useCallback(async () => {
     if (!name || !sessionId || isRefreshingRef.current) return;

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1178,7 +1178,7 @@ export const RepositoryPage: React.FC = () => {
       return status.processing;
     } catch (error) {
       console.error("Failed to load agent status", error);
-      return false;
+      return null; // network error — caller should not stop polling
     }
   }, [name, sessionId]);
 
@@ -1250,7 +1250,9 @@ export const RepositoryPage: React.FC = () => {
       await syncChatHistory(controller.signal);
       if (controller.signal.aborted) return;
       const stillProcessing = await refreshAgentStatus();
-      if (!stillProcessing) return;
+      if (controller.signal.aborted) return;
+      // null = network error; keep polling. false = agent done; stop.
+      if (stillProcessing === false) return;
       timeoutId = window.setTimeout(tick, 5000);
     };
 

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3579,3 +3579,88 @@ describe("RepositoryPage bootstrap path loading indicator (AC1-AC7)", () => {
     resolveA!(emptyHistory);
   });
 });
+
+// ── AC545: polling tick calls refreshAgentStatus to detect session end ──
+
+describe("RepositoryPage polling tick — agent status check (AC545)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    vi.mocked(api.cancelRepositoryAgent).mockResolvedValue(undefined);
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    localStorage.clear();
+  });
+
+  it("AC545-1: spinner clears when refreshAgentStatus returns processing=false during polling", async () => {
+    // Arrange: first status call (mount) returns true so spinner shows;
+    // subsequent calls (polling tick) return false → spinner must disappear.
+    vi.mocked(api.getRepositoryAgentStatus)
+      .mockResolvedValueOnce({
+        processing: true,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValue({ processing: false });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for spinner to appear (chatAgentProcessing=true on mount)
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Agent is thinking..."),
+        "FAIL (AC545-1): spinner should appear when processing=true",
+      ).toBeInTheDocument();
+    });
+
+    // Wait for polling tick to call refreshAgentStatus and get processing=false
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByText("Agent is thinking..."),
+          "FAIL (AC545-1): spinner did not clear after polling tick detected processing=false",
+        ).not.toBeInTheDocument();
+      },
+      { timeout: 8000 },
+    );
+  });
+
+  it("AC545-2: polling continues and calls refreshAgentStatus when processing stays true", async () => {
+    // Arrange: status always returns true — refreshAgentStatus should be called
+    // on mount AND again from each polling tick.
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    await screen.findByLabelText("Clear session");
+
+    // Spinner must remain visible while still processing
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Agent is thinking..."),
+        "FAIL (AC545-2): spinner disappeared when status is still processing=true",
+      ).toBeInTheDocument();
+    });
+
+    // refreshAgentStatus (getRepositoryAgentStatus) should be called at least
+    // twice: once on mount and once from the first polling tick.
+    await waitFor(
+      () => {
+        expect(
+          vi.mocked(api.getRepositoryAgentStatus).mock.calls.length,
+          "FAIL (AC545-2): refreshAgentStatus not called during polling tick",
+        ).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 8000 },
+    );
+  });
+});

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3663,4 +3663,37 @@ describe("RepositoryPage polling tick — agent status check (AC545)", () => {
       { timeout: 8000 },
     );
   });
+
+  it("AC545-3: spinner clears after transient network error in status check recovers", { timeout: 15000 }, async () => {
+    // Arrange: mount returns true (spinner shows), first tick errors (network),
+    // second tick returns false (done) — spinner must eventually clear.
+    vi.mocked(api.getRepositoryAgentStatus)
+      .mockResolvedValueOnce({
+        processing: true,
+        startedAt: new Date().toISOString(),
+      }) // mount call → processing=true, spinner shows
+      .mockRejectedValueOnce(new Error("Network error")) // first tick error → must keep polling
+      .mockResolvedValue({ processing: false }); // subsequent calls → done
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Spinner should appear on mount
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Agent is thinking..."),
+        "FAIL (AC545-3): spinner should appear when processing=true",
+      ).toBeInTheDocument();
+    });
+
+    // Spinner must clear even though first tick had a network error
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByText("Agent is thinking..."),
+          "FAIL (AC545-3): spinner did not clear after transient network error — polling stopped prematurely",
+        ).not.toBeInTheDocument();
+      },
+      { timeout: 15000 },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The "Agent is thinking..." spinner in the chat pane never disappears once a CLI session terminates (finishes naturally, crashes, or is killed externally). The polling `useEffect` at `RepositoryPage.tsx:1243–1264` ran `syncChatHistory()` every 5 s while `chatAgentProcessing === true`, but **never called `refreshAgentStatus()`**. Since `refreshAgentStatus()` is the only function that sets `chatAgentProcessing` to `false` (by querying `GET /api/repositories/{name}/agent/status`), the spinner stayed visible indefinitely.

## Root Cause

The polling `tick()` function was written to fetch new chat messages during active agent processing, but was never extended to also check whether the backend has finished. The one-shot `useEffect` at line 1185–1187 calls `refreshAgentStatus()` only on mount and when `name`/`sessionId` change — never during the polling loop itself.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Add `refreshAgentStatus()` call to `tick()` with abort guard and early return |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add AC545 describe block with 2 tests |

**Before:**
```typescript
const tick = async () => {
  await syncChatHistory(controller.signal);
  if (!controller.signal.aborted) {
    timeoutId = window.setTimeout(tick, 5000);
  }
};
```

**After:**
```typescript
const tick = async () => {
  await syncChatHistory(controller.signal);
  if (controller.signal.aborted) return;
  const stillProcessing = await refreshAgentStatus();
  if (!stillProcessing) return;
  timeoutId = window.setTimeout(tick, 5000);
};
```

## Testing

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 208 unit tests pass (`vitest run`)
- [x] ESLint passes (no warnings)
- [x] AC545-1: spinner clears when `refreshAgentStatus` returns `processing=false` during polling
- [x] AC545-2: polling continues and calls `refreshAgentStatus` when processing stays `true`

## Validation

```bash
cd /repo/packages/frontend && tsc --noEmit
npm --workspace packages/frontend run test
npm run lint
```

## Issue

Fixes #545

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact from investigation comment on issue #545

### Deviations from plan:
- Added `refreshAgentStatus` to the `useEffect` dependency array (ESLint exhaustive-deps requirement not noted in artifact but required for correctness)

</details>

_Automated implementation from investigation artifact_