### PR TITLE
fix(#591): replace async useEffect sessionIdRef sync with inline render-time assignment

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -146,9 +146,7 @@ export const ConstitutionPage: React.FC = () => {
     [isExternal, name],
   );
 
-  useEffect(() => {
-    sessionIdRef.current = sessionId;
-  }, [sessionId]);
+  sessionIdRef.current = sessionId;
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -144,9 +144,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
     [isExternal, name],
   );
 
-  useEffect(() => {
-    sessionIdRef.current = sessionId;
-  }, [sessionId]);
+  sessionIdRef.current = sessionId;
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -692,9 +692,7 @@ export const RepositoryPage: React.FC = () => {
   useEffect(() => {
     lastKnownTimestampRef.current = lastKnownTimestamp;
   }, [lastKnownTimestamp]);
-  useEffect(() => {
-    sessionIdRef.current = sessionId;
-  }, [sessionId]);
+  sessionIdRef.current = sessionId;
   const chatRef = useRef(chat);
   useEffect(() => {
     chatRef.current = chat;

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -128,9 +128,7 @@ export const TaskPage: React.FC = () => {
     [name],
   );
 
-  useEffect(() => {
-    sessionIdRef.current = sessionId;
-  }, [sessionId]);
+  sessionIdRef.current = sessionId;
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);


### PR DESCRIPTION
## Summary

`refreshAgentStatus` in all 4 page components used a stale-response guard comparing `sessionIdRef.current` (written by a `useEffect` that runs **after** render) against `sessionId` (captured in the `useCallback` closure **during** render). Because effects run asynchronously after the render/paint cycle, a timing window exists where the guard incorrectly fires and bails out, leaving lifecycle stuck at `"loading"` instead of transitioning to `"hydrated"` or `"streaming"`.

## Root Cause

The `useEffect(() => { sessionIdRef.current = sessionId; }, [sessionId])` pattern defers the ref update to after the render. If `refreshAgentStatus` resolves in the window between the render setting a new `sessionId` closure value and the effect writing it to the ref, the guard `sessionIdRef.current !== sessionId` evaluates true for a non-stale response and incorrectly bails out.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Replace `useEffect` sessionIdRef sync with inline render-time assignment |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Same fix — identical pattern |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Same fix — identical pattern |
| `packages/frontend/src/pages/TaskPage.tsx` | Same fix — identical pattern |

Writing to `ref.current` during the render body is synchronous. By the time any effect or event handler reads `sessionIdRef.current`, it already reflects the current render's `sessionId`. This closes the timing window entirely.

Adjacent `chatRef` and `lastKnownTimestampRef` `useEffect` syncs are **not changed** — they are not involved in timing-sensitive guards.

## Testing

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 124 RepositoryPage unit tests pass
- [x] Full QA gate passes (`make qa-quick`): 442 backend + 124 frontend tests
- [x] Existing D1 (AC6) stale-closure regression test continues to pass

## Validation

```bash
cd packages/frontend && npx tsc --noEmit
cd packages/frontend && npx vitest run src/pages/__tests__/RepositoryPage.test.tsx
make qa-quick
```

## Issue

Fixes #591

<details>
<summary>Implementation Details</summary>

### Deviations from plan

None — implementation follows the artifact exactly.

</details>

_Automated implementation from investigation artifact_