### PR TITLE
Fix: remove agentCli from session storage keys to prevent race condition (#584)

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -22,7 +22,6 @@ const CommandsTab = React.lazy(() => import("../components/CommandsTab"));
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { usePersistentStringList } from "../hooks/usePersistentStringList";
-import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
@@ -67,24 +66,20 @@ export const ConstitutionPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
-  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `constitution-chat-${name}` : "constitution-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () =>
-      name
-        ? `constitution-session-${name}-${agentCli}`
-        : `constitution-session-${agentCli}`,
-    [agentCli, name],
+    () => (name ? `constitution-session-${name}` : "constitution-session"),
+    [name],
   );
   const savedSessionStorageKey = useMemo(
     () =>
       name
-        ? `constitution-saved-sessions-${name}-${agentCli}`
-        : `constitution-saved-sessions-${agentCli}`,
-    [agentCli, name],
+        ? `constitution-saved-sessions-${name}`
+        : "constitution-saved-sessions",
+    [name],
   );
   const harnessHistoryStorageKey = useMemo(
     () =>

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -22,7 +22,6 @@ const CommandsTab = React.lazy(() => import("../components/CommandsTab"));
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { usePersistentStringList } from "../hooks/usePersistentStringList";
-import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
@@ -67,24 +66,20 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
-  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `knowledge-chat-${name}` : "knowledge-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () =>
-      name
-        ? `knowledge-session-${name}-${agentCli}`
-        : `knowledge-session-${agentCli}`,
-    [agentCli, name],
+    () => (name ? `knowledge-session-${name}` : "knowledge-session"),
+    [name],
   );
   const savedSessionStorageKey = useMemo(
     () =>
       name
-        ? `knowledge-saved-sessions-${name}-${agentCli}`
-        : `knowledge-saved-sessions-${agentCli}`,
-    [agentCli, name],
+        ? `knowledge-saved-sessions-${name}`
+        : "knowledge-saved-sessions",
+    [name],
   );
   const harnessHistoryStorageKey = useMemo(
     () =>

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -34,7 +34,6 @@ import {
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { usePersistentStringList } from "../hooks/usePersistentStringList";
-import { useAgentCli } from "../hooks/useAgentCli";
 import {
   api,
   CommandDefinition,
@@ -410,24 +409,20 @@ export const RepositoryPage: React.FC = () => {
   const [fileTreeLoading, setFileTreeLoading] = useState(true);
   const [fileActionError, setFileActionError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(["."]));
-  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `repository-chat-${name}` : "repository-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () =>
-      name
-        ? `repository-session-${name}-${agentCli}`
-        : `repository-session-${agentCli}`,
-    [agentCli, name],
+    () => (name ? `repository-session-${name}` : "repository-session"),
+    [name],
   );
   const savedSessionStorageKey = useMemo(
     () =>
       name
-        ? `repository-saved-sessions-${name}-${agentCli}`
-        : `repository-saved-sessions-${agentCli}`,
-    [agentCli, name],
+        ? `repository-saved-sessions-${name}`
+        : "repository-saved-sessions",
+    [name],
   );
   const modelStorageKey = useMemo(
     () => (name ? `repository-model-${name}` : "repository-model"),

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -22,7 +22,6 @@ const CommandsTab = React.lazy(() => import("../components/CommandsTab"));
 import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { usePersistentStringList } from "../hooks/usePersistentStringList";
-import { useAgentCli } from "../hooks/useAgentCli";
 import { api, ChatSession } from "../hooks/useApi";
 import { ChatMessage } from "../types/chat";
 import "../styles/page.css";
@@ -60,22 +59,17 @@ export const TaskPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("content");
   const [frontmatter, setFrontmatter] = useState<Record<string, unknown>>({});
   const [content, setContent] = useState("");
-  const agentCli = useAgentCli();
   const chatStorageKey = useMemo(
     () => (name ? `task-chat-${name}` : "task-chat"),
     [name],
   );
   const sessionStorageKey = useMemo(
-    () =>
-      name ? `task-session-${name}-${agentCli}` : `task-session-${agentCli}`,
-    [agentCli, name],
+    () => (name ? `task-session-${name}` : "task-session"),
+    [name],
   );
   const savedSessionStorageKey = useMemo(
-    () =>
-      name
-        ? `task-saved-sessions-${name}-${agentCli}`
-        : `task-saved-sessions-${agentCli}`,
-    [agentCli, name],
+    () => (name ? `task-saved-sessions-${name}` : "task-saved-sessions"),
+    [name],
   );
   const harnessHistoryStorageKey = useMemo(
     () => (name ? `task-harness-history-${name}` : "task-harness-history"),

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -3184,7 +3184,7 @@ describe("RepositoryPage session loading indicator (AC1-AC10)", () => {
 // ── AC1-AC7: bootstrap path loading indicator (Issue #522) ─────────────
 
 describe("RepositoryPage bootstrap path loading indicator (AC1-AC7)", () => {
-  const sessionStorageKey = "repository-session-test-repo-opencode";
+  const sessionStorageKey = "repository-session-test-repo";
   const historyWithMessages: ChatHistoryResponse = {
     sessionId: "session-b",
     messages: [
@@ -4058,8 +4058,8 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
       text: "Cached message",
       timestamp: "2026-01-01T00:00:00.000Z",
     };
-    // sessionStorageKey = "repository-session-test-repo-opencode" (agentCli defaults to "opencode")
-    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
+    // sessionStorageKey = "repository-session-test-repo" (no agentCli suffix)
+    localStorage.setItem("repository-session-test-repo", "session-a");
     localStorage.setItem(
       "repository-chat-test-repo",
       JSON.stringify([cachedMessage]),
@@ -4099,7 +4099,7 @@ describe("RepositoryPage syncChatHistory full-fetch on session load (#481)", () 
       text: "Corrupted cached message",
       timestamp: "2099-01-01T00:00:00.000Z",
     };
-    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
+    localStorage.setItem("repository-session-test-repo", "session-a");
     localStorage.setItem(
       "repository-chat-test-repo",
       JSON.stringify([futureMessage]),
@@ -4161,7 +4161,7 @@ describe("RepositoryPage AC590 — stale localStorage chat cleared on page refre
       text: "Stale message from before",
       timestamp: "2026-01-01T00:00:00.000Z",
     };
-    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
+    localStorage.setItem("repository-session-test-repo", "session-a");
     localStorage.setItem(
       "repository-chat-test-repo",
       JSON.stringify([staleMsg]),
@@ -4200,7 +4200,7 @@ describe("RepositoryPage AC590 — stale localStorage chat cleared on page refre
       text: "Stale message must not persist on error",
       timestamp: "2026-01-01T00:00:00.000Z",
     };
-    localStorage.setItem("repository-session-test-repo-opencode", "session-a");
+    localStorage.setItem("repository-session-test-repo", "session-a");
     localStorage.setItem(
       "repository-chat-test-repo",
       JSON.stringify([staleMsg]),


### PR DESCRIPTION
## Summary

On page refresh, `useAgentCli` initialises synchronously with the default value `"opencode"` then fetches the real value from the API asynchronously. Because `sessionStorageKey` and `savedSessionStorageKey` embedded `agentCli` in their key strings, the key changed mid-render once the API response resolved. `usePersistentString` re-read `localStorage` with the new key (typically empty), making `sessionId` flip to null. The loading effect bailed out early (`if (!sessionId) return`) without resetting `lifecycle`, permanently leaving the UI stuck at `"loading"`. User sees "Loading session..." forever with no recovery except navigating away.

## Root Cause

`agentCli` was added to localStorage key computations to namespace session state per configured CLI tool (commit "Namespace session storage by agent CLI"), but because `useAgentCli` is asynchronous, the storage key becomes unstable across the first render cycle, breaking the lifecycle state machine of every page component.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Remove `${agentCli}` from `sessionStorageKey` and `savedSessionStorageKey`; remove unused `useAgentCli` import and variable |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Same change for constitution-prefixed keys |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Same change for knowledge-prefixed keys |
| `packages/frontend/src/pages/TaskPage.tsx` | Same change for task-prefixed keys |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Update localStorage key literals to match new stable key format (remove `-opencode` suffix) |

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] Unit tests pass (127/127 in RepositoryPage.test.tsx)
- [x] Lint passes (`eslint`)

## Validation

```bash
cd packages/frontend && npx tsc --noEmit
cd /repo && npm run lint
cd /repo/packages/frontend && npx vitest run src/pages/__tests__/RepositoryPage.test.tsx
```

## Issue

Fixes #584

<details>
<summary>Implementation Details</summary>

### Deviations from plan

The investigation plan specified removing `agentCli` from the `useMemo` deps arrays and key templates. After doing so, the `const agentCli = useAgentCli()` variable and its import became unused in all 4 pages, causing lint errors. These were also removed as a necessary follow-on step — consistent with the plan's out-of-scope note that `useAgentCli.ts` itself needs no changes.

The test file update was not in the plan's Step 5 ("No test changes needed"), but the existing test at line 3187 hardcoded the old key `"repository-session-test-repo-opencode"`. After the fix, the page uses `"repository-session-test-repo"`, so 4 test cases that set/read the old key needed updating to match the new stable key format.

</details>

_Automated implementation from investigation artifact_