### PR TITLE
Fix: apply reactive session-loading pipeline to Knowledge, Constitution, Task pages (#485)

### DIFF
--- a/packages/frontend/src/hooks/useSessionLoader.ts
+++ b/packages/frontend/src/hooks/useSessionLoader.ts
@@ -1,0 +1,77 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useState } from "react";
+import type { ChatMessage } from "../types/chat";
+import type { ChatHistoryResponse } from "./useApi";
+import { mapHistoryToMessages } from "../utils/chat";
+
+export type GetHistoryFn = (
+  name: string,
+  sessionId: string,
+  signal?: AbortSignal,
+) => Promise<ChatHistoryResponse>;
+
+interface UseSessionLoaderParams {
+  name: string | undefined;
+  sessionId: string | null | undefined;
+  setChat: Dispatch<SetStateAction<ChatMessage[]>>;
+  getHistory: GetHistoryFn;
+}
+
+interface UseSessionLoaderResult {
+  sessionLoading: boolean;
+  sessionError: string | null;
+}
+
+/**
+ * Reactive hook that loads chat session history whenever name or sessionId
+ * changes. Encapsulates the loading/error state and cleanup (AbortController)
+ * so pages only need a dumb setter in handleSessionSelect.
+ *
+ * - Calls setChat([]) immediately when a new (name, sessionId) pair is seen.
+ * - Sets sessionLoading=true for the duration of the fetch.
+ * - Ignores AbortError (stale request cancelled by cleanup).
+ * - Surfaces other errors in sessionError.
+ */
+export function useSessionLoader({
+  name,
+  sessionId,
+  setChat,
+  getHistory,
+}: UseSessionLoaderParams): UseSessionLoaderResult {
+  const [sessionLoading, setSessionLoading] = useState(false);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!name || !sessionId) return;
+
+    setSessionLoading(true);
+    setSessionError(null);
+    setChat([]);
+
+    const controller = new AbortController();
+
+    getHistory(name, sessionId, controller.signal)
+      .then((history) => {
+        if (controller.signal.aborted) return;
+        setSessionLoading(false);
+        const mapped = mapHistoryToMessages(history.messages || []);
+        setChat(mapped);
+      })
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        setSessionLoading(false);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load session history";
+        setSessionError(message);
+      });
+
+    return () => {
+      controller.abort();
+      setSessionLoading(false);
+    };
+  }, [name, sessionId, getHistory, setChat]);
+
+  return { sessionLoading, sessionError };
+}

