### PR TITLE
Fix: prefers-reduced-motion override ignored due to CSS cascade order (#579)

### DIFF
--- a/packages/frontend/src/styles/page.css
+++ b/packages/frontend/src/styles/page.css
@@ -599,17 +599,17 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .skeleton {
-    animation: none;
-  }
-}
-
 .skeleton {
   background: var(--border);
   border-radius: 0.5rem;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
   display: block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
 }
 
 /* Repository metadata badge row */

--- a/packages/frontend/src/styles/sidebar.css
+++ b/packages/frontend/src/styles/sidebar.css
@@ -79,9 +79,15 @@
 /* skeleton-pulse defined here for isolated rendering (e.g. tests/Storybook);
    the canonical definition lives in page.css */
 @keyframes skeleton-pulse {
-  0%   { opacity: 1; }
-  50%  { opacity: 0.4; }
-  100% { opacity: 1; }
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 .sidebar-version-skeleton {
   height: 0.9rem;
@@ -92,5 +98,7 @@
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 @media (prefers-reduced-motion: reduce) {
-  .sidebar-version-skeleton { animation: none; }
+  .sidebar-version-skeleton {
+    animation: none;
+  }
 }

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -1059,9 +1059,7 @@ def list_docker_containers():
 
 @app.post("/api/docker-containers/{container_id}/stop")
 def stop_docker_container(
-    container_id: Annotated[
-        str, PathParam(pattern=CONTAINER_ID_PATTERN)
-    ],
+    container_id: Annotated[str, PathParam(pattern=CONTAINER_ID_PATTERN)],
 ):
     try:
         logger.info("Stopping Docker container id=%s", container_id)


### PR DESCRIPTION
## Summary

The `@media (prefers-reduced-motion: reduce)` block in `packages/frontend/src/styles/page.css` was placed **before** the `.skeleton` rule it was intended to override. Because CSS cascade resolves equal-specificity declarations last-wins, `animation: skeleton-pulse` (later) always overrode `animation: none` (earlier), rendering the accessibility media query completely ineffective for every user with that OS/browser setting enabled.

## Root Cause

CSS cascade ordering mistake introduced in PR #577 / commit `e006838`. The `@media` block was added as a best-practice override but placed before the base `.skeleton` rule instead of after it.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/styles/page.css` | Moved `.skeleton` base rule before `@media (prefers-reduced-motion: reduce)` block |
| `packages/frontend/src/styles/sidebar.css` | Auto-formatter cleanup (no logic change) |
| `packages/pybackend/app.py` | Auto-formatter cleanup (no logic change) |

## Testing

- [x] Lint passes (`eslint`, `ruff check`)
- [x] Format passes (`ruff format`)
- [x] All 443 backend unit tests pass
- [x] Frontend type check passes

### Manual Verification

1. Enable `prefers-reduced-motion: reduce` in OS settings or via Chrome DevTools → Rendering
2. Navigate to a page that shows skeleton loading state
3. Verify skeleton placeholders are **static** (no pulse animation)
4. Disable preference — pulse animation should resume

## Validation

```bash
make qa-quick   # lint + format + unit-test — all pass
```

## Issue

Fixes #579

<details>
<summary>📋 Implementation Details</summary>

### Pattern followed

`packages/frontend/src/styles/sidebar.css:86–96` already demonstrates the correct cascade order for `.sidebar-version-skeleton` — this fix mirrors that exact pattern.

### Deviations from plan

None. The CSS reorder is exactly as specified in the investigation comment.

</details>

_Automated implementation from investigation artifact_