### PR TITLE
Fix: clear stale localStorage chat on page refresh (#590)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -759,9 +759,10 @@ export const RepositoryPage: React.FC = () => {
   // Trigger session load when a session is available and lifecycle has not been set yet
   useEffect(() => {
     if (lifecycle === "idle" && name && sessionId) {
+      setChat([]);
       setLifecycle("loading");
     }
-  }, [lifecycle, name, sessionId]);
+  }, [lifecycle, name, sessionId, setChat]);
 
   useEffect(() => {
     const search = splitMentionSearch(mentionQuery);

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4114,6 +4114,95 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
   });
 });
 
+describe("RepositoryPage AC590 — stale localStorage chat cleared on page refresh", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+    });
+    localStorage.clear();
+  });
+
+  it("AC590-1: stale localStorage message is NOT visible during session loading on page refresh", async () => {
+    // Arrange: localStorage has stale chat from a previous session
+    const staleMsg = {
+      id: "stale-1",
+      role: "user",
+      text: "Stale message from before",
+      timestamp: "2026-01-01T00:00:00.000Z",
+    };
+    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
+    localStorage.setItem(
+      "repository-chat-test-repo",
+      JSON.stringify([staleMsg]),
+    );
+
+    let resolveFetch!: (v: ChatHistoryResponse) => void;
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValue(
+      new Promise<ChatHistoryResponse>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent"]);
+
+    // During loading, stale message must NOT be visible; spinner must show
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading session..."),
+        "FAIL (AC590-1): loading indicator not shown — stale messages still in chat or lifecycle not entering loading",
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Stale message from before"),
+      "FAIL (AC590-1): stale localStorage message visible during loading — setChat([]) missing in idle→loading transition",
+    ).not.toBeInTheDocument();
+
+    resolveFetch!(emptyHistory);
+  });
+
+  it("AC590-2: after fetch failure, stale localStorage message is NOT shown (error state, not stale data)", async () => {
+    // Arrange: localStorage has stale chat
+    const staleMsg = {
+      id: "stale-2",
+      role: "user",
+      text: "Stale message must not persist on error",
+      timestamp: "2026-01-01T00:00:00.000Z",
+    };
+    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
+    localStorage.setItem(
+      "repository-chat-test-repo",
+      JSON.stringify([staleMsg]),
+    );
+
+    vi.mocked(api.getRepositoryAgentHistory).mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent"]);
+
+    // Wait for error state
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Network failure"),
+        "FAIL (AC590-2): error message not shown after fetch failure",
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Stale message must not persist on error"),
+      "FAIL (AC590-2): stale localStorage message visible after fetch failure — setChat([]) missing, stale data persists permanently",
+    ).not.toBeInTheDocument();
+  });
+});
+
 // ── Session selection regression: Knowledge, Constitution, Task pages ─────────
 
 function renderTaskPage(initialEntries = ["/tasks/test-task?tab=agent"]) {


### PR DESCRIPTION
## Summary

On page refresh with an existing session, `usePersistentChat` initialises `chat` synchronously from localStorage. The idle→loading trigger effect transitioned lifecycle without first clearing the stale chat, causing users to see outdated messages during loading. If the API fetch failed or was aborted, the stale data persisted permanently with no visual indication to the user.

## Root Cause

The `lifecycle === "idle" → "loading"` trigger effect in `RepositoryPage.tsx:761` did not call `setChat([])` before `setLifecycle("loading")`. Every other entry into the loading state already called `setChat([])` first (`handleSessionSelect`, URL-param bootstrap, `reloadCurrentSession`) — only this path was missed.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Add `setChat([])` + `setChat` to dep array in idle→loading effect (line 761) |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add AC590-1/AC590-2 regression tests |

## Testing

- [x] Type check passes
- [x] Unit tests pass (126 tests)
- [x] Lint passes
- [x] AC590-1: stale message NOT visible during loading (loading spinner shows)
- [x] AC590-2: stale message NOT visible after fetch failure (error message shows)

## Validation

```bash
cd packages/frontend && npx vitest run --reporter=verbose -t "AC590" src/pages/__tests__/RepositoryPage.test.tsx
make qa-quick
```

## Issue

Fixes #590

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from investigation comment

### Deviations from plan:

None — implemented Step 1 exactly as specified in the investigation comment (owner's comment, 2026-06-26T11:53:06Z). The artifact specified adding `setChat([])` in the idle→loading trigger effect and adding AC590-1/AC590-2 tests, both of which are included.

</details>

_Automated implementation from investigation artifact_