### PR TITLE
fix(tests): make cron service tests resilient to running backend instances (#405)

### DIFF
--- a/packages/pybackend/tests/unit/test_cron_service.py
+++ b/packages/pybackend/tests/unit/test_cron_service.py
@@ -24,7 +24,9 @@ def teardown_function():
 @patch("cron_service.list_scheduled_tasks")
 @patch("cron_service.read_workflows")
 @patch("cron_service.get_workspace_home")
+@patch("cron_service._claim_cron_ownership", return_value=True)
 def test_start_cron_clock_registers_only_enabled_workflows_with_existing_scripts(
+    mock_claim_ownership,
     mock_workspace_home,
     mock_read_workflows,
     mock_list_scheduled_tasks,
@@ -95,7 +97,9 @@ def test_start_cron_clock_registers_only_enabled_workflows_with_existing_scripts
 @patch("cron_service.list_scheduled_tasks")
 @patch("cron_service.read_workflows")
 @patch("cron_service.get_workspace_home")
+@patch("cron_service._claim_cron_ownership", return_value=True)
 def test_start_cron_clock_marks_invalid_cron_as_warning(
+    mock_claim_ownership,
     mock_workspace_home,
     mock_read_workflows,
     mock_list_scheduled_tasks,
@@ -331,7 +335,9 @@ def test_get_cron_job_diagnostics_includes_runtime_metadata():
 @patch("cron_service.list_scheduled_tasks")
 @patch("cron_service.read_workflows")
 @patch("cron_service.get_workspace_home")
+@patch("cron_service._claim_cron_ownership", return_value=True)
 def test_start_cron_clock_registers_scheduled_tasks(
+    mock_claim_ownership,
     mock_workspace_home,
     mock_read_workflows,
     mock_list_scheduled_tasks,


### PR DESCRIPTION
## Problem

Three cron service unit tests fail when another MADE backend process is already running on the same machine:

- `test_start_cron_clock_registers_only_enabled_workflows_with_existing_scripts`
- `test_start_cron_clock_marks_invalid_cron_as_warning`
- `test_start_cron_clock_registers_scheduled_tasks`

The cron ownership mechanism reads a PID file and detects a live process, causing `start_cron_clock` to skip scheduling entirely. The tests had no mock for this check, so they produced:

```
WARNING  cron_service.py: Another MADE backend instance is already running the cron service. Skipping cron scheduler startup to avoid duplicate job execution.
```

This broke `make qa-quick` on developer machines running MADE in the background.

Fixes #405

## Solution

Patch `_claim_cron_ownership` to return `True` in all three affected tests, so they are fully isolated from the host environment's PID file state.

## Changes

- Add `@patch("cron_service._claim_cron_ownership", return_value=True)` to `test_start_cron_clock_registers_only_enabled_workflows_with_existing_scripts`
- Add same patch to `test_start_cron_clock_marks_invalid_cron_as_warning`
- Add same patch to `test_start_cron_clock_registers_scheduled_tasks`

## Testing

All three previously-failing tests now pass regardless of whether a MADE backend is running:

```
tests/unit/test_cron_service.py::test_start_cron_clock_registers_only_enabled_workflows_with_existing_scripts PASSED
tests/unit/test_cron_service.py::test_start_cron_clock_marks_invalid_cron_as_warning PASSED
tests/unit/test_cron_service.py::test_start_cron_clock_registers_scheduled_tasks PASSED
```

## Notes

Follows the same mock pattern already used in `test_start_cron_clock_skips_when_ownership_fails`.