### PR TITLE
Fix: add agent status polling loop to Knowledge, Constitution, Task pages (#589)

### DIFF
--- a/packages/frontend/src/hooks/useAgentPolling.test.ts
+++ b/packages/frontend/src/hooks/useAgentPolling.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useAgentPolling } from "./useAgentPolling";
+
+describe("useAgentPolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not call syncHistory or checkStatus when isProcessing is false", () => {
+    const syncHistory = vi.fn().mockResolvedValue(undefined);
+    const checkStatus = vi.fn().mockResolvedValue(false);
+    renderHook(() =>
+      useAgentPolling({ isProcessing: false, syncHistory, checkStatus }),
+    );
+    expect(syncHistory).not.toHaveBeenCalled();
+    expect(checkStatus).not.toHaveBeenCalled();
+  });
+
+  it("calls syncHistory then checkStatus immediately when isProcessing becomes true", async () => {
+    const syncHistory = vi.fn().mockResolvedValue(undefined);
+    const checkStatus = vi.fn().mockResolvedValue(false);
+    renderHook(() =>
+      useAgentPolling({ isProcessing: true, syncHistory, checkStatus }),
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(syncHistory).toHaveBeenCalledTimes(1);
+    expect(checkStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-polls after 5s when checkStatus returns true (still processing)", async () => {
+    const syncHistory = vi.fn().mockResolvedValue(undefined);
+    const checkStatus = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+    renderHook(() =>
+      useAgentPolling({ isProcessing: true, syncHistory, checkStatus }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    expect(checkStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops polling when checkStatus returns false", async () => {
+    const syncHistory = vi.fn().mockResolvedValue(undefined);
+    const checkStatus = vi.fn().mockResolvedValue(false);
+    renderHook(() =>
+      useAgentPolling({ isProcessing: true, syncHistory, checkStatus }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15000);
+    });
+    expect(checkStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues polling when checkStatus returns null (network error)", async () => {
+    const syncHistory = vi.fn().mockResolvedValue(undefined);
+    const checkStatus = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(false);
+    renderHook(() =>
+      useAgentPolling({ isProcessing: true, syncHistory, checkStatus }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12000);
+    });
+    expect(checkStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("aborts and clears timer on unmount", async () => {
+    const syncHistory = vi.fn().mockResolvedValue(undefined);
+    const checkStatus = vi.fn().mockResolvedValue(true);
+    const { unmount } = renderHook(() =>
+      useAgentPolling({ isProcessing: true, syncHistory, checkStatus }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    unmount();
+    const callsBefore = checkStatus.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(checkStatus.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/packages/frontend/src/hooks/useAgentPolling.ts
+++ b/packages/frontend/src/hooks/useAgentPolling.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+/**
+ * Polls agent status every 5 seconds while chatAgentProcessing is true.
+ * Mirrors the polling useEffect in RepositoryPage.tsx:1249-1275.
+ * Stops when checkStatus() returns false (agent done) or component unmounts.
+ * null (network error) keeps polling.
+ */
+export function useAgentPolling({
+  isProcessing,
+  syncHistory,
+  checkStatus,
+}: {
+  isProcessing: boolean;
+  syncHistory: (signal: AbortSignal) => Promise<void>;
+  checkStatus: () => Promise<boolean | null>;
+}): void {
+  useEffect(() => {
+    if (!isProcessing) return;
+
+    const controller = new AbortController();
+    let timeoutId: number | undefined;
+
+    const tick = async () => {
+      await syncHistory(controller.signal);
+      if (controller.signal.aborted) return;
+      const stillProcessing = await checkStatus();
+      if (controller.signal.aborted) return;
+      // null = network error; keep polling. false = agent done; stop.
+      if (stillProcessing === false) return;
+      timeoutId = window.setTimeout(tick, 5000);
+    };
+
+    tick();
+
+    return () => {
+      controller.abort();
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [isProcessing, syncHistory, checkStatus]);
+}

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -29,8 +29,10 @@ import {
   formatChatMessageLabel,
   formatChatMessageTimestamp,
   mapHistoryToMessages,
+  mergeChatMessages,
 } from "../utils/chat";
 import { useSessionLoader } from "../hooks/useSessionLoader";
+import { useAgentPolling } from "../hooks/useAgentPolling";
 import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 const SessionPickerModal = React.lazy(
@@ -145,6 +147,16 @@ export const ConstitutionPage: React.FC = () => {
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);
+
+  const lastKnownTimestamp = useMemo(() => {
+    if (!chat.length) return undefined;
+    const parsed = Date.parse(chat[chat.length - 1].timestamp);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }, [chat]);
+  const lastKnownTimestampRef = useRef<number | undefined>(lastKnownTimestamp);
+  useEffect(() => {
+    lastKnownTimestampRef.current = lastKnownTimestamp;
+  }, [lastKnownTimestamp]);
 
   const getConstitutionHistory = useCallback(
     (n: string, sid: string, signal?: AbortSignal) =>
@@ -270,6 +282,34 @@ export const ConstitutionPage: React.FC = () => {
       });
   }, [isExternal, linkedExternalMatter, name, navigate]);
 
+  const syncChatHistory = useCallback(
+    async (signal: AbortSignal): Promise<void> => {
+      if (!name || isExternal || !sessionId) return;
+      const startTimestamp = lastKnownTimestampRef.current
+        ? lastKnownTimestampRef.current + 1
+        : undefined;
+      try {
+        const history = await api.getConstitutionAgentHistory(
+          name,
+          sessionId,
+          startTimestamp,
+          signal,
+        );
+        if (signal.aborted) return;
+        if (!history.messages?.length) return;
+        setChat((previousChat) => {
+          const mapped = mapHistoryToMessages(history.messages);
+          return mergeChatMessages(previousChat, mapped);
+        });
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+        console.error("Failed to sync chat history", error);
+      }
+    },
+    [isExternal, name, sessionId, setChat],
+  );
+
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     if (!sessionId) {
@@ -298,6 +338,12 @@ export const ConstitutionPage: React.FC = () => {
   useEffect(() => {
     refreshAgentStatus();
   }, [refreshAgentStatus]);
+
+  useAgentPolling({
+    isProcessing: chatAgentProcessing,
+    syncHistory: syncChatHistory,
+    checkStatus: refreshAgentStatus,
+  });
 
   const openSessionModal = useCallback(async () => {
     if (!name || isExternal) return;
@@ -395,7 +441,7 @@ export const ConstitutionPage: React.FC = () => {
         setActiveTab("agent");
         setAgentStatus(null);
 
-        // Keep chatAgentProcessing=true if processing (triggers existing polling)
+        // Keep chatAgentProcessing=true if still processing; polling loop handles the rest
         if (!reply.processing) setChatAgentProcessing(false);
       } catch (error) {
         console.error("Failed to contact agent", error);
@@ -449,6 +495,7 @@ export const ConstitutionPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
+    lastKnownTimestampRef.current = undefined;
     setSessionId(null);
     setChatAgentProcessing(false);
     setAgentStatus(null);
@@ -458,6 +505,7 @@ export const ConstitutionPage: React.FC = () => {
 
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
+    lastKnownTimestampRef.current = undefined;
     setSessionId(null);
     setChatAgentProcessing(false);
     setAgentStatus(null);

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -29,8 +29,10 @@ import {
   formatChatMessageLabel,
   formatChatMessageTimestamp,
   mapHistoryToMessages,
+  mergeChatMessages,
 } from "../utils/chat";
 import { useSessionLoader } from "../hooks/useSessionLoader";
+import { useAgentPolling } from "../hooks/useAgentPolling";
 import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 const SessionPickerModal = React.lazy(
@@ -76,9 +78,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   );
   const savedSessionStorageKey = useMemo(
     () =>
-      name
-        ? `knowledge-saved-sessions-${name}`
-        : "knowledge-saved-sessions",
+      name ? `knowledge-saved-sessions-${name}` : "knowledge-saved-sessions",
     [name],
   );
   const harnessHistoryStorageKey = useMemo(
@@ -143,6 +143,16 @@ export const KnowledgeArtefactPage: React.FC = () => {
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);
+
+  const lastKnownTimestamp = useMemo(() => {
+    if (!chat.length) return undefined;
+    const parsed = Date.parse(chat[chat.length - 1].timestamp);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }, [chat]);
+  const lastKnownTimestampRef = useRef<number | undefined>(lastKnownTimestamp);
+  useEffect(() => {
+    lastKnownTimestampRef.current = lastKnownTimestamp;
+  }, [lastKnownTimestamp]);
 
   const getKnowledgeHistory = useCallback(
     (n: string, sid: string, signal?: AbortSignal) =>
@@ -268,6 +278,34 @@ export const KnowledgeArtefactPage: React.FC = () => {
       });
   }, [isExternal, linkedExternalMatter, name, navigate]);
 
+  const syncChatHistory = useCallback(
+    async (signal: AbortSignal): Promise<void> => {
+      if (!name || isExternal || !sessionId) return;
+      const startTimestamp = lastKnownTimestampRef.current
+        ? lastKnownTimestampRef.current + 1
+        : undefined;
+      try {
+        const history = await api.getKnowledgeAgentHistory(
+          name,
+          sessionId,
+          startTimestamp,
+          signal,
+        );
+        if (signal.aborted) return;
+        if (!history.messages?.length) return;
+        setChat((previousChat) => {
+          const mapped = mapHistoryToMessages(history.messages);
+          return mergeChatMessages(previousChat, mapped);
+        });
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+        console.error("Failed to sync chat history", error);
+      }
+    },
+    [isExternal, name, sessionId, setChat],
+  );
+
   const refreshAgentStatus = useCallback(async () => {
     if (!name || isExternal) return false;
     if (!sessionId) {
@@ -296,6 +334,12 @@ export const KnowledgeArtefactPage: React.FC = () => {
   useEffect(() => {
     refreshAgentStatus();
   }, [refreshAgentStatus]);
+
+  useAgentPolling({
+    isProcessing: chatAgentProcessing,
+    syncHistory: syncChatHistory,
+    checkStatus: refreshAgentStatus,
+  });
 
   const openSessionModal = useCallback(async () => {
     if (!name || isExternal) return;
@@ -393,7 +437,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
         setActiveTab("agent");
         setAgentStatus(null);
 
-        // Keep chatAgentProcessing=true if processing (triggers existing polling)
+        // Keep chatAgentProcessing=true if still processing; polling loop handles the rest
         if (!reply.processing) setChatAgentProcessing(false);
       } catch (error) {
         console.error("Failed to contact agent", error);
@@ -447,6 +491,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
+    lastKnownTimestampRef.current = undefined;
     setSessionId(null);
     setChatAgentProcessing(false);
     setAgentStatus(null);
@@ -456,6 +501,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
 
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
+    lastKnownTimestampRef.current = undefined;
     setSessionId(null);
     setChatAgentProcessing(false);
     setAgentStatus(null);

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -441,7 +441,9 @@ export const RepositoryPage: React.FC = () => {
   const [isAgentBusy, setIsAgentBusy] = useState(false);
   // Initialize from sessionId so history loading state is correct on first render
   // for persisted sessions (avoids brief flash of stale localStorage content).
-  const [isLoadingHistory, setIsLoadingHistory] = useState(() => Boolean(sessionId));
+  const [isLoadingHistory, setIsLoadingHistory] = useState(() =>
+    Boolean(sessionId),
+  );
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -29,8 +29,10 @@ import {
   formatChatMessageLabel,
   formatChatMessageTimestamp,
   mapHistoryToMessages,
+  mergeChatMessages,
 } from "../utils/chat";
 import { useSessionLoader } from "../hooks/useSessionLoader";
+import { useAgentPolling } from "../hooks/useAgentPolling";
 import { appendRestrictedAccessPolicy } from "../utils/agentPrompt";
 import { ClearSessionModal } from "../components/ClearSessionModal";
 const SessionPickerModal = React.lazy(
@@ -126,6 +128,16 @@ export const TaskPage: React.FC = () => {
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);
+
+  const lastKnownTimestamp = useMemo(() => {
+    if (!chat.length) return undefined;
+    const parsed = Date.parse(chat[chat.length - 1].timestamp);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }, [chat]);
+  const lastKnownTimestampRef = useRef<number | undefined>(lastKnownTimestamp);
+  useEffect(() => {
+    lastKnownTimestampRef.current = lastKnownTimestamp;
+  }, [lastKnownTimestamp]);
 
   const getTaskHistory = useCallback(
     (n: string, sid: string, signal?: AbortSignal) =>
@@ -232,6 +244,34 @@ export const TaskPage: React.FC = () => {
       });
   }, [name, navigate]);
 
+  const syncChatHistory = useCallback(
+    async (signal: AbortSignal): Promise<void> => {
+      if (!name || !sessionId) return;
+      const startTimestamp = lastKnownTimestampRef.current
+        ? lastKnownTimestampRef.current + 1
+        : undefined;
+      try {
+        const history = await api.getTaskAgentHistory(
+          name,
+          sessionId,
+          startTimestamp,
+          signal,
+        );
+        if (signal.aborted) return;
+        if (!history.messages?.length) return;
+        setChat((previousChat) => {
+          const mapped = mapHistoryToMessages(history.messages);
+          return mergeChatMessages(previousChat, mapped);
+        });
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+        console.error("Failed to sync chat history", error);
+      }
+    },
+    [name, sessionId, setChat],
+  );
+
   const refreshAgentStatus = useCallback(async () => {
     if (!name) return false;
     if (!sessionId) {
@@ -257,6 +297,12 @@ export const TaskPage: React.FC = () => {
   useEffect(() => {
     refreshAgentStatus();
   }, [refreshAgentStatus]);
+
+  useAgentPolling({
+    isProcessing: chatAgentProcessing,
+    syncHistory: syncChatHistory,
+    checkStatus: refreshAgentStatus,
+  });
 
   const openSessionModal = useCallback(async () => {
     if (!name) return;
@@ -330,7 +376,7 @@ export const TaskPage: React.FC = () => {
         setActiveTab("agent");
         setAgentStatus(null);
 
-        // Keep chatAgentProcessing=true if processing (triggers existing polling)
+        // Keep chatAgentProcessing=true if still processing; polling loop handles the rest
         if (!reply.processing) setChatAgentProcessing(false);
       } catch (error) {
         console.error("Failed to contact agent", error);
@@ -384,6 +430,7 @@ export const TaskPage: React.FC = () => {
 
   const handleClearSessionOnly = () => {
     sendRequestIdRef.current += 1;
+    lastKnownTimestampRef.current = undefined;
     setSessionId(null);
     setChatAgentProcessing(false);
     setAgentStatus(null);
@@ -393,6 +440,7 @@ export const TaskPage: React.FC = () => {
 
   const handleClearSessionAndHistory = () => {
     sendRequestIdRef.current += 1;
+    lastKnownTimestampRef.current = undefined;
     setSessionId(null);
     setChatAgentProcessing(false);
     setAgentStatus(null);


### PR DESCRIPTION
## Summary

Three pages (`KnowledgeArtefactPage`, `ConstitutionPage`, `TaskPage`) set `chatAgentProcessing=true` when sending a message but had no recurring polling loop to re-check agent status. The `// triggers existing polling` comment in each `handleSendMessage` was written expecting a polling `useEffect` to be added, which was never done. `RepositoryPage` already has the correct 5-second polling pattern.

## Root Cause

PR #556 (commit `85b61fe`) restructured the three pages to use `useSessionLoader` but did not port the polling loop from `RepositoryPage`. The stale comments in `handleSendMessage` are the smoking gun: they promised polling that was never implemented.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/hooks/useAgentPolling.ts` | New shared hook: AbortController + recursive tick + 5s setTimeout |
| `packages/frontend/src/hooks/useAgentPolling.test.ts` | 6 unit tests covering all hook branches |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Add `syncChatHistory`, `lastKnownTimestampRef`, `useAgentPolling`; reset ref in clear-session handlers |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Same pattern with `getConstitutionAgentHistory` |
| `packages/frontend/src/pages/TaskPage.tsx` | Same pattern with `getTaskAgentHistory` (no `isExternal` guard) |

## Testing

- [x] Type check passes
- [x] 275 frontend unit tests pass (6 new for `useAgentPolling`)
- [x] 448 backend tests pass
- [x] Lint passes

## Validation

```bash
cd packages/frontend && npx vitest run src/hooks/useAgentPolling.test.ts
npx tsc --project packages/frontend/tsconfig.json --noEmit
npm run lint
```

## Issue

Fixes #589

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.agents/issues/issue-589.md`

### Deviations from plan:

None — implementation exactly follows the investigation plan from issue #589 comment by tbrandenburg.

</details>

_Automated implementation from investigation artifact_