### PR TITLE
Fix: optimistic Cancel restores Send button immediately (#562)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1392,7 +1392,7 @@ export const RepositoryPage: React.FC = () => {
 
   const handleCancelAgent = () => {
     if (!name) return;
-    // Optimistic update: flip to idle immediately so Send button renders on the next frame
+    // Optimistic update: flip to hydrated immediately so Send button renders on the next frame
     setLifecycle("hydrated");
     api
       .cancelRepositoryAgent(name, sessionId || undefined)

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1390,16 +1390,19 @@ export const RepositoryPage: React.FC = () => {
     }
   };
 
-  const handleCancelAgent = async () => {
+  const handleCancelAgent = () => {
     if (!name) return;
-    try {
-      await api.cancelRepositoryAgent(name, sessionId || undefined);
-    } catch (error) {
-      console.error("Failed to cancel agent request", error);
-      setChatError("Unable to cancel the agent request.");
-    } finally {
-      await refreshAgentStatus();
-    }
+    // Optimistic update: flip to idle immediately so Send button renders on the next frame
+    setLifecycle("hydrated");
+    api
+      .cancelRepositoryAgent(name, sessionId || undefined)
+      .catch((error) => {
+        console.error("Failed to cancel agent request", error);
+        setChatError("Unable to cancel the agent request.");
+      })
+      .finally(() => {
+        refreshAgentStatus();
+      });
   };
 
   const handleCancelClearSession = () => {

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4805,5 +4805,13 @@ describe("issue #562: handleCancelAgent optimistic update", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
     });
+
+    // Error message must appear — the .catch() path in handleCancelAgent fires setChatError
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unable to cancel the agent request."),
+        "Error message must appear after cancel API failure (.catch() path)",
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4692,3 +4692,118 @@ describe("RepositoryPage lifecycle guard semantics (issue #475)", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+// ── Issue #562: optimistic Cancel ──────────────────────────────────────────
+describe("issue #562: handleCancelAgent optimistic update", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    vi.mocked(api.cancelRepositoryAgent).mockResolvedValue(undefined);
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    localStorage.clear();
+  });
+
+  it("562-1: Send button appears immediately on Cancel click before cancel API resolves", async () => {
+    // sendAgentMessage never resolves so lifecycle stays streaming after Send
+    vi.mocked(api.sendAgentMessage).mockReturnValue(
+      new Promise<AgentReply>(() => {}),
+    );
+    // getRepositoryAgentStatus never resolves → polling never flips lifecycle back to hydrated
+    vi.mocked(api.getRepositoryAgentStatus).mockReturnValue(
+      new Promise(() => {}),
+    );
+    // cancelRepositoryAgent never resolves — the critical test condition
+    let resolveCancel!: () => void;
+    vi.mocked(api.cancelRepositoryAgent).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveCancel = resolve;
+      }),
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+    await screen.findByLabelText("Clear session");
+
+    // Enter streaming state by sending a message
+    const textarea = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    // Cancel button should appear (lifecycle = streaming)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+        "Cancel button should appear when lifecycle=streaming",
+      ).toBeInTheDocument();
+    });
+
+    // Act: click Cancel while cancel API is still pending (never resolves)
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Assert: Send appears immediately (optimistic update, before cancel API resolves)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /send/i }),
+        "Send button must appear immediately via optimistic update",
+      ).toBeInTheDocument();
+    });
+
+    // Cancel button must be gone
+    expect(
+      screen.queryByRole("button", { name: /cancel/i }),
+      "Cancel button must disappear after optimistic update",
+    ).not.toBeInTheDocument();
+
+    // API must have been called
+    expect(api.cancelRepositoryAgent).toHaveBeenCalled();
+
+    // Cleanup — resolve so no lingering unhandled promise
+    resolveCancel();
+  });
+
+  it("562-2: cancel API failure still shows Send button (optimistic update fired before rejection)", async () => {
+    // sendAgentMessage never resolves so lifecycle stays streaming
+    vi.mocked(api.sendAgentMessage).mockReturnValue(
+      new Promise<AgentReply>(() => {}),
+    );
+    // getRepositoryAgentStatus never resolves → polling doesn't interfere
+    vi.mocked(api.getRepositoryAgentStatus).mockReturnValue(
+      new Promise(() => {}),
+    );
+    // cancelRepositoryAgent rejects — simulates network failure
+    vi.mocked(api.cancelRepositoryAgent).mockRejectedValue(
+      new Error("network failure"),
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+    await screen.findByLabelText("Clear session");
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Send still appears (optimistic setLifecycle("hydrated") fired before the rejection)
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`handleCancelAgent` awaited two sequential network calls before yielding, blocking React from re-rendering with the Send button until both the cancel POST and a `refreshAgentStatus` GET completed — typically 200–500 ms of visible lag after the user clicks Cancel.

## Root Cause

`handleCancelAgent` was declared `async` and used `await` on both `api.cancelRepositoryAgent(...)` and `refreshAgentStatus()` inside a `finally` block. `chatAgentProcessing` is derived from `lifecycle === "streaming"`, and `setLifecycle` was only called inside `refreshAgentStatus()`. With no early state update, React could not re-render until the entire async function settled.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Remove `async/await`; add synchronous `setLifecycle("hydrated")` as first side-effect; fire cancel + status reconciliation as background work |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add test block `issue #562` with 2 cases verifying the optimistic update |

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] All 241 unit tests pass (`npm run test --workspace=packages/frontend -- --run`)
- [x] Lint passes (`npm run lint --workspace=packages/frontend`)
- [x] 562-1: Send button appears before cancel API resolves (never-resolving mock)
- [x] 562-2: Send button appears even when cancel API rejects

## Validation

```bash
npm run test --workspace=packages/frontend -- --run
npm run lint --workspace=packages/frontend
```

## Issue

Fixes #562

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact from issue #562 investigation comment

### Deviations from plan:

Test approach uses never-resolving `getRepositoryAgentStatus` mock (instead of relying on `processing: true` return value) to prevent the streaming-polling effect from flipping lifecycle back to hydrated before the test can observe the Cancel button. Functionally equivalent — the tests verify the same behaviour.

</details>

_Automated implementation following investigation artifact_