### PR TITLE
Fix: replace chatAgentProcessing boolean with explicit Lifecycle state (#475)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -34,7 +34,9 @@ interface MockVirtuosoProps {
     Item?: ComponentType<React.HTMLAttributes<HTMLDivElement>>;
     Footer?: ComponentType;
   };
-  initialTopMostItemIndex?: number | { index: number; align?: string; behavior?: string };
+  initialTopMostItemIndex?:
+    | number
+    | { index: number; align?: string; behavior?: string };
   followOutput?: (atBottom: boolean) => "auto" | false;
 }
 
@@ -43,7 +45,16 @@ vi.mock("react-virtuoso", async () => {
 
   return {
     Virtuoso: ReactModule.forwardRef<MockVirtuosoHandle, MockVirtuosoProps>(
-      function MockVirtuoso({ data, itemContent, components, initialTopMostItemIndex, followOutput }, ref) {
+      function MockVirtuoso(
+        {
+          data,
+          itemContent,
+          components,
+          initialTopMostItemIndex,
+          followOutput,
+        },
+        ref,
+      ) {
         ReactModule.useImperativeHandle(ref, () => ({
           scrollToIndex: scrollToIndexMock,
         }));
@@ -579,7 +590,10 @@ describe("ChatWindow", () => {
     );
 
     const cb = followOutputCapture.current;
-    expect(cb, "followOutput callback must be captured by the mock").toBeDefined();
+    expect(
+      cb,
+      "followOutput callback must be captured by the mock",
+    ).toBeDefined();
     // User scrolled up → Virtuoso must NOT auto-scroll
     expect(cb!(false)).toBe(false);
     // User is at bottom → Virtuoso may auto-scroll
@@ -597,7 +611,10 @@ describe("ChatWindow", () => {
     );
 
     const firstRef = componentsCapture.current;
-    expect(firstRef, "components must be captured on first render").toBeDefined();
+    expect(
+      firstRef,
+      "components must be captured on first render",
+    ).toBeDefined();
 
     // Toggle sessionLoading — a prop change that updates the Footer's displayed content
     // but must NOT create a new components object reference.

--- a/packages/frontend/src/components/SessionPickerModal.tsx
+++ b/packages/frontend/src/components/SessionPickerModal.tsx
@@ -73,7 +73,11 @@ export const SessionPickerModal: React.FC<SessionPickerModalProps> = ({
   return (
     <Modal open={open} title="Choose a session" onClose={onClose}>
       {loading && (
-        <div className="loading-indicator" role="status" aria-label="Loading sessions">
+        <div
+          className="loading-indicator"
+          role="status"
+          aria-label="Loading sessions"
+        >
           <div className="loading-spinner"></div>
         </div>
       )}

--- a/packages/frontend/src/hooks/useSessionLoader.ts
+++ b/packages/frontend/src/hooks/useSessionLoader.ts
@@ -66,7 +66,8 @@ export function useSessionLoader({
         setChat(mapped);
       })
       .catch((error) => {
-        if (error instanceof DOMException && error.name === "AbortError") return;
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
         setSessionLoading(false);
         const message =
           error instanceof Error

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -389,6 +389,15 @@ const MagnifyingGlassIcon: React.FC = () => (
   </svg>
 );
 
+/** Explicit session-load and agent-streaming state machine for RepositoryPage.
+ *  - 'idle'      : no session loaded yet (initial state or after session clear)
+ *  - 'loading'   : history fetch in progress (session select / URL bootstrap / init mount)
+ *  - 'hydrated'  : session fully loaded; agent not processing
+ *  - 'streaming' : agent actively processing; polling loop is running
+ *  - 'error'     : reserved for future error-state UI (currently unused; errors surface via chatError)
+ */
+type Lifecycle = "idle" | "loading" | "hydrated" | "streaming" | "error";
+
 export const RepositoryPage: React.FC = () => {
   const { name } = useParams();
   const navigate = useNavigate();
@@ -443,7 +452,6 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedModel = selectedModel ?? "default";
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
-  type Lifecycle = "idle" | "loading" | "hydrated" | "streaming" | "error";
   const [lifecycle, setLifecycle] = useState<Lifecycle>("idle");
   const chatAgentProcessing = lifecycle === "streaming";
   const [sessionModalOpen, setSessionModalOpen] = useState(false);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -443,7 +443,9 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedModel = selectedModel ?? "default";
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
-  const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
+  type Lifecycle = "idle" | "loading" | "hydrated" | "streaming" | "error";
+  const [lifecycle, setLifecycle] = useState<Lifecycle>("idle");
+  const chatAgentProcessing = lifecycle === "streaming";
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(
@@ -608,7 +610,7 @@ export const RepositoryPage: React.FC = () => {
         return;
       }
       setChatError(null);
-      setSessionLoading(true);
+      setLifecycle("loading");
       setSessionId(incomingSessionId);
       setChat([]);
       sendRequestIdRef.current += 1;
@@ -731,14 +733,20 @@ export const RepositoryPage: React.FC = () => {
   const [movePath, setMovePath] = useState("");
   const [loadingFile, setLoadingFile] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
-  const [sessionLoading, setSessionLoading] = useState(false);
-  const clearSessionLoading = () => setSessionLoading(false);
+  const sessionLoading = lifecycle === "loading";
   const [isRefreshing, setIsRefreshing] = useState(false);
   const isRefreshingRef = useRef(false);
   const chatInputId = "repository-agent-prompt";
   const webPreviewUrl = name
     ? `/api/repositories/${encodeURIComponent(name)}/web`
     : "";
+
+  // Trigger session load when a session is available and lifecycle has not been set yet
+  useEffect(() => {
+    if (lifecycle === "idle" && name && sessionId) {
+      setLifecycle("loading");
+    }
+  }, [lifecycle, name, sessionId]);
 
   useEffect(() => {
     const search = splitMentionSearch(mentionQuery);
@@ -1160,7 +1168,7 @@ export const RepositoryPage: React.FC = () => {
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     if (!sessionId) {
-      setChatAgentProcessing(false);
+      setLifecycle("idle");
       return false;
     }
     try {
@@ -1169,7 +1177,7 @@ export const RepositoryPage: React.FC = () => {
         sessionId || undefined,
       );
       if (sessionIdRef.current !== sessionId) return false;
-      setChatAgentProcessing(status.processing);
+      setLifecycle(status.processing ? "streaming" : "hydrated");
       setChatError(
         status.processing
           ? "Agent is still processing the previous message."
@@ -1201,7 +1209,6 @@ export const RepositoryPage: React.FC = () => {
         );
 
         if (signal?.aborted) return false;
-        clearSessionLoading();
 
         if (!history.messages?.length) {
           console.info("[ChatHistory] Request completed with no new messages");
@@ -1223,7 +1230,6 @@ export const RepositoryPage: React.FC = () => {
           error instanceof Error
             ? error.message
             : "Failed to load chat history";
-        clearSessionLoading();
         setChatError(message);
         return false;
       }
@@ -1232,23 +1238,31 @@ export const RepositoryPage: React.FC = () => {
   );
 
   useEffect(() => {
-    if (chatAgentProcessing || !name || !sessionId) return;
-    setSessionLoading(true);
+    if (lifecycle !== "loading" || !name || !sessionId) return;
     const controller = new AbortController();
     const run = async () => {
       const ok = await syncChatHistory(controller.signal, true);
-      if (!ok || controller.signal.aborted) return;
+      if (controller.signal.aborted) return;
+      if (!ok) {
+        // Fetch failed (not aborted); clear loading so the error message is visible
+        setLifecycle("hydrated");
+        return;
+      }
       await refreshAgentStatus();
+      // refreshAgentStatus sets lifecycle to 'streaming' or 'hydrated' on success.
+      // Guard: if lifecycle is still 'loading' (e.g., status network error), clear it.
+      if (!controller.signal.aborted) {
+        setLifecycle((prev) => (prev === "loading" ? "hydrated" : prev));
+      }
     };
     run();
     return () => {
       controller.abort(); // No argument — preserves DOMException('AbortError') shape
-      clearSessionLoading(); // Ensure loading state is cleared if effect is torn down before fetch completes
     };
-  }, [chatAgentProcessing, name, sessionId, syncChatHistory, refreshAgentStatus]);
+  }, [lifecycle, name, sessionId, syncChatHistory, refreshAgentStatus]);
 
   useEffect(() => {
-    if (!chatAgentProcessing || !name || !sessionId) return;
+    if (lifecycle !== "streaming" || !name || !sessionId) return;
 
     const controller = new AbortController();
     let timeoutId: number | undefined;
@@ -1273,7 +1287,7 @@ export const RepositoryPage: React.FC = () => {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [chatAgentProcessing, name, sessionId, syncChatHistory, refreshAgentStatus]);
+  }, [lifecycle, name, sessionId, syncChatHistory, refreshAgentStatus]);
 
   const reloadCurrentSession = useCallback(async () => {
     if (!name || !sessionId || isRefreshingRef.current) return;
@@ -1325,7 +1339,7 @@ export const RepositoryPage: React.FC = () => {
     lastSentPromptRef.current = pendingPrompt;
     setChat((prev) => [...prev, userMessage]);
     setPendingPrompt("");
-    setChatAgentProcessing(true);
+    setLifecycle("streaming");
     try {
       const model =
         normalizedSelectedModel === "default"
@@ -1352,8 +1366,8 @@ export const RepositoryPage: React.FC = () => {
       setChatError(null);
       setActiveTab("agent");
 
-      // Keep chatAgentProcessing=true if processing (triggers existing polling)
-      if (!reply.processing) setChatAgentProcessing(false);
+      // Keep lifecycle streaming if processing (triggers polling); transition to hydrated when done
+      if (!reply.processing) setLifecycle("hydrated");
     } catch (error) {
       if (sendRequestIdRef.current !== sendRequestId) return;
       const messageText = error instanceof Error ? error.message : "";
@@ -1364,10 +1378,7 @@ export const RepositoryPage: React.FC = () => {
           : "Failed to reach agent",
       );
       console.error("Failed to send agent message", error);
-      const processing = await refreshAgentStatus();
-      if (!processing) {
-        setChatAgentProcessing(false);
-      }
+      await refreshAgentStatus();
     }
   };
 
@@ -1390,8 +1401,7 @@ export const RepositoryPage: React.FC = () => {
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    clearSessionLoading();
-    setChatAgentProcessing(false);
+    setLifecycle("idle");
     setChatError(null);
     setPendingPrompt(lastSentPromptRef.current);
     lastSentPromptRef.current = "";
@@ -1402,8 +1412,7 @@ export const RepositoryPage: React.FC = () => {
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
-    clearSessionLoading();
-    setChatAgentProcessing(false);
+    setLifecycle("idle");
     setChatError(null);
     setPendingPrompt(lastSentPromptRef.current);
     lastSentPromptRef.current = "";
@@ -1425,10 +1434,9 @@ export const RepositoryPage: React.FC = () => {
     }
     sendRequestIdRef.current += 1;
     setSessionModalOpen(false);
-    setChatAgentProcessing(false);
     setChatError(null);
     setChat([]);
-    setSessionLoading(true);
+    setLifecycle("loading");
     setSessionId(session.id);
   };
 

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3842,38 +3842,42 @@ describe("RepositoryPage polling tick — agent status check (AC545)", () => {
     );
   });
 
-  it("AC545-3: spinner clears after transient network error in status check recovers", { timeout: 15000 }, async () => {
-    // Arrange: mount returns true (spinner shows), first tick errors (network),
-    // second tick returns false (done) — spinner must eventually clear.
-    vi.mocked(api.getRepositoryAgentStatus)
-      .mockResolvedValueOnce({
-        processing: true,
-        startedAt: new Date().toISOString(),
-      }) // mount call → processing=true, spinner shows
-      .mockRejectedValueOnce(new Error("Network error")) // first tick error → must keep polling
-      .mockResolvedValue({ processing: false }); // subsequent calls → done
+  it(
+    "AC545-3: spinner clears after transient network error in status check recovers",
+    { timeout: 15000 },
+    async () => {
+      // Arrange: mount returns true (spinner shows), first tick errors (network),
+      // second tick returns false (done) — spinner must eventually clear.
+      vi.mocked(api.getRepositoryAgentStatus)
+        .mockResolvedValueOnce({
+          processing: true,
+          startedAt: new Date().toISOString(),
+        }) // mount call → processing=true, spinner shows
+        .mockRejectedValueOnce(new Error("Network error")) // first tick error → must keep polling
+        .mockResolvedValue({ processing: false }); // subsequent calls → done
 
-    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+      renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
 
-    // Spinner should appear on mount
-    await waitFor(() => {
-      expect(
-        screen.queryByText("Agent is thinking..."),
-        "FAIL (AC545-3): spinner should appear when processing=true",
-      ).toBeInTheDocument();
-    });
-
-    // Spinner must clear even though first tick had a network error
-    await waitFor(
-      () => {
+      // Spinner should appear on mount
+      await waitFor(() => {
         expect(
           screen.queryByText("Agent is thinking..."),
-          "FAIL (AC545-3): spinner did not clear after transient network error — polling stopped prematurely",
-        ).not.toBeInTheDocument();
-      },
-      { timeout: 15000 },
-    );
-  });
+          "FAIL (AC545-3): spinner should appear when processing=true",
+        ).toBeInTheDocument();
+      });
+
+      // Spinner must clear even though first tick had a network error
+      await waitFor(
+        () => {
+          expect(
+            screen.queryByText("Agent is thinking..."),
+            "FAIL (AC545-3): spinner did not clear after transient network error — polling stopped prematurely",
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 15000 },
+      );
+    },
+  );
 });
 
 // ── AC546: "Loading session..." clears when fetch is aborted mid-flight ──
@@ -3897,12 +3901,16 @@ describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () =
 
   it("AC546-1 (post-478): status check runs after history resolves, not concurrently", async () => {
     // Arrange: history resolves normally; status check is controlled
-    let resolveStatus!: (value: { processing: boolean; startedAt?: string | null }) => void;
-    const statusPromise = new Promise<{ processing: boolean; startedAt?: string | null }>(
-      (resolve) => {
-        resolveStatus = resolve;
-      },
-    );
+    let resolveStatus!: (value: {
+      processing: boolean;
+      startedAt?: string | null;
+    }) => void;
+    const statusPromise = new Promise<{
+      processing: boolean;
+      startedAt?: string | null;
+    }>((resolve) => {
+      resolveStatus = resolve;
+    });
     vi.mocked(api.getRepositoryAgentStatus).mockReturnValueOnce(statusPromise);
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
 
@@ -3935,7 +3943,10 @@ describe("RepositoryPage loading state clears on mid-flight abort (AC546)", () =
 
   it("AC546-2: AbortError from a session-switch cleanup does not show an error message", async () => {
     // Arrange: first fetch is pending (manually controlled); second fetch resolves immediately
-    const abortError = new DOMException("The operation was aborted", "AbortError");
+    const abortError = new DOMException(
+      "The operation was aborted",
+      "AbortError",
+    );
     let rejectFirst!: (reason: DOMException) => void;
     vi.mocked(api.getRepositoryAgentHistory)
       .mockReturnValueOnce(
@@ -4012,10 +4023,7 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
       timestamp: "2026-01-01T00:00:00.000Z",
     };
     // sessionStorageKey = "repository-session-test-repo-opencode" (agentCli defaults to "opencode")
-    localStorage.setItem(
-      "repository-session-test-repo-opencode",
-      "session-a",
-    );
+    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
     localStorage.setItem(
       "repository-chat-test-repo",
       JSON.stringify([cachedMessage]),
@@ -4032,7 +4040,12 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
     expect(
       api.getRepositoryAgentHistory,
       "FAIL (AC481-1): session-load used incremental startTimestamp instead of undefined (full fetch)",
-    ).toHaveBeenCalledWith("test-repo", "session-a", undefined, expect.anything());
+    ).toHaveBeenCalledWith(
+      "test-repo",
+      "session-a",
+      undefined,
+      expect.anything(),
+    );
   });
 
   it("AC481-3: stale localStorage timestamp does not prevent server messages from appearing", async () => {
@@ -4050,10 +4063,7 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
       text: "Corrupted cached message",
       timestamp: "2099-01-01T00:00:00.000Z",
     };
-    localStorage.setItem(
-      "repository-session-test-repo-opencode",
-      "session-a",
-    );
+    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
     localStorage.setItem(
       "repository-chat-test-repo",
       JSON.stringify([futureMessage]),
@@ -4122,10 +4132,7 @@ function renderConstitutionPage(
   return render(
     <MemoryRouter initialEntries={initialEntries}>
       <Routes>
-        <Route
-          path="/constitutions/:name/*"
-          element={<ConstitutionPage />}
-        />
+        <Route path="/constitutions/:name/*" element={<ConstitutionPage />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -4233,9 +4240,7 @@ describe("KnowledgeArtefactPage session selection", () => {
   });
 
   it("page load with ?sessionId=X triggers exactly 1 API call", async () => {
-    renderKnowledgePage([
-      "/knowledge/test-artefact?sessionId=session-b",
-    ]);
+    renderKnowledgePage(["/knowledge/test-artefact?sessionId=session-b"]);
 
     await waitFor(() => {
       expect(api.getKnowledgeAgentHistory).toHaveBeenCalledTimes(1);
@@ -4437,7 +4442,9 @@ describe("RepositoryPage status check sequencing after session load (AC478)", ()
     document.body.innerHTML = "";
     vi.clearAllMocks();
     localStorage.clear();
-    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({ sessions: [] });
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
     vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
       processing: false,
       startedAt: null,
@@ -4542,5 +4549,146 @@ describe("RepositoryPage status check sequencing after session load (AC478)", ()
       api.getRepositoryAgentStatus,
       "FAIL (AC478-3): getRepositoryAgentStatus was called after history failure — would clear the error message",
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe("RepositoryPage lifecycle guard semantics (issue #475)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    localStorage.clear();
+  });
+
+  it("L1: streaming→hydrated transition does NOT re-trigger a full history fetch", async () => {
+    // Setup: agent returns processing:true on first status check, then false
+    vi.mocked(api.getRepositoryAgentStatus)
+      .mockResolvedValueOnce({
+        processing: true,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValue({ processing: false, startedAt: null });
+
+    // All history fetches resolve immediately so the polling tick can complete
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for the first status check — lifecycle becomes 'streaming'
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalledTimes(1);
+    });
+
+    // lifecycle is now 'streaming'; polling loop fires.
+    // The first polling tick: history + status(processing:false) → lifecycle='hydrated'
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalledTimes(2);
+    });
+
+    // Record history call count AFTER the streaming→hydrated transition
+    const callsAfterTransition = vi.mocked(api.getRepositoryAgentHistory).mock
+      .calls.length;
+
+    // Wait a tick for any spurious Effect 1 re-runs
+    await new Promise((r) => setTimeout(r, 50));
+
+    // KEY ASSERTION: no additional full history fetches after streaming→hydrated transition
+    // Effect 1 guards on lifecycle === 'loading', so it must NOT re-fire here
+    expect(
+      vi.mocked(api.getRepositoryAgentHistory).mock.calls.length,
+      "FAIL (L1): Effect 1 re-fired after streaming ended — lifecycle guard not applied",
+    ).toBe(callsAfterTransition);
+  });
+
+  it("L2: polling loop does NOT start during session-load (lifecycle = 'loading')", async () => {
+    // Simulate slow history fetch — status check must not fire until after history resolves
+    let resolveHistory!: (value: ChatHistoryResponse) => void;
+    const historyPromise = new Promise<ChatHistoryResponse>((resolve) => {
+      resolveHistory = resolve;
+    });
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(
+      historyPromise,
+    );
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // History fetch is in-flight; status must not be called yet
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      api.getRepositoryAgentStatus,
+      "FAIL (L2): status check fired while history fetch was in-flight — polling started during 'loading'",
+    ).not.toHaveBeenCalled();
+
+    // Resolve history → now status check runs
+    resolveHistory(emptyHistory);
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("L3: send message transitions lifecycle to streaming then hydrated on completion", async () => {
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    vi.mocked(api.sendAgentMessage).mockResolvedValue({
+      messageId: "m1",
+      sent: new Date().toISOString(),
+      response: "ok",
+      sessionId: "session-a",
+      processing: false,
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for initial hydration (status check runs once after history loads)
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalled();
+    });
+
+    // Send button should be present (lifecycle = 'hydrated')
+    const sendBtn = await screen.findByRole("button", { name: /send/i });
+    expect(sendBtn).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(sendBtn);
+
+    // sendAgentMessage resolves with processing:false → lifecycle = 'hydrated' → Send visible again
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+    });
+  });
+
+  it("L4: clearSessionOnly resets lifecycle to idle (no loading spinner)", async () => {
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for hydration
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalled();
+    });
+
+    // Open and confirm clear session (clear-only, no history wipe)
+    const clearBtn = await screen.findByLabelText("Clear session");
+    fireEvent.click(clearBtn);
+    const noBtn = screen.getByRole("button", { name: /^no$/i });
+    fireEvent.click(noBtn);
+
+    // Loading spinner (session loading) must not be visible after clear
+    expect(
+      screen.queryByText(/loading session/i),
+      "FAIL (L4): session loading spinner still visible after clearSessionOnly",
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

`chatAgentProcessing: boolean` conflated two exclusive states — "agent actively streaming" and "not streaming" — while `sessionLoading: boolean` separately tracked history loading. Effect 1 (one-shot sync) guarded on `!chatAgentProcessing`, causing it to re-fire spuriously whenever streaming ended, triggering a redundant full history reload that the polling loop had already completed.

## Root Cause

A single boolean cannot distinguish "freshly loaded session awaiting first sync" from "agent just finished; polling loop already captured all messages". Both states triggered the same `!chatAgentProcessing` guard in Effect 1, causing wasteful full history reloads after every streaming cycle.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Replace two booleans with `Lifecycle` discriminated union; update all setters and effect guards |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add 4 lifecycle guard tests (L1-L4) |

**Key changes in `RepositoryPage.tsx`:**
- Add `type Lifecycle = 'idle' | 'loading' | 'hydrated' | 'streaming' | 'error'`
- `chatAgentProcessing` and `sessionLoading` preserved as derived constants (all UI bindings unchanged)
- Add `idle → loading` init effect for persisted `sessionId` on mount
- Effect 1 (one-shot sync) now guards on `lifecycle === 'loading'` — fires **only** on explicit session-load transitions, never on streaming end
- Effect 2 (polling loop) now guards on `lifecycle === 'streaming'` — fires **only** during active agent processing
- `refreshAgentStatus` transitions lifecycle to `'streaming'` or `'hydrated'`
- All lifecycle setters updated: `handleSendMessage`, `handleSessionSelect`, `handleClear*`, `switchSessionIfNeeded`
- Remove `clearSessionLoading` from `syncChatHistory`; lifecycle transitions managed by Effect 1's `run()`
- Fallback in Effect 1 clears `'loading'` if `refreshAgentStatus` encounters a network error

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] All 239 unit tests pass (including 4 new lifecycle guard tests L1-L4)
- [x] Lint passes (`eslint`)
- [x] L1: streaming→hydrated does NOT re-trigger a full history fetch
- [x] L2: polling loop does NOT start during session-load (lifecycle = 'loading')
- [x] L3: send message transitions streaming→hydrated on completion
- [x] L4: clearSessionOnly resets lifecycle to idle

## Validation

```bash
cd packages/frontend
/repo/node_modules/.bin/tsc --noEmit
/repo/node_modules/.bin/vitest run
eslint src/pages/RepositoryPage.tsx src/pages/__tests__/RepositoryPage.test.tsx
```

## Issue

Fixes #475

<details>
<summary>Implementation Details</summary>

### Deviations from plan:

- **Step 4 (Effect 1)**: Added a failure-path transition (`setLifecycle('hydrated')` when `syncChatHistory` returns `false` but not aborted) and a fallback after `refreshAgentStatus` (clears `'loading'` on network error). The plan stated "loading spinner should remain until `refreshAgentStatus` runs" but since `refreshAgentStatus` is not called in the failure path and may fail with a network error, a fallback was needed to prevent a stuck loading state — confirmed by 6 pre-existing tests.
- **L1 test**: Revised to use `mockResolvedValue(emptyHistory)` for all history calls so the polling tick can complete and trigger the second status check. The original design kept the history fetch pending, which blocked the polling tick from calling status.

</details>

_Automated implementation from investigation artifact_