### PR TITLE
Fix: reloadCurrentSession never calls refreshAgentStatus (#585)

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -507,6 +507,7 @@ export const ConstitutionPage: React.FC = () => {
       const mapped = mapHistoryToMessages(history.messages || []);
       setChat(mapped);
       setAgentStatus(null);
+      await refreshAgentStatus();
     } catch (error) {
       setChat(chatBeforeRefresh);
       console.error("Failed to load session history", error);
@@ -519,7 +520,14 @@ export const ConstitutionPage: React.FC = () => {
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, isExternal, setChat, setAgentStatus]);
+  }, [
+    name,
+    sessionId,
+    isExternal,
+    setChat,
+    setAgentStatus,
+    refreshAgentStatus,
+  ]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -502,6 +502,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       const mapped = mapHistoryToMessages(history.messages || []);
       setChat(mapped);
       setAgentStatus(null);
+      await refreshAgentStatus();
     } catch (error) {
       setChat(chatBeforeRefresh);
       console.error("Failed to load session history", error);
@@ -514,7 +515,14 @@ export const KnowledgeArtefactPage: React.FC = () => {
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, isExternal, setChat, setAgentStatus]);
+  }, [
+    name,
+    sessionId,
+    isExternal,
+    setChat,
+    setAgentStatus,
+    refreshAgentStatus,
+  ]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1325,6 +1325,7 @@ export const RepositoryPage: React.FC = () => {
         setChat(mapped);
       }
       setChatError(null);
+      await refreshAgentStatus();
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
       setChat(chatBeforeRefresh);
@@ -1338,7 +1339,7 @@ export const RepositoryPage: React.FC = () => {
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, setChat, setChatError]);
+  }, [name, sessionId, setChat, setChatError, refreshAgentStatus]);
 
   const handleSendMessage = async (prompt?: string) => {
     if (!name) return;

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -440,6 +440,7 @@ export const TaskPage: React.FC = () => {
       const mapped = mapHistoryToMessages(history.messages || []);
       setChat(mapped);
       setAgentStatus(null);
+      await refreshAgentStatus();
     } catch (error) {
       setChat(chatBeforeRefresh);
       console.error("Failed to load session history", error);
@@ -452,7 +453,7 @@ export const TaskPage: React.FC = () => {
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, setChat, setAgentStatus]);
+  }, [name, sessionId, setChat, setAgentStatus, refreshAgentStatus]);
 
   const handleSaveSession = useCallback(() => {
     if (!sessionId) return;

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1329,6 +1329,30 @@ describe("RepositoryPage reload current session (AC1-AC7)", () => {
     vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
     resolveFetch!(emptyHistory);
   });
+
+  it("AC585: reloadCurrentSession calls refreshAgentStatus (getRepositoryAgentStatus) after successful history fetch", async () => {
+    // Arrange: getRepositoryAgentStatus mock auto-resolves via Proxy (processing: false by default)
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // Wait for initial load to complete (refreshAgentStatus fires on mount)
+    await waitFor(() => {
+      expect(api.getRepositoryAgentStatus).toHaveBeenCalled();
+    });
+
+    vi.mocked(api.getRepositoryAgentStatus).mockClear();
+
+    // Act: click Refresh button
+    const refreshBtn = await screen.findByLabelText("Refresh current session");
+    fireEvent.click(refreshBtn);
+
+    // Assert: getRepositoryAgentStatus is called once after the history fetch
+    await waitFor(() => {
+      expect(
+        api.getRepositoryAgentStatus,
+        "FAIL (AC585): getRepositoryAgentStatus not called after manual refresh — refreshAgentStatus missing from reloadCurrentSession",
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 // ── AC4 cross-page ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`reloadCurrentSession` (triggered by the manual Refresh button and same-session re-selection) fetched updated chat history but never called `refreshAgentStatus()` to check whether the agent is currently processing. After a manual refresh the `lifecycle` / `chatAgentProcessing` state was left at its pre-refresh value, so the "Agent Thinking..." indicator was never shown, the Cancel button never appeared, and the Send button could be incorrectly enabled while the agent was busy. The bug existed identically in all four agent page components.

## Root Cause

`reloadCurrentSession` was introduced in commit `9091de2e` without the `refreshAgentStatus()` call. Every other code path that loads chat history (session-loading Effect, polling Effect, `handleSendMessage` catch, `handleCancelAgent` finally) already calls `refreshAgentStatus()`. `reloadCurrentSession` was simply never wired up with this call, and `refreshAgentStatus` was absent from its `useCallback` dependency array.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Add `await refreshAgentStatus()` after history fetch; add `refreshAgentStatus` to deps |
| `packages/frontend/src/pages/TaskPage.tsx` | Same fix |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Same fix |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Same fix |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add AC585 regression test verifying `getRepositoryAgentStatus` is called after manual Refresh |

## Testing

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 125 RepositoryPage tests pass (124 existing + 1 new AC585)
- [x] Lint passes (`npm run lint`)
- [x] Full `make qa-quick` passes (442 passed, 1 skipped)

## Validation

```bash
cd packages/frontend && npx tsc --noEmit
cd packages/frontend && npx vitest run src/pages/__tests__/RepositoryPage.test.tsx
cd packages/frontend && npm run lint
make qa-quick
```

## Issue

Fixes #585

<details>
<summary>Implementation Details</summary>

### Deviations from plan

None. Implementation followed the investigation artifact exactly.

</details>

_Automated implementation from investigation artifact_