### PR TITLE
Fix: remove false-positive error banner from refreshAgentStatus (#560)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1191,11 +1191,8 @@ export const RepositoryPage: React.FC = () => {
       );
       if (sessionIdRef.current !== sessionId) return false;
       setLifecycle(status.processing ? "streaming" : "hydrated");
-      setChatError(
-        status.processing
-          ? "Agent is still processing the previous message."
-          : null,
-      );
+      // No error — agent running is a normal state, not a user-facing error.
+      // chatError is set exclusively by handleSendMessage's catch block (HTTP 409 conflict).
       return status.processing;
     } catch (error) {
       console.error("Failed to load agent status", error);

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4956,3 +4956,76 @@ describe("issue #562: handleCancelAgent optimistic update", () => {
     });
   });
 });
+
+// ── AC560: refreshAgentStatus must NOT set chatError ──────────────────────────
+
+describe("RepositoryPage refreshAgentStatus does not set chatError (AC560)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    vi.mocked(api.cancelRepositoryAgent).mockResolvedValue(undefined);
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+    localStorage.clear();
+  });
+
+  it("AC560-1: no error banner on page load when agent is processing", async () => {
+    // Arrange: status returns processing:true on mount (agent already running)
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for the Cancel button to appear (lifecycle correctly set to streaming)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+        "FAIL (AC560-1): Cancel button should appear when processing=true",
+      ).toBeInTheDocument();
+    });
+
+    // Error banner must NOT appear — agent being busy is a normal state, not an error
+    expect(
+      document.querySelectorAll(".alert").length,
+      "FAIL (AC560-1): error banner appeared on page load with processing=true — setChatError must be removed from refreshAgentStatus",
+    ).toBe(0);
+  });
+
+  it("AC560-2: no error banner after cancel when agent is still processing", async () => {
+    // Arrange: status always returns processing:true (simulate agent still running after cancel)
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: true,
+      startedAt: new Date().toISOString(),
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for Cancel button to appear
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Click Cancel
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Allow the cancel + refreshAgentStatus finally block to resolve
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+    // Error banner must NOT appear after cancel + status poll
+    expect(
+      document.querySelectorAll(".alert").length,
+      "FAIL (AC560-2): error banner appeared after cancel when processing=true — setChatError must be removed from refreshAgentStatus",
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`refreshAgentStatus()` unconditionally wrote to `chatError` based on the polling result, showing "Agent is still processing the previous message." on page load, session switch, and after cancel — situations where the user did nothing wrong and the agent is simply running normally.

## Root Cause

The `setChatError(...)` block at `RepositoryPage.tsx:1194-1198` ran inside `refreshAgentStatus()`, which is called from:
- The session-loading `useEffect` (fires on every page load and session switch)
- The polling-tick `useEffect` (fires repeatedly while agent is running)
- `handleCancelAgent`'s `.finally()` block (fires after every cancel)

The genuine conflict error (HTTP 409) is already set correctly and exclusively by `handleSendMessage`'s catch block — that is the only place `chatError` should ever be set.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Remove 5-line `setChatError(...)` block from `refreshAgentStatus()` |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add AC560 describe block with 2 tests asserting no error banner on page load or after cancel when `processing:true` |

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] All 121 unit tests pass (including 2 new AC560 tests)
- [x] Lint passes (`eslint`)
- [x] AC560-1: no error banner on page load when agent is processing
- [x] AC560-2: no error banner after cancel when agent is still processing

## Validation

```bash
node_modules/.bin/tsc --project packages/frontend/tsconfig.json --noEmit
node_modules/.bin/vitest run packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
node_modules/.bin/eslint --config packages/frontend/eslint.config.js packages/frontend/src/pages/RepositoryPage.tsx
```

## Issue

Fixes #560

<details>
<summary>📋 Implementation Details</summary>

### Deviations from plan:

None — implemented exactly as specified in the investigation comment.

</details>

_Automated implementation from investigation artifact_