### PR TITLE
Fix: syncChatHistory uses full fetch on session-load path (#481)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1187,15 +1187,16 @@ export const RepositoryPage: React.FC = () => {
   }, [refreshAgentStatus]);
 
   const syncChatHistory = useCallback(
-    async (signal?: AbortSignal) => {
+    async (signal?: AbortSignal, fullFetch?: boolean) => {
       if (!name || !sessionId) return;
       console.info("[ChatHistory] Request started");
       try {
         setChatError(null);
-        const currentTimestamp = lastKnownTimestampRef.current;
-        const startTimestamp = currentTimestamp
-          ? currentTimestamp + 1
-          : undefined;
+        const startTimestamp = fullFetch
+          ? undefined
+          : lastKnownTimestampRef.current
+            ? lastKnownTimestampRef.current + 1
+            : undefined;
         const history = await api.getRepositoryAgentHistory(
           name,
           sessionId,
@@ -1236,7 +1237,7 @@ export const RepositoryPage: React.FC = () => {
     if (chatAgentProcessing || !name || !sessionId) return;
     setSessionLoading(true);
     const controller = new AbortController();
-    syncChatHistory(controller.signal);
+    syncChatHistory(controller.signal, true);
     return () => {
       controller.abort(); // No argument — preserves DOMException('AbortError') shape
       clearSessionLoading(); // Ensure loading state is cleared if effect is torn down before fetch completes

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4054,6 +4054,10 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
   });
 
   it("AC481-3: stale localStorage timestamp does not prevent server messages from appearing", async () => {
+    // AC481-2 is omitted: after handleSessionSelect calls setChat([]), lastKnownTimestamp
+    // becomes undefined before the session-load effect fires, so the session-switch path
+    // already uses startTimestamp=undefined without the fix. The regression is specific to
+    // initial page load where setChat([]) is NOT called (covered by AC481-1 above).
     // Arrange: localStorage has a message with a far-future timestamp simulating clock skew
     // or data corruption. The mock returns real messages only for a full fetch (startTimestamp=undefined).
     // Without the fix, the incremental fetch (startTimestamp = futureTs + 1) returns empty and

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4003,3 +4003,105 @@ describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () =
     ).not.toBeInTheDocument();
   });
 });
+
+describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    localStorage.clear();
+  });
+
+  it("AC481-1: session-load calls API with startTimestamp=undefined even when localStorage has a cached timestamp", async () => {
+    // Arrange: pre-seed localStorage with BOTH the session ID and a chat message so that
+    // on initial render sessionId is non-null AND lastKnownTimestampRef.current is Tn (non-null).
+    // switchSessionIfNeeded returns early (incomingSessionId === sessionId) which means
+    // setChat([]) is NOT called — the stale timestamp persists in the ref.
+    // Without the fix, syncChatHistory would use startTimestamp = Tn + 1 (incremental fetch).
+    // With the fix, it uses startTimestamp = undefined (full fetch).
+    const cachedMessage = {
+      id: "cached-1",
+      role: "agent",
+      text: "Cached message",
+      timestamp: "2026-01-01T00:00:00.000Z",
+    };
+    // sessionStorageKey = "repository-session-test-repo-opencode" (agentCli defaults to "opencode")
+    localStorage.setItem(
+      "repository-session-test-repo-opencode",
+      "session-a",
+    );
+    localStorage.setItem(
+      "repository-chat-test-repo",
+      JSON.stringify([cachedMessage]),
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalled();
+    });
+
+    // The session-load path must use startTimestamp=undefined regardless of the cached timestamp.
+    // FAIL without fix: called with startTimestamp = Date.parse("2026-01-01T00:00:00.000Z") + 1
+    expect(
+      api.getRepositoryAgentHistory,
+      "FAIL (AC481-1): session-load used incremental startTimestamp instead of undefined (full fetch)",
+    ).toHaveBeenCalledWith("test-repo", "session-a", undefined, expect.anything());
+  });
+
+  it("AC481-3: stale localStorage timestamp does not prevent server messages from appearing", async () => {
+    // Arrange: localStorage has a message with a far-future timestamp simulating clock skew
+    // or data corruption. The mock returns real messages only for a full fetch (startTimestamp=undefined).
+    // Without the fix, the incremental fetch (startTimestamp = futureTs + 1) returns empty and
+    // the server message is never shown. With the fix, full fetch returns the server message.
+    const futureMessage = {
+      id: "future-1",
+      role: "agent",
+      text: "Corrupted cached message",
+      timestamp: "2099-01-01T00:00:00.000Z",
+    };
+    localStorage.setItem(
+      "repository-session-test-repo-opencode",
+      "session-a",
+    );
+    localStorage.setItem(
+      "repository-chat-test-repo",
+      JSON.stringify([futureMessage]),
+    );
+
+    const serverMsg: ChatHistoryMessage = {
+      role: "assistant",
+      type: "text",
+      content: "Real server message",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    // Only return server messages for a full fetch (startTimestamp=undefined).
+    // An incremental fetch (any non-undefined startTimestamp) returns empty.
+    vi.mocked(api.getRepositoryAgentHistory).mockImplementation(
+      async (_name, _sessionId, startTimestamp) => {
+        if (startTimestamp === undefined) {
+          return { sessionId: "session-a", messages: [serverMsg] };
+        }
+        return emptyHistory;
+      },
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Server message must appear because full fetch retrieved it.
+    // FAIL without fix: incremental fetch with futureTs+1 returns empty → "Real server message" missing
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByText("Real server message"),
+          "FAIL (AC481-3): server message missing — incremental fetch with stale timestamp returned empty",
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`syncChatHistory` used `lastKnownTimestampRef.current` to derive `startTimestamp` for **every** invocation, including session-load paths where the full chat history must be fetched. When localStorage contained a stale or future timestamp (due to clock skew or corruption), the incremental fetch returned an empty list. Because `setChat([])` had already been called by the session-switch path, the chat panel appeared empty even though server-side history existed.

## Root Cause

`syncChatHistory` had no way for callers to request a full fetch. The session-load `useEffect` (line 1236) always called `syncChatHistory(controller.signal)`, which computed `startTimestamp = lastKnownTimestampRef.current + 1`. The polling tick also called this function, but polling legitimately needs the incremental path.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Add optional `fullFetch?: boolean` param to `syncChatHistory`; when `true`, `startTimestamp` is forced to `undefined` |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Session-load `useEffect` passes `fullFetch=true` |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add regression tests AC481-1 and AC481-3 |

Polling tick `useEffect` is unchanged — it omits `fullFetch`, preserving incremental behaviour.

## Testing

- [x] TypeScript check passes (`tsc --noEmit`)
- [x] All 218 frontend unit tests pass
- [x] ESLint passes
- [x] AC481-1: Session-load calls API with `startTimestamp=undefined` even when localStorage has a cached timestamp
- [x] AC481-3: Server messages appear even when localStorage has a far-future (corrupted) timestamp

## Validation

```bash
# TypeScript
node_modules/.bin/tsc --noEmit -p packages/frontend/tsconfig.json

# Tests
npm run test  # from packages/frontend/

# Lint
npm run lint  # from repo root
```

## Issue

Fixes #481

<details>
<summary>Implementation Details</summary>

### Deviations from plan

None — implementation follows the investigation artifact exactly.

Steps 1–3 from the plan are implemented as specified. Tests AC481-1 and AC481-3 are added (AC481-2 was omitted: after `handleSessionSelect` calls `setChat([])`, `lastKnownTimestampRef.current` is already reset to `undefined` before the session-load effect fires, making AC481-2 not a meaningful regression target).

</details>

_Automated implementation from investigation artifact_