--- a/packages/frontend/src/hooks/useSessionLoader.ts
+++ b/packages/frontend/src/hooks/useSessionLoader.ts
@@ -31,6 +31,7 @@ interface UseSessionLoaderResult {
  * - Sets sessionLoading=true for the duration of the fetch.
  * - Ignores AbortError (stale request cancelled by cleanup).
  * - Surfaces other errors in sessionError.
+ * - Resets sessionError when name/sessionId becomes falsy (e.g. session clear).
  */
 export function useSessionLoader({
   name,
@@ -40,6 +41,13 @@ export function useSessionLoader({
 }: UseSessionLoaderParams): UseSessionLoaderResult {
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
+
+  // Reset error state when the session is cleared (name or sessionId goes falsy).
+  useEffect(() => {
+    if (!name || !sessionId) {
+      setSessionError(null);
+    }
+  }, [name, sessionId]);
 
   useEffect(() => {
     if (!name || !sessionId) return;

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -31,6 +31,7 @@ import {
   formatChatMessageTimestamp,
   mapHistoryToMessages,
 } from "../utils/chat";
+import { useSessionLoader } from "../hooks/useSessionLoader";
 import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 const SessionPickerModal = React.lazy(
@@ -152,6 +153,18 @@ export const ConstitutionPage: React.FC = () => {
     chatRef.current = chat;
   }, [chat]);
 
+  const getConstitutionHistory = useCallback(
+    (n: string, sid: string, signal?: AbortSignal) =>
+      api.getConstitutionAgentHistory(n, sid, undefined, signal),
+    [],
+  );
+  const { sessionLoading, sessionError } = useSessionLoader({
+    name: isExternal ? undefined : name,
+    sessionId,
+    setChat,
+    getHistory: getConstitutionHistory,
+  });
+
   const scrollToBottom = useCallback(() => {
     chatWindowRef.current?.scrollToBottom();
   }, []);
@@ -161,45 +174,18 @@ export const ConstitutionPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
-    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
       setSearchParams(nextParams, { replace: true });
     }
 
-    const switchSessionIfNeeded = async () => {
-      if (!incomingSessionId || incomingSessionId === sessionId) {
-        return;
-      }
-
+    const switchSessionIfNeeded = () => {
+      if (!incomingSessionId || incomingSessionId === sessionId) return;
       setSessionId(incomingSessionId);
-      setChat([]);
-      setChatAgentProcessing(true);
-      try {
-        const history = await api.getConstitutionAgentHistory(
-          name,
-          incomingSessionId,
-        );
-        if (cancelled) return;
-        const mapped = mapHistoryToMessages(history.messages || []);
-        setChat(mapped);
-        setAgentStatus(null);
-      } catch (error) {
-        if (cancelled) return;
-        console.error("Failed to load session history", error);
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to load session history";
-        setAgentStatus(message);
-      } finally {
-        if (!cancelled) {
-          setChatAgentProcessing(false);
-        }
-      }
+      // useSessionLoader effect handles setChat([]) + loading
     };
-    void switchSessionIfNeeded();
+    switchSessionIfNeeded();
 
     if (
       hasConsumedChatBootstrap(
@@ -227,12 +213,7 @@ export const ConstitutionPage: React.FC = () => {
       textarea?.focus();
       textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
     });
-
-    return () => {
-      cancelled = true;
-    };
   }, [
-    api,
     location.pathname,
     name,
     searchParams,
@@ -317,7 +298,7 @@ export const ConstitutionPage: React.FC = () => {
       return status.processing;
     } catch (error) {
       console.error("Failed to load agent status", error);
-      return false;
+      return null; // network error — caller should not stop polling
     }
   }, [isExternal, name, sessionId]);
 
@@ -492,28 +473,22 @@ export const ConstitutionPage: React.FC = () => {
     setClearSessionModalOpen(false);
   };
 
-  const handleSessionSelect = async (session: ChatSession) => {
+  const handleSessionSelect = (session: ChatSession) => {
     if (!name) return;
+    if (!session.id) {
+      setSessionModalOpen(false);
+      return;
+    }
+    if (session.id === sessionId) {
+      setSessionModalOpen(false);
+      reloadCurrentSession();
+      return;
+    }
     sendRequestIdRef.current += 1;
     setSessionModalOpen(false);
-    setChat([]);
+    setChatAgentProcessing(false);
+    setAgentStatus(null);
     setSessionId(session.id);
-    setChatAgentProcessing(true);
-    try {
-      const history = await api.getConstitutionAgentHistory(name, session.id);
-      const mapped = mapHistoryToMessages(history.messages || []);
-      setChat(mapped);
-      setAgentStatus(null);
-    } catch (error) {
-      console.error("Failed to load session history", error);
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Failed to load session history";
-      setAgentStatus(message);
-    } finally {
-      setChatAgentProcessing(false);
-    }
   };
 
   const reloadCurrentSession = useCallback(async () => {
@@ -521,7 +496,6 @@ export const ConstitutionPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
-    setChatAgentProcessing(true);
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
     try {
@@ -542,18 +516,10 @@ export const ConstitutionPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatAgentProcessing(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [
-    name,
-    sessionId,
-    isExternal,
-    setChat,
-    setChatAgentProcessing,
-    setAgentStatus,
-  ]);
+  }, [name, sessionId, isExternal, setChat, setAgentStatus]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;
@@ -731,6 +697,8 @@ export const ConstitutionPage: React.FC = () => {
               chat={chat}
               chatWindowRef={chatWindowRef}
               agentProcessing={chatAgentProcessing}
+              sessionLoading={sessionLoading}
+              refreshing={isRefreshing}
               emptyMessage="Start a conversation to discuss this constitution."
               sessionId={sessionId}
               onClearSession={() => setClearSessionModalOpen(true)}
@@ -740,7 +708,9 @@ export const ConstitutionPage: React.FC = () => {
               )}
               markdownOptions={chatMarkdownOptions}
             />
-            {agentStatus && <div className="alert">{agentStatus}</div>}
+            {(agentStatus || sessionError) && (
+              <div className="alert">{agentStatus ?? sessionError}</div>
+            )}
             <MentionPathTextarea
               id={chatInputId}
               value={prompt}

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -31,6 +31,7 @@ import {
   formatChatMessageTimestamp,
   mapHistoryToMessages,
 } from "../utils/chat";
+import { useSessionLoader } from "../hooks/useSessionLoader";
 import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 const SessionPickerModal = React.lazy(
@@ -150,6 +151,18 @@ export const KnowledgeArtefactPage: React.FC = () => {
     chatRef.current = chat;
   }, [chat]);
 
+  const getKnowledgeHistory = useCallback(
+    (n: string, sid: string, signal?: AbortSignal) =>
+      api.getKnowledgeAgentHistory(n, sid, undefined, signal),
+    [],
+  );
+  const { sessionLoading, sessionError } = useSessionLoader({
+    name: isExternal ? undefined : name,
+    sessionId,
+    setChat,
+    getHistory: getKnowledgeHistory,
+  });
+
   const scrollToBottom = useCallback(() => {
     chatWindowRef.current?.scrollToBottom();
   }, []);
@@ -159,45 +172,18 @@ export const KnowledgeArtefactPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
-    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
       setSearchParams(nextParams, { replace: true });
     }
 
-    const switchSessionIfNeeded = async () => {
-      if (!incomingSessionId || incomingSessionId === sessionId) {
-        return;
-      }
-
+    const switchSessionIfNeeded = () => {
+      if (!incomingSessionId || incomingSessionId === sessionId) return;
       setSessionId(incomingSessionId);
-      setChat([]);
-      setChatAgentProcessing(true);
-      try {
-        const history = await api.getKnowledgeAgentHistory(
-          name,
-          incomingSessionId,
-        );
-        if (cancelled) return;
-        const mapped = mapHistoryToMessages(history.messages || []);
-        setChat(mapped);
-        setAgentStatus(null);
-      } catch (error) {
-        if (cancelled) return;
-        console.error("Failed to load session history", error);
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to load session history";
-        setAgentStatus(message);
-      } finally {
-        if (!cancelled) {
-          setChatAgentProcessing(false);
-        }
-      }
+      // useSessionLoader effect handles setChat([]) + loading
     };
-    void switchSessionIfNeeded();
+    switchSessionIfNeeded();
 
     if (
       hasConsumedChatBootstrap(
@@ -225,12 +211,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       textarea?.focus();
       textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
     });
-
-    return () => {
-      cancelled = true;
-    };
   }, [
-    api,
     location.pathname,
     name,
     searchParams,
@@ -315,7 +296,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       return status.processing;
     } catch (error) {
       console.error("Failed to load agent status", error);
-      return false;
+      return null; // network error — caller should not stop polling
     }
   }, [isExternal, name, sessionId]);
 
@@ -490,28 +471,22 @@ export const KnowledgeArtefactPage: React.FC = () => {
     setClearSessionModalOpen(false);
   };
 
-  const handleSessionSelect = async (session: ChatSession) => {
+  const handleSessionSelect = (session: ChatSession) => {
     if (!name) return;
+    if (!session.id) {
+      setSessionModalOpen(false);
+      return;
+    }
+    if (session.id === sessionId) {
+      setSessionModalOpen(false);
+      reloadCurrentSession();
+      return;
+    }
     sendRequestIdRef.current += 1;
     setSessionModalOpen(false);
-    setChat([]);
+    setChatAgentProcessing(false);
+    setAgentStatus(null);
     setSessionId(session.id);
-    setChatAgentProcessing(true);
-    try {
-      const history = await api.getKnowledgeAgentHistory(name, session.id);
-      const mapped = mapHistoryToMessages(history.messages || []);
-      setChat(mapped);
-      setAgentStatus(null);
-    } catch (error) {
-      console.error("Failed to load session history", error);
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Failed to load session history";
-      setAgentStatus(message);
-    } finally {
-      setChatAgentProcessing(false);
-    }
   };
 
   const reloadCurrentSession = useCallback(async () => {
@@ -519,7 +494,6 @@ export const KnowledgeArtefactPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
-    setChatAgentProcessing(true);
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
     try {
@@ -537,18 +511,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatAgentProcessing(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [
-    name,
-    sessionId,
-    isExternal,
-    setChat,
-    setChatAgentProcessing,
-    setAgentStatus,
-  ]);
+  }, [name, sessionId, isExternal, setChat, setAgentStatus]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;
@@ -743,6 +709,8 @@ export const KnowledgeArtefactPage: React.FC = () => {
             chat={chat}
             chatWindowRef={chatWindowRef}
             agentProcessing={chatAgentProcessing}
+            sessionLoading={sessionLoading}
+            refreshing={isRefreshing}
             emptyMessage="Start a conversation to collaborate with agents."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}
@@ -752,7 +720,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
             )}
             markdownOptions={chatMarkdownOptions}
           />
-          {agentStatus && <div className="alert">{agentStatus}</div>}
+          {(agentStatus || sessionError) && (
+            <div className="alert">{agentStatus ?? sessionError}</div>
+          )}
           <MentionPathTextarea
             id={chatInputId}
             value={prompt}

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -31,6 +31,7 @@ import {
   formatChatMessageTimestamp,
   mapHistoryToMessages,
 } from "../utils/chat";
+import { useSessionLoader } from "../hooks/useSessionLoader";
 import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 const SessionPickerModal = React.lazy(
@@ -134,6 +135,18 @@ export const TaskPage: React.FC = () => {
     chatRef.current = chat;
   }, [chat]);
 
+  const getTaskHistory = useCallback(
+    (n: string, sid: string, signal?: AbortSignal) =>
+      api.getTaskAgentHistory(n, sid, undefined, signal),
+    [],
+  );
+  const { sessionLoading, sessionError } = useSessionLoader({
+    name,
+    sessionId,
+    setChat,
+    getHistory: getTaskHistory,
+  });
+
   const scrollToBottom = useCallback(() => {
     chatWindowRef.current?.scrollToBottom();
   }, []);
@@ -143,42 +156,18 @@ export const TaskPage: React.FC = () => {
     const { sessionId: incomingSessionId, message: incomingMessage } =
       getChatBootstrapParams(searchParams);
     if (!incomingSessionId && !incomingMessage) return;
-    let cancelled = false;
 
     const { nextParams, changed } = stripChatBootstrapParams(searchParams);
     if (changed) {
       setSearchParams(nextParams, { replace: true });
     }
 
-    const switchSessionIfNeeded = async () => {
-      if (!incomingSessionId || incomingSessionId === sessionId) {
-        return;
-      }
-
+    const switchSessionIfNeeded = () => {
+      if (!incomingSessionId || incomingSessionId === sessionId) return;
       setSessionId(incomingSessionId);
-      setChat([]);
-      setChatAgentProcessing(true);
-      try {
-        const history = await api.getTaskAgentHistory(name, incomingSessionId);
-        if (cancelled) return;
-        const mapped = mapHistoryToMessages(history.messages || []);
-        setChat(mapped);
-        setAgentStatus(null);
-      } catch (error) {
-        if (cancelled) return;
-        console.error("Failed to load session history", error);
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to load session history";
-        setAgentStatus(message);
-      } finally {
-        if (!cancelled) {
-          setChatAgentProcessing(false);
-        }
-      }
+      // useSessionLoader effect handles setChat([]) + loading
     };
-    void switchSessionIfNeeded();
+    switchSessionIfNeeded();
 
     if (
       hasConsumedChatBootstrap(
@@ -206,12 +195,7 @@ export const TaskPage: React.FC = () => {
       textarea?.focus();
       textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
     });
-
-    return () => {
-      cancelled = true;
-    };
   }, [
-    api,
     location.pathname,
     name,
     searchParams,
@@ -274,7 +258,7 @@ export const TaskPage: React.FC = () => {
       return status.processing;
     } catch (error) {
       console.error("Failed to load agent status", error);
-      return false;
+      return null; // network error — caller should not stop polling
     }
   }, [name, sessionId]);
 
@@ -425,28 +409,22 @@ export const TaskPage: React.FC = () => {
     setClearSessionModalOpen(false);
   };
 
-  const handleSessionSelect = async (session: ChatSession) => {
+  const handleSessionSelect = (session: ChatSession) => {
     if (!name) return;
+    if (!session.id) {
+      setSessionModalOpen(false);
+      return;
+    }
+    if (session.id === sessionId) {
+      setSessionModalOpen(false);
+      reloadCurrentSession();
+      return;
+    }
     sendRequestIdRef.current += 1;
     setSessionModalOpen(false);
-    setChat([]);
+    setChatAgentProcessing(false);
+    setAgentStatus(null);
     setSessionId(session.id);
-    setChatAgentProcessing(true);
-    try {
-      const history = await api.getTaskAgentHistory(name, session.id);
-      const mapped = mapHistoryToMessages(history.messages || []);
-      setChat(mapped);
-      setAgentStatus(null);
-    } catch (error) {
-      console.error("Failed to load session history", error);
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Failed to load session history";
-      setAgentStatus(message);
-    } finally {
-      setChatAgentProcessing(false);
-    }
   };
 
   const reloadCurrentSession = useCallback(async () => {
@@ -454,7 +432,6 @@ export const TaskPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
-    setChatAgentProcessing(true);
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
     try {
@@ -472,11 +449,10 @@ export const TaskPage: React.FC = () => {
           : "Failed to load session history";
       setAgentStatus(message);
     } finally {
-      setChatAgentProcessing(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, setChat, setChatAgentProcessing, setAgentStatus]);
+  }, [name, sessionId, setChat, setAgentStatus]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;
@@ -677,6 +653,8 @@ export const TaskPage: React.FC = () => {
                   chat={chat}
                   chatWindowRef={chatWindowRef}
                   agentProcessing={chatAgentProcessing}
+                  sessionLoading={sessionLoading}
+                  refreshing={isRefreshing}
                   emptyMessage="Start a conversation to discuss this task."
                   sessionId={sessionId}
                   onClearSession={() => setClearSessionModalOpen(true)}
@@ -686,7 +664,9 @@ export const TaskPage: React.FC = () => {
                   )}
                   markdownOptions={chatMarkdownOptions}
                 />
-                {agentStatus && <div className="alert">{agentStatus}</div>}
+                {(agentStatus || sessionError) && (
+                  <div className="alert">{agentStatus ?? sessionError}</div>
+                )}
                 <MentionPathTextarea
                   id={chatInputId}
                   value={prompt}

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4109,3 +4109,194 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
     );
   });
 });
+
+// ── Session selection regression: Knowledge, Constitution, Task pages ─────────
+
+function renderTaskPage(initialEntries = ["/tasks/test-task?tab=agent"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/tasks/:name/*" element={<TaskPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderKnowledgePage(
+  initialEntries = ["/knowledge/test-artefact?tab=agent"],
+) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/knowledge/:name/*" element={<KnowledgeArtefactPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderConstitutionPage(
+  initialEntries = ["/constitutions/test-constitution?tab=agent"],
+) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route
+          path="/constitutions/:name/*"
+          element={<ConstitutionPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("TaskPage session selection", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getTaskAgentHistory).mockResolvedValue(emptyHistory);
+    localStorage.clear();
+  });
+
+  it("session select triggers exactly 1 API call (not 3)", async () => {
+    vi.mocked(api.getTaskAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    renderTaskPage(["/tasks/test-task"]);
+
+    // Navigate to the agent tab (default is "content")
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    const chooseBtn = await screen.findByLabelText("Choose a session");
+    fireEvent.click(chooseBtn);
+
+    const sessionBtn = await screen.findByTitle("Session A");
+    fireEvent.click(sessionBtn);
+
+    await waitFor(() => {
+      expect(api.getTaskAgentHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("page load with ?sessionId=X triggers exactly 1 API call", async () => {
+    renderTaskPage(["/tasks/test-task?sessionId=session-b"]);
+
+    await waitFor(() => {
+      expect(api.getTaskAgentHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("re-selecting the same session triggers full refresh", async () => {
+    vi.mocked(api.getTaskAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    renderTaskPage(["/tasks/test-task"]);
+
+    // Navigate to the agent tab (default is "content")
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    const chooseBtn = await screen.findByLabelText("Choose a session");
+    fireEvent.click(chooseBtn);
+
+    const sessionBtn = await screen.findByTitle("Session A");
+    fireEvent.click(sessionBtn);
+
+    await waitFor(() => {
+      expect(api.getTaskAgentHistory).toHaveBeenCalledTimes(1);
+    });
+
+    vi.mocked(api.getTaskAgentHistory).mockClear();
+    vi.mocked(api.getTaskAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    fireEvent.click(chooseBtn);
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getTaskAgentHistory).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("KnowledgeArtefactPage session selection", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getKnowledgeAgentHistory).mockResolvedValue(emptyHistory);
+    localStorage.clear();
+  });
+
+  it("session select triggers exactly 1 API call", async () => {
+    vi.mocked(api.getKnowledgeAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    renderKnowledgePage(["/knowledge/test-artefact"]);
+
+    // Navigate to the agent tab (default is "content")
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    const chooseBtn = await screen.findByLabelText("Choose a session");
+    fireEvent.click(chooseBtn);
+
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getKnowledgeAgentHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("page load with ?sessionId=X triggers exactly 1 API call", async () => {
+    renderKnowledgePage([
+      "/knowledge/test-artefact?sessionId=session-b",
+    ]);
+
+    await waitFor(() => {
+      expect(api.getKnowledgeAgentHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("ConstitutionPage session selection", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getConstitutionAgentHistory).mockResolvedValue(emptyHistory);
+    localStorage.clear();
+  });
+
+  it("session select triggers exactly 1 API call", async () => {
+    vi.mocked(api.getConstitutionAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    renderConstitutionPage(["/constitutions/test-constitution"]);
+
+    // Navigate to the agent tab (default is "content")
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    const chooseBtn = await screen.findByLabelText("Choose a session");
+    fireEvent.click(chooseBtn);
+
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getConstitutionAgentHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("page load with ?sessionId=X triggers exactly 1 API call", async () => {
+    renderConstitutionPage([
+      "/constitutions/test-constitution?sessionId=session-b",
+    ]);
+
+    await waitFor(() => {
+      expect(api.getConstitutionAgentHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4299,4 +4299,152 @@ describe("ConstitutionPage session selection", () => {
       expect(api.getConstitutionAgentHistory).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("re-selecting the same session triggers full refresh", async () => {
+    vi.mocked(api.getConstitutionAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    renderConstitutionPage(["/constitutions/test-constitution"]);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    const chooseBtn = await screen.findByLabelText("Choose a session");
+    fireEvent.click(chooseBtn);
+
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getConstitutionAgentHistory).toHaveBeenCalledTimes(1);
+    });
+
+    vi.mocked(api.getConstitutionAgentHistory).mockClear();
+    vi.mocked(api.getConstitutionAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    fireEvent.click(chooseBtn);
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getConstitutionAgentHistory).toHaveBeenCalled();
+    });
+  });
+});
+
+// ── sessionError display tests ────────────────────────────────────────────────
+
+describe("TaskPage sessionError display", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows error alert when session history fetch fails", async () => {
+    vi.mocked(api.getTaskAgentHistory).mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    renderTaskPage(["/tasks/test-task?sessionId=session-b"]);
+
+    // Navigate to agent tab so the alert becomes visible
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network failure")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("KnowledgeArtefactPage session selection — same-session refresh", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getKnowledgeAgentHistory).mockResolvedValue(emptyHistory);
+    localStorage.clear();
+  });
+
+  it("re-selecting the same session triggers full refresh", async () => {
+    vi.mocked(api.getKnowledgeAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    renderKnowledgePage(["/knowledge/test-artefact"]);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    const chooseBtn = await screen.findByLabelText("Choose a session");
+    fireEvent.click(chooseBtn);
+
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getKnowledgeAgentHistory).toHaveBeenCalledTimes(1);
+    });
+
+    vi.mocked(api.getKnowledgeAgentHistory).mockClear();
+    vi.mocked(api.getKnowledgeAgentSessions).mockResolvedValue({
+      sessions: [sessionA],
+    });
+
+    fireEvent.click(chooseBtn);
+    fireEvent.click(await screen.findByTitle("Session A"));
+
+    await waitFor(() => {
+      expect(api.getKnowledgeAgentHistory).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("KnowledgeArtefactPage sessionError display", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows error alert when session history fetch fails", async () => {
+    vi.mocked(api.getKnowledgeAgentHistory).mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    renderKnowledgePage(["/knowledge/test-artefact?sessionId=session-b"]);
+
+    // Navigate to agent tab so the alert becomes visible
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network failure")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ConstitutionPage sessionError display", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows error alert when session history fetch fails", async () => {
+    vi.mocked(api.getConstitutionAgentHistory).mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    renderConstitutionPage([
+      "/constitutions/test-constitution?sessionId=session-b",
+    ]);
+
+    // Navigate to agent tab so the alert becomes visible
+    fireEvent.click(await screen.findByRole("button", { name: "Agent" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network failure")).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`KnowledgeArtefactPage`, `ConstitutionPage`, and `TaskPage` all loaded session history imperatively inside `handleSessionSelect`, using `setChatAgentProcessing(true)` as a loading signal while the history API call was in-flight. This conflated "agent is running" with "loading old messages", caused fragile timing issues, prevented the proper loading indicator from showing, and left the Cancel button visible during history fetches.

## Root Cause

The three pages lacked the reactive session-loading pipeline that `RepositoryPage` already has. All history loading was inlined into event handlers, making it impossible to cancel in-flight fetches, apply proper loading state, or decouple the loading indicator from agent processing.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/hooks/useSessionLoader.ts` | Created: reactive hook that fires on name/sessionId change, manages AbortController, returns `sessionLoading`/`sessionError` |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Wire hook, synchronous `handleSessionSelect`, simplify bootstrap `switchSessionIfNeeded`, remove `setChatAgentProcessing` from session loading, pass `sessionLoading`/`refreshing` to ChatWindow, fix `refreshAgentStatus` network error return |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Same as above using `getConstitutionAgentHistory` |
| `packages/frontend/src/pages/TaskPage.tsx` | Same as above (simpler: no `isExternal`) using `getTaskAgentHistory` |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Added 7 session selection regression tests for the three pages |

## Testing

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 227 unit tests pass (`npm test`)
- [x] ESLint passes (`npm run lint`)
- [x] New tests verify exactly 1 API call on session select (not 3)
- [x] New tests verify page load with `?sessionId=X` triggers exactly 1 API call
- [x] New tests verify re-selecting the same session triggers a full refresh

## Validation

```bash
cd packages/frontend
npm run lint
npm run test
```

## Issue

Fixes #485

<details>
<summary>📋 Implementation Details</summary>

### Key Design Decisions

- Used simpler `useSessionLoader` hook (KISS principle) instead of the more complex two-effect pipeline: the pages already have their own `refreshAgentStatus` polling, so the hook only needs to handle the idle-path session load
- The hook calls `setChat([])` immediately when a new (name, sessionId) pair is observed, ensuring instant visual feedback
- `handleSessionSelect` becomes a pure dispatcher (same pattern as `RepositoryPage`)
- Same-session re-select delegates to `reloadCurrentSession` which bypasses the hook and does a direct reload
- Bootstrap `switchSessionIfNeeded` simplified to synchronous: just sets `sessionId`, the hook handles the rest

### Deviations from artifact

The investigation plan described two alternative hook designs. This implementation uses the simpler interface `(name, sessionId, setChat, getHistory) → { sessionLoading, sessionError }` consistent with the KISS guideline in AGENTS.md, rather than the more complex hook that also manages polling. The polling mechanism already exists on each page and was not removed.

</details>

_Automated implementation from investigation artifact_