### PR TITLE
Fix: merge refreshAgentStatus into session-loading Effect C (#478)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1254,6 +1254,8 @@ export const RepositoryPage: React.FC = () => {
     let timeoutId: number | undefined;
 
     const tick = async () => {
+      // boolean return from syncChatHistory is intentionally ignored here:
+      // polling must still check agent status regardless of history fetch result
       await syncChatHistory(controller.signal);
       if (controller.signal.aborted) return;
       const stillProcessing = await refreshAgentStatus();

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1182,13 +1182,9 @@ export const RepositoryPage: React.FC = () => {
     }
   }, [name, sessionId]);
 
-  useEffect(() => {
-    refreshAgentStatus();
-  }, [refreshAgentStatus]);
-
   const syncChatHistory = useCallback(
-    async (signal?: AbortSignal, fullFetch?: boolean) => {
-      if (!name || !sessionId) return;
+    async (signal?: AbortSignal, fullFetch?: boolean): Promise<boolean> => {
+      if (!name || !sessionId) return false;
       console.info("[ChatHistory] Request started");
       try {
         setChatError(null);
@@ -1204,12 +1200,12 @@ export const RepositoryPage: React.FC = () => {
           signal,
         );
 
-        if (signal?.aborted) return;
+        if (signal?.aborted) return false;
         clearSessionLoading();
 
         if (!history.messages?.length) {
           console.info("[ChatHistory] Request completed with no new messages");
-          return;
+          return true;
         }
 
         setChat((previousChat) => {
@@ -1217,9 +1213,10 @@ export const RepositoryPage: React.FC = () => {
           console.info("[ChatHistory] Request completed; merge finished");
           return mergeChatMessages(previousChat, mapped);
         });
+        return true;
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
-          return;
+          return false;
         }
         console.error("Failed to load chat history", error);
         const message =
@@ -1228,6 +1225,7 @@ export const RepositoryPage: React.FC = () => {
             : "Failed to load chat history";
         clearSessionLoading();
         setChatError(message);
+        return false;
       }
     },
     [name, sessionId, setChat, setChatError],
@@ -1237,12 +1235,17 @@ export const RepositoryPage: React.FC = () => {
     if (chatAgentProcessing || !name || !sessionId) return;
     setSessionLoading(true);
     const controller = new AbortController();
-    syncChatHistory(controller.signal, true);
+    const run = async () => {
+      const ok = await syncChatHistory(controller.signal, true);
+      if (!ok || controller.signal.aborted) return;
+      await refreshAgentStatus();
+    };
+    run();
     return () => {
       controller.abort(); // No argument — preserves DOMException('AbortError') shape
       clearSessionLoading(); // Ensure loading state is cleared if effect is torn down before fetch completes
     };
-  }, [chatAgentProcessing, name, sessionId, syncChatHistory]);
+  }, [chatAgentProcessing, name, sessionId, syncChatHistory, refreshAgentStatus]);
 
   useEffect(() => {
     if (!chatAgentProcessing || !name || !sessionId) return;

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3895,60 +3895,42 @@ describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () =
     localStorage.clear();
   });
 
