### PR TITLE
fix(#546): Clear sessionLoading in effect cleanup to prevent stuck indicator

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1237,7 +1237,10 @@ export const RepositoryPage: React.FC = () => {
     setSessionLoading(true);
     const controller = new AbortController();
     syncChatHistory(controller.signal);
-    return () => controller.abort(); // No argument — preserves DOMException('AbortError') shape
+    return () => {
+      controller.abort(); // No argument — preserves DOMException('AbortError') shape
+      clearSessionLoading(); // Ensure loading state is cleared if effect is torn down before fetch completes
+    };
   }, [chatAgentProcessing, name, sessionId, syncChatHistory]);
 
   useEffect(() => {

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3697,3 +3697,124 @@ describe("RepositoryPage polling tick — agent status check (AC545)", () => {
     );
   });
 });
+
+// ── AC546: "Loading session..." clears when fetch is aborted mid-flight ──
+
+describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [sessionA, sessionB],
+    });
+    // Default: agent not processing, history empty
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    localStorage.clear();
+  });
+
+  it("AC546-1: sessionLoading clears when chatAgentProcessing flips to true while history fetch is in-flight", async () => {
+    // Arrange: history fetch is pending; status check is also pending (controlled)
+    let resolveStatus!: (value: { processing: boolean; startedAt?: string | null }) => void;
+    vi.mocked(api.getRepositoryAgentStatus).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
+
+    let resolveFetch!: (value: ChatHistoryResponse) => void;
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(
+      new Promise<ChatHistoryResponse>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderPage();
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session B"));
+
+    // Loading indicator must appear: non-polling effect fires (chatAgentProcessing=false, status pending)
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading session..."),
+        "FAIL (AC546-1): loading not visible when fetch is in-flight",
+      ).toBeInTheDocument();
+    });
+
+    // Flip chatAgentProcessing to true by resolving the pending status check
+    // This triggers the non-polling effect cleanup, which must call clearSessionLoading()
+    resolveStatus({ processing: true, startedAt: new Date().toISOString() });
+
+    // Loading must clear: cleanup fires clearSessionLoading(); new effect returns early (chatAgentProcessing guard)
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading session..."),
+        "FAIL (AC546-1): loading stuck after chatAgentProcessing flipped to true — clearSessionLoading() missing in effect cleanup",
+      ).not.toBeInTheDocument();
+    });
+
+    // Resolve the stale fetch after loading has cleared — must not re-show loading
+    resolveFetch(emptyHistory);
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(
+      screen.queryByText("Loading session..."),
+      "FAIL (AC546-1): loading reappeared after stale fetch resolved — clearSessionLoading on abort path accidentally re-triggered",
+    ).not.toBeInTheDocument();
+  });
+
+  it("AC546-2: AbortError from a session-switch cleanup does not show an error message", async () => {
+    // Arrange: first fetch is pending (manually controlled); second fetch resolves immediately
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    let rejectFirst!: (reason: DOMException) => void;
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockReturnValueOnce(
+        new Promise<ChatHistoryResponse>((_, reject) => {
+          rejectFirst = reject;
+        }),
+      )
+      .mockResolvedValueOnce(emptyHistory);
+
+    renderPage();
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session B"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading session..."),
+        "FAIL (AC546-2): loading not visible when first fetch is in-flight",
+      ).toBeInTheDocument();
+    });
+
+    // Switch to Session A — cleanup fires (clearSessionLoading + abort), new session fetch resolves
+    fireEvent.click(await screen.findByLabelText("Choose a session"));
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    // Wait for loading to settle after the switch
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading session..."),
+        "FAIL (AC546-2): loading stuck after session switch before stale AbortError",
+      ).not.toBeInTheDocument();
+    });
+
+    // Now reject the stale first fetch with AbortError (simulating native abort rejection)
+    rejectFirst(abortError);
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    // AbortError must not produce a user-visible error message
+    expect(
+      screen.queryByText("The operation was aborted"),
+      "FAIL (AC546-2): AbortError message visible — setChatError was called on AbortError path",
+    ).not.toBeInTheDocument();
+
+    // Loading must remain cleared
+    expect(
+      screen.queryByText("Loading session..."),
+      "FAIL (AC546-2): loading stuck after stale AbortError rejection",
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3727,11 +3727,16 @@ describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () =
     );
 
     let resolveFetch!: (value: ChatHistoryResponse) => void;
