### PR TITLE
Fix: replace chatAgentProcessing tri-value with two booleans (#587)

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -455,12 +455,9 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
   const [lifecycle, setLifecycle] = useState<Lifecycle>("idle");
-  const chatAgentProcessing: boolean | null =
-    lifecycle === "streaming"
-      ? true
-      : lifecycle === "loading" || (lifecycle === "idle" && !!sessionId)
-        ? null
-        : false;
+  const chatAgentProcessing = lifecycle === "streaming";
+  const sessionLoading =
+    lifecycle === "loading" || (lifecycle === "idle" && !!sessionId);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(
@@ -746,7 +743,6 @@ export const RepositoryPage: React.FC = () => {
   const [movePath, setMovePath] = useState("");
   const [loadingFile, setLoadingFile] = useState(false);
   const [clearSessionModalOpen, setClearSessionModalOpen] = useState(false);
-  const sessionLoading = lifecycle === "loading";
   const [isRefreshing, setIsRefreshing] = useState(false);
   const isRefreshingRef = useRef(false);
   const chatInputId = "repository-agent-prompt";
@@ -2017,7 +2013,9 @@ export const RepositoryPage: React.FC = () => {
                   onClick={reloadCurrentSession}
                   aria-label="Refresh current session"
                   title="Refresh current session"
-                  disabled={chatAgentProcessing !== false || isRefreshing}
+                  disabled={
+                    chatAgentProcessing || sessionLoading || isRefreshing
+                  }
                 >
                   <RefreshIcon />
                 </button>
@@ -2053,7 +2051,7 @@ export const RepositoryPage: React.FC = () => {
           <ChatWindow
             chat={chat}
             chatWindowRef={chatWindowRef}
-            agentProcessing={chatAgentProcessing === true}
+            agentProcessing={chatAgentProcessing}
             refreshing={isRefreshing}
             sessionLoading={sessionLoading}
             emptyMessage="No conversation yet."
@@ -2081,7 +2079,7 @@ export const RepositoryPage: React.FC = () => {
                 selectId="agent-select"
                 selectedAgent={normalizedSelectedAgent}
                 onChange={setSelectedAgent}
-                disabled={chatAgentProcessing !== false}
+                disabled={chatAgentProcessing || sessionLoading}
                 repositoryName={name || undefined}
               />
               <label className="model-select" htmlFor="agent-model-select">
@@ -2089,7 +2087,7 @@ export const RepositoryPage: React.FC = () => {
                   id="agent-model-select"
                   value={normalizedSelectedModel}
                   onChange={(event) => setSelectedModel(event.target.value)}
-                  disabled={chatAgentProcessing !== false}
+                  disabled={chatAgentProcessing || sessionLoading}
                   aria-label="Model"
                 >
                   {MODEL_OPTIONS.map((option) => (
@@ -2114,7 +2112,9 @@ export const RepositoryPage: React.FC = () => {
                   className="primary"
                   onClick={() => handleSendMessage()}
                   disabled={
-                    !pendingPrompt.trim() || chatAgentProcessing === null
+                    !pendingPrompt.trim() ||
+                    sessionLoading ||
+                    chatAgentProcessing
                   }
                 >
                   Send

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -4938,6 +4938,62 @@ describe("RepositoryPage Send button disabled during status-unknown state (AC559
   });
 });
 
+// ── AC587: idle-with-sessionId render gap shows loading indicator ─────────
+describe("RepositoryPage loading indicator shown during idle-with-sessionId gap (AC587)", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    vi.mocked(api.cancelRepositoryAgent).mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  it("AC587-1: sessionLoading is true immediately on render when sessionId is present (before useEffect fires)", () => {
+    // Hold the history and status calls so the page never leaves 'loading'
+    vi.mocked(api.getRepositoryAgentHistory).mockReturnValue(
+      new Promise(() => {}),
+    );
+    vi.mocked(api.getRepositoryAgentStatus).mockReturnValue(
+      new Promise(() => {}) as unknown as ReturnType<
+        typeof api.getRepositoryAgentStatus
+      >,
+    );
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-a"]);
+
+    // The loading indicator must appear immediately (covers the idle→loading gap)
+    expect(
+      screen.getByText(/loading session/i),
+      "FAIL (AC587-1a): Loading session indicator must appear immediately when sessionId is present",
+    ).toBeInTheDocument();
+
+    // Send button must be disabled during the gap
+    const textarea = screen.getByPlaceholderText(
+      "Describe the change or ask the agent...",
+    );
+    fireEvent.change(textarea, { target: { value: "test" } });
+    expect(
+      screen.getByRole("button", { name: /send/i }),
+      "FAIL (AC587-1b): Send button must be disabled during idle-with-sessionId gap",
+    ).toBeDisabled();
+
+    // AgentSelector must be disabled during the gap
+    expect(
+      screen.getByLabelText("Agent"),
+      "FAIL (AC587-1c): AgentSelector must be disabled during idle-with-sessionId gap",
+    ).toBeDisabled();
+
+    // Model select must be disabled during the gap
+    expect(
+      screen.getByLabelText("Model"),
+      "FAIL (AC587-1d): Model select must be disabled during idle-with-sessionId gap",
+    ).toBeDisabled();
+  });
+});
+
 // ── Issue #562: optimistic Cancel ──────────────────────────────────────────
 describe("issue #562: handleCancelAgent optimistic update", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

`chatAgentProcessing` in `RepositoryPage.tsx` was derived as `boolean | null`, where `null` represented an unknown/pending state (lifecycle is `"loading"` or `"idle" && !!sessionId`). This `null` silently coerced to `false` in JSX boolean contexts, causing the loading indicator and controls to behave as if the agent was idle — even though state was unknown. This created an invisible UI gap during every session load.

## Root Cause

The `boolean | null` tri-value was introduced in commit `eeeced5` when `chatAgentProcessing` was replaced with a `Lifecycle` discriminated union. The `null` arm was intended as a "pending" sentinel but `ChatWindow` accepts `agentProcessing: boolean` and all JSX consumers evaluate it as a boolean — so `null` silently becomes `false`, defeating its purpose. Additionally, `sessionLoading` at line 749 only covered `lifecycle === "loading"`, missing the `"idle" && !!sessionId` gap before the `useEffect` fires.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Replace tri-value with `chatAgentProcessing = lifecycle === "streaming"` and `sessionLoading = lifecycle === "loading" \|\| (lifecycle === "idle" && !!sessionId)` |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Remove duplicate narrow `sessionLoading` (was: `lifecycle === "loading"` only) |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Update 5 usage sites: Refresh button, agentProcessing prop, AgentSelector, Model select, Send button |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Add AC587-1 test for idle-with-sessionId render gap |

## Testing

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] RepositoryPage unit tests pass (128 tests)
- [x] ChatWindow unit tests pass (27 tests)
- [x] Lint passes
- [x] Full `make qa-quick` passes (448 backend + frontend tests)

## Validation

```bash
cd packages/frontend && npx tsc --noEmit
cd packages/frontend && npm test -- --run src/pages/__tests__/RepositoryPage.test.tsx
cd packages/frontend && npm run lint
make qa-quick
```

## Issue

Fixes #587

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact from:

Issue #587 investigation comment (tbrandenburg, 2026-06-26T13:00:00Z)

### Deviations from plan:

None — all 8 steps followed exactly as specified.

</details>

_Automated implementation from investigation artifact_