### PR TITLE
Fix: remove unused send_agent_message import in test_unit.py (#596)

### DIFF
--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -440,7 +440,7 @@ class TestAgentService:
 
     def test_same_session_blocked_while_processing(self):
         """A single session sending a second message before first completes must raise ChannelBusyError."""
-        from agent_service import _mark_channel_processing, _clear_channel_processing, ChannelBusyError, send_agent_message
+        from agent_service import _mark_channel_processing, _clear_channel_processing, ChannelBusyError
 
         # Given: lock for session X is already held
         assert _mark_channel_processing("ses_X") is True


### PR DESCRIPTION
## Summary

`test_same_session_blocked_while_processing` imports `send_agent_message` from `agent_service` but never calls it. This produces an F401 "imported but unused" ruff lint error when the file is checked directly with `ruff check tests/unit/test_unit.py`. The `make qa-quick` path-scoping hides the error during CI, making it invisible until a direct ruff invocation.

## Root Cause

The import was included in the original commit (9e35fb5a) when the concurrent-session lock feature was added, but the test body was designed to call `_mark_channel_processing` and `_clear_channel_processing` directly, making `send_agent_message` dead code.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/tests/unit/test_unit.py` | Remove `send_agent_message` from import at line 443 |

## Testing

- [x] Direct ruff check passes: `cd packages/pybackend && uv run ruff check tests/unit/test_unit.py`
- [x] Targeted test still passes: `test_same_session_blocked_while_processing`
- [x] Full QA gate passes: `make qa-quick` (448 passed, 1 skipped)

## Validation

```bash
cd packages/pybackend && uv run ruff check tests/unit/test_unit.py
cd packages/pybackend && uv run python -m pytest tests/unit/test_unit.py -k test_same_session_blocked_while_processing -v
make qa-quick
```

## Issue

Fixes #596

<details>
<summary>Implementation Details</summary>

### Deviations from plan

None — change matches investigation artifact exactly.

</details>

_Automated implementation from investigation artifact_