-  it("AC546-1: sessionLoading clears when chatAgentProcessing flips to true while history fetch is in-flight", async () => {
-    // Arrange: history fetch is pending; status check is also pending (controlled)
+  it("AC546-1 (post-478): status check runs after history resolves, not concurrently", async () => {
+    // Arrange: history resolves normally; status check is controlled
     let resolveStatus!: (value: { processing: boolean; startedAt?: string | null }) => void;
-    vi.mocked(api.getRepositoryAgentStatus).mockReturnValueOnce(
-      new Promise((resolve) => {
+    const statusPromise = new Promise<{ processing: boolean; startedAt?: string | null }>(
+      (resolve) => {
         resolveStatus = resolve;
-      }),
+      },
     );
+    vi.mocked(api.getRepositoryAgentStatus).mockReturnValueOnce(statusPromise);
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
 
-    let resolveFetch!: (value: ChatHistoryResponse) => void;
-    vi.mocked(api.getRepositoryAgentHistory)
-      .mockReturnValueOnce(
-        new Promise<ChatHistoryResponse>((resolve) => {
-          resolveFetch = resolve;
-        }),
-      )
-      // All subsequent calls (polling tick, etc.) return a never-resolving promise so that
-      // clearSessionLoading() can ONLY be reached via the effect cleanup — not via a concurrent
-      // syncChatHistory invocation that uses a fresh (non-aborted) AbortSignal.
-      .mockReturnValue(new Promise<ChatHistoryResponse>(() => {}));
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
 
-    renderPage();
-    fireEvent.click(await screen.findByLabelText("Choose a session"));
-    fireEvent.click(await screen.findByTitle("Session B"));
-
-    // Loading indicator must appear: non-polling effect fires (chatAgentProcessing=false, status pending)
+    // History resolves immediately; status check fires after.
+    // Verify history was called exactly once.
     await waitFor(() => {
-      expect(
-        screen.queryByText("Loading session..."),
-        "FAIL (AC546-1): loading not visible when fetch is in-flight",
-      ).toBeInTheDocument();
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(1);
     });
 
-    // Flip chatAgentProcessing to true by resolving the pending status check
-    // This triggers the non-polling effect cleanup, which must call clearSessionLoading()
-    resolveStatus({ processing: true, startedAt: new Date().toISOString() });
-
-    // Loading must clear: cleanup fires clearSessionLoading(); new effect returns early (chatAgentProcessing guard)
-    // Without the fix: cleanup only calls controller.abort() — loading stays true (stuck) because the
-    // polling tick's syncChatHistory is also blocked (never-resolving mock), so nothing clears loading.
+    // Status must have been dispatched after history resolved (sequential, not concurrent).
     await waitFor(() => {
       expect(
-        screen.queryByText("Loading session..."),
-        "FAIL (AC546-1): loading stuck after chatAgentProcessing flipped to true — clearSessionLoading() missing in effect cleanup",
+        api.getRepositoryAgentStatus,
+        "FAIL (AC546-1 post-478): getRepositoryAgentStatus was never called after history resolved",
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    // Resolve status as processing=false — no Cancel button expected.
+    resolveStatus({ processing: false, startedAt: null });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /cancel/i }),
+        "FAIL (AC546-1 post-478): Cancel should NOT appear when processing=false",
       ).not.toBeInTheDocument();
     });
-
-    // Resolve the stale fetch after loading has cleared — must not re-show loading
-    resolveFetch(emptyHistory);
-    await new Promise<void>((r) => setTimeout(r, 50));
-    expect(
-      screen.queryByText("Loading session..."),
-      "FAIL (AC546-1): loading reappeared after stale fetch resolved — clearSessionLoading on abort path accidentally re-triggered",
-    ).not.toBeInTheDocument();
   });
 
   it("AC546-2: AbortError from a session-switch cleanup does not show an error message", async () => {
@@ -4446,5 +4428,87 @@ describe("ConstitutionPage sessionError display", () => {
     await waitFor(() => {
       expect(screen.getByText("Network failure")).toBeInTheDocument();
     });
+  });
+});
+
+describe("RepositoryPage status check sequencing after session load (AC478)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({ sessions: [] });
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue({
+      sessionId: "session-b",
+      messages: [],
+    });
+  });
+
+  it("AC478-1: status check is not dispatched while history fetch is in-flight", async () => {
+    // Arrange: freeze history so we can observe whether status fires concurrently
+    let resolveHistory!: (v: ChatHistoryResponse) => void;
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(
+      new Promise<ChatHistoryResponse>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
+
+    // Wait for the history fetch to be in-flight
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(1);
+    });
+
+    // Status must NOT have been called while history is still pending
+    expect(
+      api.getRepositoryAgentStatus,
+      "FAIL (AC478-1): getRepositoryAgentStatus was dispatched concurrently with history fetch — standalone effect still present",
+    ).not.toHaveBeenCalled();
+
+    resolveHistory({ sessionId: "session-b", messages: [] });
+
+    // After history resolves, status SHOULD be called
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentStatus,
+        "FAIL (AC478-1): getRepositoryAgentStatus was never called after history resolved",
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("AC478-2: when status returns processing=true after history loads, Cancel button appears without history being re-fetched", async () => {
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+    // Effect C fetches history once (completes). Effect D's first polling tick
+    // immediately starts a second fetch; keep it pending to isolate the two calls.
+    vi.mocked(api.getRepositoryAgentHistory)
+      .mockResolvedValueOnce({ sessionId: "session-b", messages: [] }) // Effect C (completes)
+      .mockReturnValue(new Promise<ChatHistoryResponse>(() => {})); // Effect D tick (in-flight)
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
+
+    // Cancel button should appear after sequential status check resolves processing=true.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+        "FAIL (AC478-2): Cancel button not visible after status=processing",
+      ).toBeInTheDocument();
+    });
+
+    // Effect C fetched history exactly once (completed, not aborted).
+    // Effect D's first tick has started a second fetch (in-flight, pending).
+    // In the old concurrent race, the initial history fetch would have been
+    // aborted before the status check completed — causing a retry or lost data.
+    expect(
+      api.getRepositoryAgentHistory,
+      "FAIL (AC478-2): expected 2 history calls (1 completed by Effect C + 1 in-flight by Effect D), indicating no abort-and-retry occurred",
+    ).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4506,9 +4506,41 @@ describe("RepositoryPage status check sequencing after session load (AC478)", ()
     // Effect D's first tick has started a second fetch (in-flight, pending).
     // In the old concurrent race, the initial history fetch would have been
     // aborted before the status check completed — causing a retry or lost data.
+    // Wrap in waitFor to ensure both Effect C and Effect D have dispatched their calls.
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentHistory,
+        "FAIL (AC478-2): expected 2 history calls (1 completed by Effect C + 1 in-flight by Effect D), indicating no abort-and-retry occurred",
+      ).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("AC478-3: when history fetch fails, agent status is never checked and error message is preserved", async () => {
+    // Arrange: history rejects; status mock would clear the error if incorrectly called
+    vi.mocked(api.getRepositoryAgentHistory).mockRejectedValue(
+      new Error("History network error"),
+    );
+    // If status were called with processing=false it would invoke setChatError(null),
+    // wiping out the history error. Verify that never happens.
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
+
+    // Error message must appear
+    await waitFor(() => {
+      expect(
+        screen.getByText("History network error"),
+        "FAIL (AC478-3): error message not shown after history fetch failure",
+      ).toBeInTheDocument();
+    });
+
+    // Status must NOT have been called (ok=false from syncChatHistory gates the call)
     expect(
-      api.getRepositoryAgentHistory,
-      "FAIL (AC478-2): expected 2 history calls (1 completed by Effect C + 1 in-flight by Effect D), indicating no abort-and-retry occurred",
-    ).toHaveBeenCalledTimes(2);
+      api.getRepositoryAgentStatus,
+      "FAIL (AC478-3): getRepositoryAgentStatus was called after history failure — would clear the error message",
+    ).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

The standalone `useEffect(() => { refreshAgentStatus(); }, [refreshAgentStatus])` fired `GET /agent/status` concurrently with Effect C's history fetch. When the status response arrived first with `processing:true`, it triggered Effect C's cleanup — aborting the in-flight history fetch and clearing `sessionLoading` prematurely. Effect D would then start without a full history load.

## Root Cause

Two independent effects write to shared loading state (`chatAgentProcessing`) with no ordering guarantee. The standalone status effect could interrupt Effect C's history fetch mid-flight by causing a dep-array re-evaluation, aborting the fetch via cleanup.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Remove standalone `refreshAgentStatus` useEffect; wrap Effect C in `async run()` that calls `refreshAgentStatus` sequentially after `syncChatHistory`; give `syncChatHistory` a `boolean` return to gate the status call |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Rewrite AC546-1 for new sequential contract; add AC478-1 and AC478-2 acceptance tests |

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] All 234 unit tests pass (`vitest run`)
- [x] Lint passes (`eslint`)
- [x] AC478-1: status is not dispatched while history is in-flight
- [x] AC478-2: processing=true after history completes shows Cancel button correctly

