### PR TITLE
Fix: add skeleton placeholders to eliminate CLS 0.66 (#434)

### DIFF
--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -32,12 +32,18 @@ interface SidebarProps {
 
 export const Sidebar: React.FC<SidebarProps> = ({ open, onNavigate }) => {
   const [version, setVersion] = useState<string>("");
+  const [versionLoaded, setVersionLoaded] = useState(false);
 
   useEffect(() => {
     fetch("/api/version")
       .then((res) => res.json())
-      .then((data: { version: string }) => setVersion(data.version))
-      .catch(() => setVersion(""));
+      .then((data: { version: string }) => {
+        setVersion(data.version);
+        setVersionLoaded(true);
+      })
+      .catch(() => {
+        setVersionLoaded(true);
+      });
   }, []);
 
   return (
@@ -62,7 +68,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ open, onNavigate }) => {
           );
         })}
       </ul>
-      {version && <div className="sidebar-version">v{version}</div>}
+      <div className="sidebar-version-placeholder">
+        {!versionLoaded ? (
+          <div className="sidebar-version-skeleton" />
+        ) : version ? (
+          <div className="sidebar-version">v{version}</div>
+        ) : null}
+      </div>
     </nav>
   );
 };

--- a/packages/frontend/src/components/Skeleton.test.tsx
+++ b/packages/frontend/src/components/Skeleton.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("renders with skeleton class", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass("skeleton");
+  });
+
+  it("applies custom width and height via style", () => {
+    const { container } = render(<Skeleton width="5rem" height="1rem" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe("5rem");
+    expect(el.style.height).toBe("1rem");
+  });
+
+  it("is hidden from assistive technology", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("appends extra className", () => {
+    const { container } = render(<Skeleton className="skeleton-badge" />);
+    expect(container.firstChild).toHaveClass("skeleton");
+    expect(container.firstChild).toHaveClass("skeleton-badge");
+  });
+});

--- a/packages/frontend/src/components/Skeleton.tsx
+++ b/packages/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Generic skeleton placeholder that reserves layout space during async loads.
+ * Use the higher-level CSS skeleton classes (e.g. .file-tree-skeleton) for
+ * complex multi-element patterns; use this component for simple single-element
+ * placeholders.
+ */
+export const Skeleton: React.FC<SkeletonProps> = ({
+  width,
+  height,
+  borderRadius,
+  className = "",
+  style,
+}) => (
+  <span
+    className={`skeleton ${className}`}
+    style={{
+      width,
+      height,
+      borderRadius,
+      ...style,
+    }}
+    aria-hidden="true"
+  />
+);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -405,7 +405,9 @@ export const RepositoryPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("agent");
   const [searchParams, setSearchParams] = useSearchParams();
   const [repository, setRepository] = useState<RepositorySummary | null>(null);
+  const [repositoryLoading, setRepositoryLoading] = useState(true);
   const [fileTree, setFileTree] = useState<FileNode | null>(null);
+  const [fileTreeLoading, setFileTreeLoading] = useState(true);
   const [fileActionError, setFileActionError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(["."]));
   const agentCli = useAgentCli();
@@ -843,16 +845,20 @@ export const RepositoryPage: React.FC = () => {
       navigate("/repositories");
       return;
     }
+    setRepositoryLoading(true);
+    setFileTreeLoading(true);
     api
       .getRepository(name)
       .then(setRepository)
       .catch((error) => {
         console.error("Failed to load repository", error);
-      });
+      })
+      .finally(() => setRepositoryLoading(false));
     api
       .getRepositoryFiles(name, ".")
       .then((tree) => setFileTree(tree))