-    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(
-      new Promise<ChatHistoryResponse>((resolve) => {
-        resolveFetch = resolve;
-      }),
-    );
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockReturnValueOnce(
+        new Promise<ChatHistoryResponse>((resolve) => {
+          resolveFetch = resolve;
+        }),
+      )
+      // All subsequent calls (polling tick, etc.) return a never-resolving promise so that
+      // clearSessionLoading() can ONLY be reached via the effect cleanup — not via a concurrent
+      // syncChatHistory invocation that uses a fresh (non-aborted) AbortSignal.
+      .mockReturnValue(new Promise<ChatHistoryResponse>(() => {}));
 
     renderPage();
     fireEvent.click(await screen.findByLabelText("Choose a session"));
@@ -3750,6 +3755,8 @@ describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () =
     resolveStatus({ processing: true, startedAt: new Date().toISOString() });
 
     // Loading must clear: cleanup fires clearSessionLoading(); new effect returns early (chatAgentProcessing guard)
+    // Without the fix: cleanup only calls controller.abort() — loading stays true (stuck) because the
+    // polling tick's syncChatHistory is also blocked (never-resolving mock), so nothing clears loading.
     await waitFor(() => {
       expect(
         screen.queryByText("Loading session..."),


### PR DESCRIPTION
## Summary

When `chatAgentProcessing` flips to `true` while a history fetch is in-flight, React's effect cleanup fires `controller.abort()` but did not call `clearSessionLoading()`. The replacement effect immediately returns early due to its `chatAgentProcessing` guard, leaving `sessionLoading` permanently `true`. Both the "Loading session..." and "Agent is thinking..." indicators were then permanently broken.

The same stuck state can also be triggered by rapidly switching sessions before a history fetch resolves.

## Root Cause

The `clearSessionLoading()` helper was added in commit `ebbb3b5` (fix #491) but only on the happy path (line 1207) and the non-abort error path (line 1228). The effect cleanup at line 1240 only called `controller.abort()` — without clearing the loading state — leaving loading stuck when the replacement effect returned early via the `chatAgentProcessing` guard.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Add `clearSessionLoading()` to the non-polling effect cleanup so loading state is always cleared when the effect is torn down |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Added AC546-1 (chatAgentProcessing flip race) and AC546-2 (AbortError no-error-message contract) regression tests |

## Deviation from Investigation Plan

The investigation plan (Steps 1 & 2) proposed adding `clearSessionLoading()` directly to the `signal?.aborted` return path and `AbortError` catch path inside `syncChatHistory`. However, this approach broke two existing tests (AC5 and adversarial triple-switch) because:

- When a session switch occurs, the stale fetch resolves/rejects asynchronously AFTER the new session's `setSessionLoading(true)` has already run.
- Calling `clearSessionLoading()` in those async paths clears the new session's loading state, not just the stale one.

The investigation's own Step 3 ("optional belt-and-suspenders: add `clearSessionLoading()` to cleanup") is the correct and complete fix. The cleanup fires **synchronously before** the new effect's `setSessionLoading(true)`, so it correctly clears the stale loading without racing against the new session.

## Testing

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Unit tests pass — all 87 tests (85 pre-existing + 2 new AC546 regression tests)
- [x] Lint passes (`eslint`)
- [x] AC5 and adversarial triple-switch tests continue to pass (no regression)

## Validation

```bash
cd packages/frontend && npm run test -- --run src/pages/__tests__/RepositoryPage.test.tsx
```

## Issue

Fixes #546

<details>
<summary>📋 Implementation Details</summary>

### Fix location

`packages/frontend/src/pages/RepositoryPage.tsx:1240-1243` — effect cleanup for the non-polling `syncChatHistory` call.

### Deviations from plan

Investigation Steps 1 & 2 were not applied — adding `clearSessionLoading()` to the async abort paths inside `syncChatHistory` breaks AC5 and the adversarial triple-switch test. Step 3 (cleanup approach) is the correct and sufficient fix.

</details>

_Automated implementation from investigation artifact_