## Deviation from plan

The investigation plan said `syncChatHistory` needed no changes. However, calling `refreshAgentStatus()` after a failed history fetch would cause `setChatError(null)` (when `processing=false`) to overwrite the history-fetch error. Adding a `boolean` return to `syncChatHistory` (true=success, false=error/abort) allows `run()` to skip the status check if history didn't load successfully — preserving the error message for the user.

## Validation

```bash
cd packages/frontend
node_modules/.bin/tsc --noEmit
node_modules/.bin/vitest run src/pages/__tests__/RepositoryPage.test.tsx --reporter=verbose
node_modules/.bin/eslint . --ext .ts,.tsx
```

## Issue

Fixes #478

<details>
<summary>📋 Implementation Details</summary>

### Steps executed:

1. Deleted standalone `refreshAgentStatus` useEffect (old lines 1185-1187)
2. Wrapped Effect C in `async run()` with sequential status check after history
3. Added `boolean` return to `syncChatHistory` to gate status call on success
4. Rewrote AC546-1 test for new sequential contract
5. Added AC478-1 and AC478-2 acceptance tests

### Deviations from plan:

- `syncChatHistory` was given a `boolean` return type (void → boolean) to prevent `refreshAgentStatus` from clearing a history-fetch error via `setChatError(null)` when `processing=false`.

</details>

_Automated implementation from investigation artifact_