-      .catch((error) => console.error("Failed to load file tree", error));
+      .catch((error) => console.error("Failed to load file tree", error))
+      .finally(() => setFileTreeLoading(false));
   }, [name, navigate]);
 
   const loadCommands = useCallback(() => {
@@ -2119,29 +2125,33 @@ export const RepositoryPage: React.FC = () => {
         </Panel>
       ),
     },
-    ...(repository?.hasGit
-      ? [
-          {
-            id: "git",
-            label: "Git",
-            content: (
-              <Suspense fallback={<div className="loading-spinner" />}>
-                <GitTab
-                  status={gitStatus}
-                  loading={gitStatusLoading}
-                  error={gitStatusError}
-                  pulling={pullingRepository}
-                  creatingWorktree={creatingWorktree}
-                  onRefresh={loadGitStatus}
-                  onPull={handleGitPull}
-                  onCreateWorktree={handleCreateWorktree}
-                  onOpenFile={openFile}
-                />
-              </Suspense>
-            ),
-          },
-        ]
-      : []),
+    {
+      id: "git",
+      label: "Git",
+      content: repositoryLoading ? (
+        <div className="loading-grid-skeleton">
+          <div className="skeleton skeleton-card" />
+          <div className="skeleton skeleton-card" />
+          <div className="skeleton skeleton-card" />
+        </div>
+      ) : repository?.hasGit ? (
+        <Suspense fallback={<div className="loading-spinner" />}>
+          <GitTab
+            status={gitStatus}
+            loading={gitStatusLoading}
+            error={gitStatusError}
+            pulling={pullingRepository}
+            creatingWorktree={creatingWorktree}
+            onRefresh={loadGitStatus}
+            onPull={handleGitPull}
+            onCreateWorktree={handleCreateWorktree}
+            onOpenFile={openFile}
+          />
+        </Suspense>
+      ) : (
+        <div className="empty">No Git repository found.</div>
+      ),
+    },
     {
       id: "harnesses",
       label: "Harnesses",
@@ -2178,7 +2188,11 @@ export const RepositoryPage: React.FC = () => {
               }
             >
               {harnessLoading && (
-                <div className="alert">Loading harnesses...</div>
+                <div className="loading-grid-skeleton">
+                  {[1, 2, 3].map((i) => (
+                    <div className="skeleton skeleton-card" key={i} />
+                  ))}
+                </div>
               )}
               {harnessError && (
                 <div className="alert error">{harnessError}</div>
@@ -2287,7 +2301,19 @@ export const RepositoryPage: React.FC = () => {
         >
           {todoError && <div className="alert error">{todoError}</div>}
           {todoLoading ? (
-            <div className="alert">Loading todos...</div>
+            <div className="file-browser">
+              <div className="file-tree-skeleton">
+                {[1, 2, 3].map((i) => (
+                  <div className="skeleton-row" key={i}>
+                    <div className="skeleton skeleton-icon" />
+                    <div
+                      className="skeleton skeleton-name"
+                      style={{ width: `${45 + i * 15}%` }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
           ) : (
             <div className="file-browser">
               {todos.length === 0 ? (
@@ -2373,7 +2399,19 @@ export const RepositoryPage: React.FC = () => {
               {fileActionError && (
                 <div className="alert error">{fileActionError}</div>
               )}
-              {fileTree ? (
+              {fileTreeLoading ? (
+                <div className="file-tree-skeleton">
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <div className="skeleton-row" key={i}>
+                      <div className="skeleton skeleton-icon" />
+                      <div
+                        className="skeleton skeleton-name"
+                        style={{ width: `${50 + i * 9}%` }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : fileTree ? (
                 renderNode(fileTree)
               ) : (
                 <div className="empty">No files found.</div>
@@ -2640,7 +2678,11 @@ export const RepositoryPage: React.FC = () => {
             }
           >
             {commandsLoading && (
-              <div className="alert">Loading commands...</div>
+              <div className="loading-grid-skeleton">
+                {[1, 2, 3].map((i) => (
+                  <div className="skeleton skeleton-card" key={i} />
+                ))}
+              </div>
             )}
             {commandsError && (
               <div className="alert error">{commandsError}</div>
@@ -2725,7 +2767,13 @@ export const RepositoryPage: React.FC = () => {
   return (
     <div className="page">
       <h1>Repository: {name}</h1>
-      {repository && (
+      {repositoryLoading ? (
+        <div className="repository-meta-skeleton">
+          <div className="skeleton skeleton-badge" />
+          <div className="skeleton skeleton-badge" />
+          <div className="skeleton skeleton-badge" />
+        </div>
+      ) : repository ? (
         <div className="repository-meta">
           <span className="badge">{repository.technology}</span>
           <span className="badge">{repository.license}</span>
@@ -2738,7 +2786,7 @@ export const RepositoryPage: React.FC = () => {
             <span className="badge">{repository.branch}</span>
           )}
         </div>
-      )}
+      ) : null}
       <TabView
         tabs={tabs}
         activeTab={activeTab}

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -5029,3 +5029,52 @@ describe("RepositoryPage refreshAgentStatus does not set chatError (AC560)", () 
     ).toBe(0);
   });
 });
+
+describe("RepositoryPage skeleton states", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue({
+      sessionId: "",
+      messages: [],
+    });
+    localStorage.clear();
+  });
+
+  it("shows repository-meta skeleton while repository loads", () => {
+    // api.getRepository returns a never-resolving promise so loading stays true
+    vi.mocked(api.getRepository).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(
+      document.querySelector(".repository-meta-skeleton"),
+      "FAIL: .repository-meta-skeleton not found during load",
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(".repository-meta"),
+      "FAIL: .repository-meta should not be present during load",
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows file-tree skeleton while fileTree loads", () => {
+    vi.mocked(api.getRepositoryFiles).mockReturnValue(new Promise(() => {}));
+    renderPage(["/repositories/test-repo?tab=files"]);
+    expect(
+      document.querySelector(".file-tree-skeleton"),
+      "FAIL: .file-tree-skeleton not found during load",
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No files found."),
+      "FAIL: 'No files found.' must not appear during load",
+    ).not.toBeInTheDocument();
+  });
+
+  it("Git tab is always present in the tab bar before repository loads", () => {
+    vi.mocked(api.getRepository).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /git/i }),
+      "FAIL: Git tab button not rendered before repository loads",
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -585,3 +585,78 @@
 .nested-folder-panel {
   margin-left: 1rem;
 }
+
+/* ── Skeleton loading placeholders ─────────────────────────── */
+@keyframes skeleton-pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
+.skeleton {
+  background: var(--border);
+  border-radius: 0.5rem;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+  display: block;
+}
+
+/* Repository metadata badge row */
+.repository-meta-skeleton {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  min-height: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+.repository-meta-skeleton .skeleton-badge {
+  width: 5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+}
+
+/* File tree skeleton rows */
+.file-tree-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+}
+.file-tree-skeleton .skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+}
+.file-tree-skeleton .skeleton-icon {
+  width: 1rem;
+  height: 1rem;
+  min-width: 1rem;
+  border-radius: 0.25rem;
+}
+.file-tree-skeleton .skeleton-name {
+  height: 1rem;
+  border-radius: 0.25rem;
+}
+
+/* Card grid skeleton (commands, harnesses, git) */
+.loading-grid-skeleton {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+.loading-grid-skeleton .skeleton-card {
+  height: 3.5rem;
+  border-radius: 0.9rem;
+}

--- a/packages/frontend/src/styles/sidebar.css
+++ b/packages/frontend/src/styles/sidebar.css
@@ -76,6 +76,13 @@
   min-height: 1.3rem;
   padding-top: 0.5rem;
 }
+/* skeleton-pulse defined here for isolated rendering (e.g. tests/Storybook);
+   the canonical definition lives in page.css */
+@keyframes skeleton-pulse {
+  0%   { opacity: 1; }
+  50%  { opacity: 0.4; }
+  100% { opacity: 1; }
+}
 .sidebar-version-skeleton {
   height: 0.9rem;
   width: 3.5rem;
@@ -83,4 +90,7 @@
   background: var(--border);
   border-radius: 0.25rem;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-version-skeleton { animation: none; }
 }

--- a/packages/frontend/src/styles/sidebar.css
+++ b/packages/frontend/src/styles/sidebar.css
@@ -67,7 +67,20 @@
   font-size: 0.7rem;
   text-align: center;
   color: var(--muted);
-  margin-top: auto;
   margin-bottom: 0;
   padding-top: 0.5rem;
+}
+
+.sidebar-version-placeholder {
+  margin-top: auto;
+  min-height: 1.3rem;
+  padding-top: 0.5rem;
+}
+.sidebar-version-skeleton {
+  height: 0.9rem;
+  width: 3.5rem;
+  margin: 0 auto;
+  background: var(--border);
+  border-radius: 0.25rem;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary

The app scores a CLS of 0.66 — nearly 3× the 'poor' threshold of 0.25. Content pops into the DOM after async data fetches because no skeleton/placeholder infrastructure exists. Four major shifts occur: repository metadata badges, the Git tab being added to the tab bar, the file tree, and the sidebar version badge. Three minor shifts occur in the commands, harnesses, and todos panels.

## Root Cause

Zero skeleton/placeholder patterns in the codebase. All async sections use either `{data && <Block/>}` (renders nothing until resolved) or text-only `<div className="alert">Loading…</div>` placeholders that are structurally shorter than the final content.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/styles/page.css` | Add `skeleton-pulse` keyframe and skeleton layout classes |
| `packages/frontend/src/styles/sidebar.css` | Add `.sidebar-version-placeholder` and `.sidebar-version-skeleton` |
| `packages/frontend/src/components/Skeleton.tsx` | New reusable Skeleton component |
| `packages/frontend/src/components/Skeleton.test.tsx` | 4 unit tests for Skeleton component |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Add `repositoryLoading`/`fileTreeLoading` state; update 6 loading indicators to skeleton markup; always render Git tab |
| `packages/frontend/src/components/Sidebar.tsx` | Add `versionLoaded` flag; always render version placeholder container |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | 3 skeleton-state integration tests |

## Testing

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Unit tests pass — 124 RepositoryPage tests + 4 Skeleton tests (128 total)
- [x] Lint passes (`npx eslint src/`)
- [x] `make qa-quick` passes (432 passed, 1 skipped)

## Validation

```bash
cd packages/frontend
npx tsc --noEmit
npx vitest run
npx eslint src/
```

## Issue

Fixes #434

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

`.agents/issues/issue-434.md`

### Deviations from plan:

- The artifact mentioned an optional `@media (prefers-reduced-motion)` rule as a deferred enhancement; it was included here (Step 1) since it's a one-liner and is a best practice.
- Skeleton test file placed as `Skeleton.test.tsx` alongside `Skeleton.tsx` (same directory, no `__tests__` subfolder) matching the existing component test convention in the codebase.

</details>

_Automated implementation from investigation artifact_