### PR TITLE
Fix: Virtuoso item height miscalculation in ChatWindow (#602)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -34,6 +34,7 @@ interface MockVirtuosoProps {
     Item?: ComponentType<React.HTMLAttributes<HTMLDivElement>>;
     Footer?: ComponentType;
   };
+  computeItemKey?: (index: number, message: ChatMessage) => string;
   initialTopMostItemIndex?:
     | number
     | { index: number; align?: string; behavior?: string };
@@ -50,6 +51,7 @@ vi.mock("react-virtuoso", async () => {
           data,
           itemContent,
           components,
+          computeItemKey,
           initialTopMostItemIndex,
           followOutput,
         },
@@ -68,8 +70,11 @@ vi.mock("react-virtuoso", async () => {
         return (
           <div>
             {data.map((message, index) => {
+              const key = computeItemKey
+                ? computeItemKey(index, message)
+                : message.id;
               const content = itemContent(index, message);
-              return Item ? <Item key={message.id}>{content}</Item> : content;
+              return Item ? <Item key={key}>{content}</Item> : content;
             })}
             {Footer ? <Footer /> : null}
           </div>
@@ -79,8 +84,9 @@ vi.mock("react-virtuoso", async () => {
   };
 });
 
+let _messageCounter = 0;
 const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
-  id: "message-1",
+  id: `message-${++_messageCounter}`,
   role: "user",
   text: "Hello",
   timestamp: "2026-04-07T00:00:00.000Z",

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -264,6 +264,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             data={chat}
             itemContent={itemContent}
             components={stableComponents}
+            computeItemKey={(_index, message) => message.id}
             followOutput={(atBottom) => (atBottom ? "auto" : false)}
             increaseViewportBy={{ top: 300, bottom: 300 }}
             style={{ height: "100%" }}

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -575,6 +575,18 @@ textarea {
   margin-top: 0.75rem;
 }
 
+.chat-message .markdown h1:first-child,
+.chat-message .markdown h2:first-child,
+.chat-message .markdown h3:first-child {
+  margin-top: 0;
+}
+
+.chat-message .markdown h1:last-child,
+.chat-message .markdown h2:last-child,
+.chat-message .markdown h3:last-child {
+  margin-bottom: 0;
+}
+
 .markdown a {
   text-decoration-line: underline;
   text-decoration-style: dashed;


### PR DESCRIPTION
## Summary

Two independent bugs in the chat window caused Virtuoso to silently miscalculate item heights, making scroll-to-bottom unreachable and causing position jumps whenever streaming content changes.

## Root Cause

**C3 — CSS margin leaking:** The `:first-child`/`:last-child` margin guard pattern (introduced in #458) was applied to `p`, `ul`, `ol`, `blockquote`, but never extended to `h1`/`h2`/`h3`. Heading `margin-top` collapsed outside the SpacedItem wrapper, causing `ResizeObserver.contentRect` to report item heights shorter than actually rendered.

**H2 — Missing `computeItemKey`:** No `computeItemKey` prop was passed to `<Virtuoso>`, so it used array index as item identity. When `mergeChatMessages` inserted or updated a message at a non-tail position, Virtuoso mapped the wrong DOM node to the wrong data, triggering full-list re-layout and DOM recycling artifacts.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/styles/index.css` | Added `:first-child`/`:last-child` margin guards for `h1`, `h2`, `h3` inside `.chat-message .markdown` |
| `packages/frontend/src/components/ChatWindow.tsx` | Added `computeItemKey={(_index, message) => message.id}` to `<Virtuoso>` |
| `packages/frontend/src/components/ChatWindow.test.tsx` | Added `computeItemKey` to mock interface + destructure; updated render loop to use it; fixed `makeMessage` to generate unique IDs via module-scoped counter |

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] Unit tests pass (`vitest run src/components/ChatWindow.test.tsx` — 29/29)
- [x] Lint passes (`eslint . --ext .ts,.tsx`)
- [x] Full quality gate passes (`make qa-quick` — 450 passed, 1 skipped)

## Validation

```bash
cd packages/frontend && npx vitest run src/components/ChatWindow.test.tsx
cd packages/frontend && npx tsc --noEmit
cd packages/frontend && npm run lint
# Or from repo root:
make qa-quick
```

## Issue

Fixes #602

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from:

Issue #602 investigation comment (tbrandenburg, 2026-06-26T16:59:43Z)

### Deviations from plan:

None — implemented exactly as specified.

</details>

_Automated implementation from investigation artifact_