### PR TITLE
Fix: add container_id validation to stop_container() to close argument injection vector (#570)

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -19,12 +19,15 @@ from urllib.parse import quote
 
 from uvicorn.config import LOGGING_CONFIG
 
+from typing import Annotated
+
 from fastapi import (
     Body,
     FastAPI,
     File,
     Form,
     HTTPException,
+    Path as PathParam,
     Query,
     Request,
     UploadFile,
@@ -1056,7 +1059,11 @@ def list_docker_containers():
 
 
 @app.post("/api/docker-containers/{container_id}/stop")
-def stop_docker_container(container_id: str):
+def stop_docker_container(
+    container_id: Annotated[
+        str, PathParam(pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]{0,127}$")
+    ],
+):
     try:
         logger.info("Stopping Docker container id=%s", container_id)
         success = stop_container(container_id)

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -15,11 +15,10 @@ import termios
 import tempfile
 from copy import deepcopy
 from pathlib import Path
+from typing import Annotated
 from urllib.parse import quote
 
 from uvicorn.config import LOGGING_CONFIG
-
-from typing import Annotated
 
 from fastapi import (
     Body,
@@ -49,7 +48,7 @@ from agent_service import (
     send_agent_message,
     terminate_agent_process,
 )
-from docker_service import list_running_containers, stop_container
+from docker_service import CONTAINER_ID_PATTERN, list_running_containers, stop_container
 from constitution_service import (
     delete_constitution,
     list_constitutions,
@@ -1061,7 +1060,7 @@ def list_docker_containers():
 @app.post("/api/docker-containers/{container_id}/stop")
 def stop_docker_container(
     container_id: Annotated[
-        str, PathParam(pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]{0,127}$")
+        str, PathParam(pattern=CONTAINER_ID_PATTERN)
     ],
 ):
     try:

--- a/packages/pybackend/docker_service.py
+++ b/packages/pybackend/docker_service.py
@@ -1,9 +1,12 @@
 import json
 import logging
+import re
 import subprocess
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_CONTAINER_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]{0,127}$")
 
 
 def list_running_containers() -> list[dict[str, Any]]:
@@ -44,6 +47,9 @@ def list_running_containers() -> list[dict[str, Any]]:
 
 def stop_container(container_id: str) -> bool:
     """Stop a running container; returns True on success."""
+    if not _CONTAINER_ID_RE.fullmatch(container_id):
+        logger.warning("Rejecting invalid container_id: %r", container_id)
+        return False
     try:
         result = subprocess.run(
             ["docker", "stop", container_id],

--- a/packages/pybackend/docker_service.py
+++ b/packages/pybackend/docker_service.py
@@ -6,7 +6,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_CONTAINER_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]{0,127}$")
+_CONTAINER_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+CONTAINER_ID_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$"
 
 
 def list_running_containers() -> list[dict[str, Any]]:

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -218,6 +218,33 @@ class TestDockerContainersEndpoint:
 
         assert response.status_code == 404
 
+    @patch("app.stop_container")
+    def test_stop_docker_container_invalid_id_flag_injection(self, mock_stop):
+        """A container_id like --time=0 should be rejected with 422."""
+        response = client.post("/api/docker-containers/--time=0/stop")
+
+        assert response.status_code == 422
+        mock_stop.assert_not_called()
+
+    @patch("app.stop_container")
+    def test_stop_docker_container_invalid_id_special_chars(self, mock_stop):
+        """A container_id containing semicolons/spaces is rejected with 422."""
+        response = client.post("/api/docker-containers/abc;rm%20-rf/stop")
+
+        assert response.status_code == 422
+        mock_stop.assert_not_called()
+
+    @patch("app.stop_container")
+    def test_stop_docker_container_valid_full_id_accepted(self, mock_stop):
+        """A 64-char hex container_id passes validation and reaches the handler."""
+        mock_stop.return_value = True
+        full_id = "a" * 64
+
+        response = client.post(f"/api/docker-containers/{full_id}/stop")
+
+        assert response.status_code == 200
+        mock_stop.assert_called_once_with(full_id)
+
 
 class TestChatHistoryEndpoint:
     @patch("app.export_chat_history")

--- a/packages/pybackend/tests/unit/test_docker_service.py
+++ b/packages/pybackend/tests/unit/test_docker_service.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from docker_service import list_running_containers
+from docker_service import list_running_containers, stop_container
 
 
 class TestListRunningContainers:
@@ -95,3 +95,70 @@ class TestListRunningContainers:
         assert c["status"] == "Up 1 hour"
         assert c["ports"] == "6379/tcp"
         assert c["names"] == "my-redis"
+
+
+class TestStopContainer:
+    @patch("docker_service.subprocess.run")
+    def test_stop_valid_container_success(self, mock_run):
+        """Valid container_id returns True when docker stop succeeds."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = stop_container("abc123def456")
+
+        assert result is True
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        assert call_args == ["docker", "stop", "abc123def456"]
+
+    @patch("docker_service.subprocess.run")
+    def test_stop_invalid_id_starting_with_dash(self, mock_run):
+        """container_id starting with '--' is rejected before subprocess call."""
+        result = stop_container("--time=0")
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    @patch("docker_service.subprocess.run")
+    def test_stop_empty_container_id(self, mock_run):
+        """Empty string is rejected before subprocess call."""
+        result = stop_container("")
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    @patch("docker_service.subprocess.run")
+    def test_stop_container_id_with_special_chars(self, mock_run):
+        """container_id with shell special chars is rejected."""
+        result = stop_container("abc;rm -rf /")
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    @patch("docker_service.subprocess.run")
+    def test_stop_container_not_found(self, mock_run):
+        """Returns False when docker stop exits non-zero."""
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result = stop_container("abc123")
+
+        assert result is False
+
+    @patch("docker_service.subprocess.run")
+    def test_stop_container_subprocess_error(self, mock_run):
+        """Returns False on SubprocessError."""
+        mock_run.side_effect = subprocess.SubprocessError("timeout")
+
+        result = stop_container("abc123")
+
+        assert result is False
+
+    @patch("docker_service.subprocess.run")
+    def test_stop_container_full_64char_id(self, mock_run):
+        """Full 64-char hex container ID is accepted."""
+        full_id = "a" * 64
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = stop_container(full_id)
+
+        assert result is True
+        mock_run.assert_called_once()


### PR DESCRIPTION
## Summary

`stop_container()` in `docker_service.py` passes its `container_id` argument directly into a `subprocess.run` argument list with no format validation. A crafted HTTP request to `POST /api/docker-containers/--time=0/stop` sets `container_id = "--time=0"`, causing Docker to interpret it as a CLI flag (`--time`) rather than a container name. While `shell=False` eliminates shell injection, argument injection into the Docker CLI remains possible and could produce unintended side-effects with current or future Docker flags.

## Root Cause

No input validation exists on `container_id` at either the route layer or the service layer. Any string that survives URL parsing reaches the Docker subprocess unchanged.

- `docker_service.py:48-49`: `["docker", "stop", container_id]` — no guard before subprocess
- `app.py:1058-1059`: `container_id: str` — no Pydantic pattern constraint on path parameter

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/docker_service.py` | Added `import re`, `_CONTAINER_ID_RE` regex constant, and format guard at top of `stop_container()` |
| `packages/pybackend/app.py` | Added `from typing import Annotated`, `Path as PathParam` to fastapi imports, applied `Annotated[str, PathParam(pattern=...)]` to route parameter |
| `packages/pybackend/tests/unit/test_docker_service.py` | Added `TestStopContainer` class with 7 unit tests covering valid IDs, flag injection, empty string, special chars, subprocess errors |
| `packages/pybackend/tests/unit/test_api.py` | Added 3 test cases to `TestDockerContainersEndpoint`: flag injection rejected (422), special chars rejected (422), valid 64-char ID accepted (200) |

## Testing

- [x] Unit tests pass (20/20 Docker-related tests)
- [x] Full QA gate passes (442 passed, 1 skipped)
- [x] Lint passes (`ruff check` clean)

## Validation

```bash
cd packages/pybackend && uv run python -m pytest tests/unit/test_docker_service.py tests/unit/test_api.py::TestDockerContainersEndpoint -v
cd packages/pybackend && uv run ruff check docker_service.py app.py
make qa-quick
```

## Deviation from Plan

The plan used `from fastapi import Path`, but `pathlib.Path` is already imported at module level in `app.py`. To avoid name collision, FastAPI's `Path` is imported as `PathParam`. Functionally identical.

## Issue

Fixes #570

_Automated implementation from investigation artifact_