### PR TITLE
Fix: stabilise Virtuoso components prop and add scroll regression tests (#482)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -6,6 +6,18 @@ import { ChatMessage } from "../types/chat";
 
 const scrollToIndexMock = vi.hoisted(() => vi.fn());
 const initialTopMostItemIndexMock = vi.hoisted(() => vi.fn());
+// Captures the `followOutput` callback reference for direct invocation in tests
+const followOutputCapture = vi.hoisted(
+  (): { current: ((atBottom: boolean) => "auto" | false) | undefined } => ({
+    current: undefined,
+  }),
+);
+// Captures the `components` prop reference to assert referential stability
+const componentsCapture = vi.hoisted(
+  (): { current: { Item?: unknown; Footer?: unknown } | undefined } => ({
+    current: undefined,
+  }),
+);
 
 interface MockVirtuosoHandle {
   scrollToIndex: (location: {
@@ -23,6 +35,7 @@ interface MockVirtuosoProps {
     Footer?: ComponentType;
   };
   initialTopMostItemIndex?: number | { index: number; align?: string; behavior?: string };
+  followOutput?: (atBottom: boolean) => "auto" | false;
 }
 
 vi.mock("react-virtuoso", async () => {
@@ -30,7 +43,7 @@ vi.mock("react-virtuoso", async () => {
 
   return {
     Virtuoso: ReactModule.forwardRef<MockVirtuosoHandle, MockVirtuosoProps>(
-      function MockVirtuoso({ data, itemContent, components, initialTopMostItemIndex }, ref) {
+      function MockVirtuoso({ data, itemContent, components, initialTopMostItemIndex, followOutput }, ref) {
         ReactModule.useImperativeHandle(ref, () => ({
           scrollToIndex: scrollToIndexMock,
         }));
@@ -38,6 +51,8 @@ vi.mock("react-virtuoso", async () => {
         const Footer = components?.Footer;
 
         initialTopMostItemIndexMock(initialTopMostItemIndex);
+        followOutputCapture.current = followOutput;
+        componentsCapture.current = components;
 
         return (
           <div>
@@ -65,6 +80,8 @@ describe("ChatWindow", () => {
   beforeEach(() => {
     scrollToIndexMock.mockClear();
     initialTopMostItemIndexMock.mockClear();
+    followOutputCapture.current = undefined;
+    componentsCapture.current = undefined;
   });
 
   afterEach(() => {
@@ -550,5 +567,52 @@ describe("ChatWindow", () => {
       screen.getByText("No messages"),
       "FAIL (AC2 reg): emptyMessage not visible when both refreshing and agentProcessing are false",
     ).toBeInTheDocument();
+  });
+
+  it("followOutput returns false when user is scrolled up (no auto-scroll on streaming arrival)", () => {
+    render(
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing
+        emptyMessage="No messages"
+      />,
+    );
+
+    const cb = followOutputCapture.current;
+    expect(cb, "followOutput callback must be captured by the mock").toBeDefined();
+    // User scrolled up → Virtuoso must NOT auto-scroll
+    expect(cb!(false)).toBe(false);
+    // User is at bottom → Virtuoso may auto-scroll
+    expect(cb!(true)).toBe("auto");
+  });
+
+  it("passes a referentially stable components prop to Virtuoso across loading-spinner re-renders", () => {
+    const { rerender } = render(
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing={false}
+        sessionLoading
+        emptyMessage="No messages"
+      />,
+    );
+
+    const firstRef = componentsCapture.current;
+    expect(firstRef, "components must be captured on first render").toBeDefined();
+
+    // Toggle sessionLoading — a prop change that updates the Footer's displayed content
+    // but must NOT create a new components object reference.
+    rerender(
+      <ChatWindow
+        chat={[makeMessage()]}
+        agentProcessing={false}
+        sessionLoading={false}
+        emptyMessage="No messages"
+      />,
+    );
+
+    expect(
+      componentsCapture.current,
+      "components object reference must be stable across loading-state re-renders",
+    ).toBe(firstRef);
   });
 });

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -166,6 +166,90 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
       [markdownOptions],
     );
 
+    // Keep a ref so the stable Footer closure always reads fresh prop values
+    // without causing the `components` object reference to change.
+    const footerPropsRef = React.useRef({
+      refreshing,
+      sessionLoading,
+      agentProcessing,
+      sessionId,
+      isSessionSaved,
+      onClearSession,
+      onSaveSession,
+    });
+    footerPropsRef.current = {
+      refreshing,
+      sessionLoading,
+      agentProcessing,
+      sessionId,
+      isSessionSaved,
+      onClearSession,
+      onSaveSession,
+    };
+
+    const stableComponents = React.useMemo(
+      () => ({
+        Item: SpacedItem,
+        Footer: () => {
+          const p = footerPropsRef.current;
+          return (
+            <>
+              {p.refreshing && (
+                <div className="loading-indicator">
+                  <div className="loading-spinner"></div>
+                  <span>Refreshing...</span>
+                </div>
+              )}
+              {!p.refreshing && p.sessionLoading && (
+                <div className="loading-indicator">
+                  <div className="loading-spinner"></div>
+                  <span>Loading session...</span>
+                </div>
+              )}
+              {!p.refreshing && !p.sessionLoading && p.agentProcessing && (
+                <div className="loading-indicator">
+                  <div className="loading-spinner"></div>
+                  <span>Agent is thinking...</span>
+                </div>
+              )}
+              {p.sessionId && (
+                <div className="chat-session-id" aria-label="Session ID">
+                  <span>Session ID: {p.sessionId}</span>
+                  <button
+                    type="button"
+                    className="icon-button-small"
+                    aria-label={
+                      p.isSessionSaved ? "Session saved" : "Save session"
+                    }
+                    title={
+                      p.isSessionSaved
+                        ? "Session already saved"
+                        : "Save session"
+                    }
+                    onClick={p.onSaveSession}
+                    disabled={!p.onSaveSession || p.isSessionSaved}
+                  >
+                    <SaveIcon />
+                  </button>
+                  <button
+                    type="button"
+                    className="icon-button-small"
+                    aria-label="Clear session"
+                    title="Clear session"
+                    onClick={p.onClearSession}
+                    disabled={!p.onClearSession}
+                  >
+                    <TrashIcon />
+                  </button>
+                </div>
+              )}
+            </>
+          );
+        },
+      }),
+      [], // Created once; Footer reads latest values via footerPropsRef
+    );
+
     return (
       <div className="chat-window" ref={setChatWindowElement}>
         {chat.length > 0 && (
@@ -179,62 +263,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             customScrollParent={scrollParent ?? undefined}
             data={chat}
             itemContent={itemContent}
-            components={{
-              Item: SpacedItem,
-              Footer: () => (
-                <>
-                  {refreshing && (
-                    <div className="loading-indicator">
-                      <div className="loading-spinner"></div>
-                      <span>Refreshing...</span>
-                    </div>
-                  )}
-                  {!refreshing && sessionLoading && (
-                    <div className="loading-indicator">
-                      <div className="loading-spinner"></div>
-                      <span>Loading session...</span>
-                    </div>
-                  )}
-                  {!refreshing && !sessionLoading && agentProcessing && (
-                    <div className="loading-indicator">
-                      <div className="loading-spinner"></div>
-                      <span>Agent is thinking...</span>
-                    </div>
-                  )}
-                  {sessionId && (
-                    <div className="chat-session-id" aria-label="Session ID">
-                      <span>Session ID: {sessionId}</span>
-                      <button
-                        type="button"
-                        className="icon-button-small"
-                        aria-label={
-                          isSessionSaved ? "Session saved" : "Save session"
-                        }
-                        title={
-                          isSessionSaved
-                            ? "Session already saved"
-                            : "Save session"
-                        }
-                        onClick={onSaveSession}
-                        disabled={!onSaveSession || isSessionSaved}
-                      >
-                        <SaveIcon />
-                      </button>
-                      <button
-                        type="button"
-                        className="icon-button-small"
-                        aria-label="Clear session"
-                        title="Clear session"
-                        onClick={onClearSession}
-                        disabled={!onClearSession}
-                      >
-                        <TrashIcon />
-                      </button>
-                    </div>
-                  )}
-                </>
-              ),
-            }}
+            components={stableComponents}
             followOutput={(atBottom) => (atBottom ? "auto" : false)}
             increaseViewportBy={{ top: 300, bottom: 300 }}
             style={{ height: "auto" }}


### PR DESCRIPTION
## Summary

The `components` prop passed to Virtuoso in `ChatWindow` was an inline object literal containing an inline `Footer` arrow function. This created a new object reference on every `ChatWindow` render, risking unnecessary Virtuoso re-mounts and making referential-stability testing impossible.

## Root Cause

Two pre-existing gaps:
1. **No test for `followOutput` callback** — the sole scroll-suppression guard was never exercised; a future change to return `"smooth"` instead of `false` when scrolled up would silently break scroll UX.
2. **`components` prop reference churn** — `components={{ Item: SpacedItem, Footer: () => (...) }}` inside JSX creates a new object + new closure every render; no test could catch a regression of this stability contract.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/components/ChatWindow.tsx` | Add `footerPropsRef` (useRef) + `stableComponents` (useMemo with empty deps); replace inline `components={{}}` with `components={stableComponents}` |
| `packages/frontend/src/components/ChatWindow.test.tsx` | Add `followOutputCapture` and `componentsCapture` hoisted captures; extend `MockVirtuosoProps` with `followOutput`; capture both in mock body; reset in `beforeEach`; add 2 new regression tests |

## Testing

- [x] Lint passes (`npm run lint`)
- [x] All 27 ChatWindow tests pass (`npm test -- --run src/components/ChatWindow.test.tsx`)
- [x] Full suite passes — 218 tests across 23 files (`npm test`)

## Validation

```bash
cd packages/frontend
npm run lint
npm test -- --run src/components/ChatWindow.test.tsx
npm test
```

## Issue

Fixes #482

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from:

Issue #482 investigation comment (2026-06-25T05:11:40Z by tbrandenburg)

### Deviations from plan:

- Removed the `// eslint-disable-next-line react-hooks/exhaustive-deps` comment — the `react-hooks` ESLint plugin is not installed in this project, so any reference to the rule is itself a lint error.

</details>

_Automated implementation from investigation artifact_