### PR TITLE
Fix: inject COMMIT_SHA and BUILD_DATE at build time for /api/version (#396)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
       
       - name: Build Docker images
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          BUILD_DATE: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
         run: make docker-build
       
       - name: Start services

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Build backend package
         run: cd packages/pybackend && uv build
 
+      - name: Build Docker images with version info
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          BUILD_DATE: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+        run: make docker-build
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: .
       dockerfile: docker/pybackend.Dockerfile
+      args:
+        - COMMIT_SHA=${COMMIT_SHA:-unknown}
+        - BUILD_DATE=${BUILD_DATE:-unknown}
     environment:
       MADE_BACKEND_PORT: 3000
     volumes:

--- a/docker/pybackend.Dockerfile
+++ b/docker/pybackend.Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 FROM python:3.12-slim
 
+ARG COMMIT_SHA=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /app
 
 # Install UV package manager
@@ -21,6 +24,8 @@ EXPOSE 3000
 # Set environment variables
 ENV PYTHONPATH=/app
 ENV PORT=3000
+ENV COMMIT_SHA=${COMMIT_SHA}
+ENV BUILD_DATE=${BUILD_DATE}
 
 # Run the application
 CMD [".venv/bin/uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3000"]

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -76,9 +76,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   );
   const savedSessionStorageKey = useMemo(
     () =>
-      name
-        ? `knowledge-saved-sessions-${name}`
-        : "knowledge-saved-sessions",
+      name ? `knowledge-saved-sessions-${name}` : "knowledge-saved-sessions",
     [name],
   );
   const harnessHistoryStorageKey = useMemo(

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -441,7 +441,9 @@ export const RepositoryPage: React.FC = () => {
   const [isAgentBusy, setIsAgentBusy] = useState(false);
   // Initialize from sessionId so history loading state is correct on first render
   // for persisted sessions (avoids brief flash of stale localStorage content).
-  const [isLoadingHistory, setIsLoadingHistory] = useState(() => Boolean(sessionId));
+  const [isLoadingHistory, setIsLoadingHistory] = useState(() =>
+    Boolean(sessionId),
+  );
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1655,3 +1655,28 @@ class TestVersionEndpoint:
         assert "commit_sha" in data
         assert "build_date" in data
         assert "environment" in data
+        # Fields must be strings (may be "unknown" in test/local env)
+        assert isinstance(data["commit_sha"], str)
+        assert isinstance(data["build_date"], str)
+
+    def test_version_reflects_commit_sha_env_var(self, monkeypatch):
+        """Version endpoint returns injected COMMIT_SHA when set."""
+        monkeypatch.setenv("COMMIT_SHA", "abc1234def5678")
+        monkeypatch.setenv("BUILD_DATE", "2026-06-26T15:00:00Z")
+
+        response = client.get("/api/version")
+
+        data = response.json()
+        assert data["commit_sha"] == "abc1234def5678"
+        assert data["build_date"] == "2026-06-26T15:00:00Z"
+
+    def test_version_defaults_to_unknown_when_env_vars_absent(self, monkeypatch):
+        """Version endpoint gracefully returns 'unknown' when env vars are not set."""
+        monkeypatch.delenv("COMMIT_SHA", raising=False)
+        monkeypatch.delenv("BUILD_DATE", raising=False)
+
+        response = client.get("/api/version")
+
+        data = response.json()
+        assert data["commit_sha"] == "unknown"
+        assert data["build_date"] == "unknown"


### PR DESCRIPTION
## Summary

The `/api/version` endpoint reads `COMMIT_SHA` and `BUILD_DATE` from environment variables but returns `"unknown"` in all deployed environments because no build-time injection was in place. This PR wires up the injection across the Docker build pipeline and GitHub Actions workflows.

## Root Cause

The Dockerfile had no `ARG`/`ENV` declarations for these variables, `docker-compose.yml` passed no build args, and the GitHub Actions workflows did not set `COMMIT_SHA`/`BUILD_DATE` env vars before running `make docker-build`.

## Changes

| File | Change |
|------|--------|
| `docker/pybackend.Dockerfile` | Add `ARG COMMIT_SHA=unknown` / `ARG BUILD_DATE=unknown` before WORKDIR; add `ENV COMMIT_SHA=${COMMIT_SHA}` / `ENV BUILD_DATE=${BUILD_DATE}` after existing ENV lines |
| `docker-compose.yml` | Add `args:` block to pybackend build section with `${COMMIT_SHA:-unknown}` defaults |
| `.github/workflows/docker.yml` | Add `env:` block with `${{ github.sha }}` and `${{ github.event.head_commit.timestamp }}` to Build Docker images step |
| `.github/workflows/release.yml` | Add Docker build step with version injection after the backend package build |
| `packages/pybackend/tests/unit/test_api.py` | Strengthen `TestVersionEndpoint`: add type assertions and two new monkeypatch tests for injected values and graceful `"unknown"` fallback |

## Testing

- [x] Unit tests pass (`TestVersionEndpoint` — 4 tests, including 2 new monkeypatch tests)
- [x] Full QA gate passes (`make qa-quick` — 450 passed, 1 skipped)
- [x] Lint passes

## Validation

```bash
# Run new version endpoint tests
cd packages/pybackend && uv run python -m pytest tests/unit/test_api.py::TestVersionEndpoint -v

# Full QA gate
make qa-quick

# Manual Docker validation (requires Docker)
COMMIT_SHA=abc123 BUILD_DATE=2026-06-26T00:00:00Z make docker-build
make docker-up
curl -s http://localhost:3000/api/version | python3 -m json.tool
# Expected: "commit_sha": "abc123", "build_date": "2026-06-26T00:00:00Z"
```

## Issue

Fixes #396

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from issue #396 investigation comment (2026-06-26T15:35:00Z)

### Deviations from plan:
None — all 5 steps implemented exactly as specified.

</details>

_Automated implementation from investigation artifact_