### PR TITLE
Fix: Send button enabled before agent status known on page load (#559)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -453,7 +453,12 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
   const [lifecycle, setLifecycle] = useState<Lifecycle>("idle");
-  const chatAgentProcessing = lifecycle === "streaming";
+  const chatAgentProcessing: boolean | null =
+    lifecycle === "streaming"
+      ? true
+      : lifecycle === "loading" || (lifecycle === "idle" && !!sessionId)
+        ? null
+        : false;
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(
@@ -2006,7 +2011,7 @@ export const RepositoryPage: React.FC = () => {
                   onClick={reloadCurrentSession}
                   aria-label="Refresh current session"
                   title="Refresh current session"
-                  disabled={chatAgentProcessing || isRefreshing}
+                  disabled={chatAgentProcessing !== false || isRefreshing}
                 >
                   <RefreshIcon />
                 </button>
@@ -2042,7 +2047,7 @@ export const RepositoryPage: React.FC = () => {
           <ChatWindow
             chat={chat}
             chatWindowRef={chatWindowRef}
-            agentProcessing={chatAgentProcessing}
+            agentProcessing={chatAgentProcessing === true}
             refreshing={isRefreshing}
             sessionLoading={sessionLoading}
             emptyMessage="No conversation yet."
@@ -2070,7 +2075,7 @@ export const RepositoryPage: React.FC = () => {
                 selectId="agent-select"
                 selectedAgent={normalizedSelectedAgent}
                 onChange={setSelectedAgent}
-                disabled={chatAgentProcessing}
+                disabled={chatAgentProcessing !== false}
                 repositoryName={name || undefined}
               />
               <label className="model-select" htmlFor="agent-model-select">
@@ -2078,7 +2083,7 @@ export const RepositoryPage: React.FC = () => {
                   id="agent-model-select"
                   value={normalizedSelectedModel}
                   onChange={(event) => setSelectedModel(event.target.value)}
-                  disabled={chatAgentProcessing}
+                  disabled={chatAgentProcessing !== false}
                   aria-label="Model"
                 >
                   {MODEL_OPTIONS.map((option) => (
@@ -2102,7 +2107,7 @@ export const RepositoryPage: React.FC = () => {
                 <button
                   className="primary"
                   onClick={() => handleSendMessage()}
-                  disabled={!pendingPrompt.trim()}
+                  disabled={!pendingPrompt.trim() || chatAgentProcessing === null}
                 >
                   Send
                 </button>

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1295,15 +1295,21 @@ describe("RepositoryPage reload current session (AC1-AC7)", () => {
   // ── AC6: concurrent-fetch guard (Refresh button path) ───────────
 
   it("AC6-REFRESH: 3 rapid Refresh clicks → exactly 1 API call (fails: button missing or guard)", async () => {
+    // Initial load uses beforeEach's resolving mock so lifecycle reaches 'hydrated'
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for full hydration so chatAgentProcessing = false and Refresh is enabled
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalled();
+    });
+
+    // Now set up never-resolving history mock for the rapid-click scenario
     let resolveFetch!: (value: ChatHistoryResponse) => void;
     vi.mocked(api.getRepositoryAgentHistory).mockReturnValue(
       new Promise<ChatHistoryResponse>((resolve) => {
         resolveFetch = resolve;
       }),
     );
-
-    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
-    await screen.findByLabelText("Clear session");
 
     const refreshBtn = await screen.findByLabelText("Refresh current session");
 
@@ -1587,15 +1593,21 @@ describe("RepositoryPage adversarial — stale-closure data integrity", () => {
   });
 
   it("I1 (ADV-5): ChatWindow shows 'Refreshing...' instead of 'Agent is thinking...' during refresh", async () => {
+    // Initial load uses beforeEach's resolving mock so lifecycle reaches 'hydrated'
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for full hydration so chatAgentProcessing = false and Refresh is enabled
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalled();
+    });
+
+    // Now set up never-resolving history mock for the Refresh click
     let resolveFetch!: (value: ChatHistoryResponse) => void;
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(
       new Promise<ChatHistoryResponse>((resolve) => {
         resolveFetch = resolve;
       }),
     );
-
-    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
-    await screen.findByLabelText("Clear session");
 
     vi.mocked(api.getRepositoryAgentHistory).mockClear();
     const refreshBtn = await screen.findByLabelText("Refresh current session");
@@ -4690,5 +4702,125 @@ describe("RepositoryPage lifecycle guard semantics (issue #475)", () => {
       screen.queryByText(/loading session/i),
       "FAIL (L4): session loading spinner still visible after clearSessionOnly",
     ).not.toBeInTheDocument();
+  });
+});
+
+// ── AC559: Send button disabled when agent status unknown on page load ──────
+describe("RepositoryPage Send button disabled during status-unknown state (AC559)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    vi.mocked(api.cancelRepositoryAgent).mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  it("AC559-1: Send disabled during initial load when agent is processing", async () => {
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(textarea, { target: { value: "test" } });
+
+    // Send button must be disabled while status is unknown (lifecycle = 'loading')
+    const sendBtn = screen.getByRole("button", { name: /send/i });
+    expect(
+      sendBtn,
+      "FAIL (AC559-1a): Send button should be disabled during initial status check",
+    ).toBeDisabled();
+
+    // After status resolves to processing=true, Cancel appears
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+        "FAIL (AC559-1b): Cancel should appear after status resolves to processing=true",
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("AC559-2: Send disabled during initial load when agent is not processing, then enabled", async () => {
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(textarea, { target: { value: "test" } });
+
+    // Send button must be disabled while status is unknown (lifecycle = 'loading')
+    expect(
+      screen.getByRole("button", { name: /send/i }),
+      "FAIL (AC559-2a): Send button should be disabled during initial status check",
+    ).toBeDisabled();
+
+    // After status resolves to processing=false, Send becomes enabled
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /send/i }),
+        "FAIL (AC559-2b): Send should be enabled after status resolves to processing=false",
+      ).not.toBeDisabled();
+    });
+  });
+
+  it("AC559-3: Send button enabled immediately when no session exists", async () => {
+    // No sessionId — lifecycle stays 'idle' without a session, chatAgentProcessing = false
+    renderPage(["/repositories/test-repo?tab=agent"]);
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(textarea, { target: { value: "test" } });
+
+    // No session means no pending status check; Send should be enabled immediately
+    expect(
+      screen.getByRole("button", { name: /send/i }),
+      "FAIL (AC559-3): Send should be enabled when there is no session",
+    ).not.toBeDisabled();
+  });
+
+  it("AC559-4: AgentSelector and Model select disabled during unknown state, enabled after idle resolves", async () => {
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Both selects must be disabled while status is unknown
+    expect(
+      screen.getByLabelText("Agent"),
+      "FAIL (AC559-4a): Agent selector should be disabled during initial status check",
+    ).toBeDisabled();
+
+    expect(
+      screen.getByLabelText("Model"),
+      "FAIL (AC559-4b): Model selector should be disabled during initial status check",
+    ).toBeDisabled();
+
+    // After status resolves to idle, both should be enabled
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Agent"),
+        "FAIL (AC559-4c): Agent selector should be enabled after status resolves to idle",
+      ).not.toBeDisabled();
+    });
+    expect(
+      screen.getByLabelText("Model"),
+      "FAIL (AC559-4d): Model selector should be enabled after status resolves to idle",
+    ).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

When the page loads (or refreshes) with a `sessionId` in localStorage, `chatAgentProcessing` was derived as `lifecycle === "streaming"`. During the `"idle"` and `"loading"` lifecycle phases — before `refreshAgentStatus()` resolves — this evaluated to `false`, incorrectly signalling "agent idle". The user could click Send and fire a duplicate message into a mid-run session, causing a 409 conflict error.

## Root Cause

Commit `eeeced5` (#558) replaced `useState<boolean>(false)` with a derived boolean: `const chatAgentProcessing = lifecycle === "streaming"`. A boolean cannot represent the third state (unknown/pending). Both `"idle"` (with a `sessionId`) and `"loading"` mean "status unknown", not "agent idle".

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Line 456: derivation changed to `boolean \| null` tri-state |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Line 2009: Refresh button `disabled={chatAgentProcessing !== false \|\| isRefreshing}` |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Line 2045: ChatWindow prop `agentProcessing={chatAgentProcessing === true}` |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Line 2073: AgentSelector `disabled={chatAgentProcessing !== false}` |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Line 2081: Model select `disabled={chatAgentProcessing !== false}` |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Line 2105: Send button `disabled={!pendingPrompt.trim() \|\| chatAgentProcessing === null}` |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Added 4 AC559 tests for tri-state behavior |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Updated AC6-REFRESH and I1 tests (Refresh button now correctly disabled during loading) |

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] All 117 unit tests pass (113 original + 4 new AC559 tests)
- [x] Lint passes (`eslint`)

## Validation

```bash
cd packages/frontend && node_modules/.bin/tsc --noEmit
npm test -- --run src/pages/__tests__/RepositoryPage.test.tsx
npm run lint
```

## Issue

Fixes #559

<details>
<summary>Implementation Details</summary>

### Tri-state derivation

```typescript
const chatAgentProcessing: boolean | null =
  lifecycle === "streaming"
    ? true
    : lifecycle === "loading" || (lifecycle === "idle" && !!sessionId)
      ? null
      : false;
```

- `true` — agent known processing (`"streaming"`)
- `null` — status unknown (`"loading"` or `"idle"` with a sessionId)
- `false` — agent known idle (`"hydrated"` or `"idle"` without sessionId)

### Deviation from plan

AC6-REFRESH and I1 pre-existing tests were updated beyond what the plan specified. Both tests set up a never-resolving history mock before rendering, leaving the page in `"loading"` state. With the Refresh button now correctly disabled during loading, these tests were restructured to hydrate the page first (wait for `getRepositoryAgentStatus` to be called) and then test the Refresh button behavior after hydration. This preserves the original test intent while matching the corrected behavior.

</details>

_Automated implementation from investigation artifact (.agents/issues/issue-559.md)_