### PR TITLE
Fix: streaming snap-jump and stale Footer spinner in ChatWindow (#604)

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -8,7 +8,7 @@ const scrollToIndexMock = vi.hoisted(() => vi.fn());
 const initialTopMostItemIndexMock = vi.hoisted(() => vi.fn());
 // Captures the `followOutput` callback reference for direct invocation in tests
 const followOutputCapture = vi.hoisted(
-  (): { current: ((atBottom: boolean) => "auto" | false) | undefined } => ({
+  (): { current: ((atBottom: boolean) => "smooth" | false) | undefined } => ({
     current: undefined,
   }),
 );
@@ -32,13 +32,14 @@ interface MockVirtuosoProps {
   itemContent: (index: number, message: ChatMessage) => ReactNode;
   components?: {
     Item?: ComponentType<React.HTMLAttributes<HTMLDivElement>>;
-    Footer?: ComponentType;
+    Footer?: ComponentType<{ context?: Record<string, unknown> }>;
   };
   computeItemKey?: (index: number, message: ChatMessage) => string;
   initialTopMostItemIndex?:
     | number
     | { index: number; align?: string; behavior?: string };
-  followOutput?: (atBottom: boolean) => "auto" | false;
+  followOutput?: (atBottom: boolean) => "smooth" | false;
+  context?: Record<string, unknown>;
 }
 
 vi.mock("react-virtuoso", async () => {
@@ -54,6 +55,7 @@ vi.mock("react-virtuoso", async () => {
           computeItemKey,
           initialTopMostItemIndex,
           followOutput,
+          context,
         },
         ref,
       ) {
@@ -76,7 +78,7 @@ vi.mock("react-virtuoso", async () => {
               const content = itemContent(index, message);
               return Item ? <Item key={key}>{content}</Item> : content;
             })}
-            {Footer ? <Footer /> : null}
+            {Footer ? <Footer context={context} /> : null}
           </div>
         );
       },
@@ -602,8 +604,8 @@ describe("ChatWindow", () => {
     ).toBeDefined();
     // User scrolled up → Virtuoso must NOT auto-scroll
     expect(cb!(false)).toBe(false);
-    // User is at bottom → Virtuoso may auto-scroll
-    expect(cb!(true)).toBe("auto");
+    // User is at bottom → Virtuoso smoothly scrolls
+    expect(cb!(true)).toBe("smooth");
   });
 
   it("passes a referentially stable components prop to Virtuoso across loading-spinner re-renders", () => {

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -166,88 +166,74 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
       [markdownOptions],
     );
 
-    // Keep a ref so the stable Footer closure always reads fresh prop values
-    // without causing the `components` object reference to change.
-    const footerPropsRef = React.useRef({
-      refreshing,
-      sessionLoading,
-      agentProcessing,
-      sessionId,
-      isSessionSaved,
-      onClearSession,
-      onSaveSession,
-    });
-    footerPropsRef.current = {
-      refreshing,
-      sessionLoading,
-      agentProcessing,
-      sessionId,
-      isSessionSaved,
-      onClearSession,
-      onSaveSession,
+    type ChatWindowContext = {
+      refreshing?: boolean;
+      sessionLoading?: boolean;
+      agentProcessing: boolean;
+      sessionId?: string | null;
+      isSessionSaved?: boolean;
+      onClearSession?: () => void;
+      onSaveSession?: () => void;
     };
 
     const stableComponents = React.useMemo(
       () => ({
         Item: SpacedItem,
-        Footer: () => {
-          const p = footerPropsRef.current;
-          return (
-            <>
-              {p.refreshing && (
-                <div className="loading-indicator">
-                  <div className="loading-spinner"></div>
-                  <span>Refreshing...</span>
-                </div>
-              )}
-              {!p.refreshing && p.sessionLoading && (
-                <div className="loading-indicator">
-                  <div className="loading-spinner"></div>
-                  <span>Loading session...</span>
-                </div>
-              )}
-              {!p.refreshing && !p.sessionLoading && p.agentProcessing && (
-                <div className="loading-indicator">
-                  <div className="loading-spinner"></div>
-                  <span>Agent is thinking...</span>
-                </div>
-              )}
-              {p.sessionId && (
-                <div className="chat-session-id" aria-label="Session ID">
-                  <span>Session ID: {p.sessionId}</span>
-                  <button
-                    type="button"
-                    className="icon-button-small"
-                    aria-label={
-                      p.isSessionSaved ? "Session saved" : "Save session"
-                    }
-                    title={
-                      p.isSessionSaved
-                        ? "Session already saved"
-                        : "Save session"
-                    }
-                    onClick={p.onSaveSession}
-                    disabled={!p.onSaveSession || p.isSessionSaved}
-                  >
-                    <SaveIcon />
-                  </button>
-                  <button
-                    type="button"
-                    className="icon-button-small"
-                    aria-label="Clear session"
-                    title="Clear session"
-                    onClick={p.onClearSession}
-                    disabled={!p.onClearSession}
-                  >
-                    <TrashIcon />
-                  </button>
-                </div>
-              )}
-            </>
-          );
-        },
+        Footer: ({ context: ctx }: { context: ChatWindowContext }) => (
+          <>
+            {ctx.refreshing && (
+              <div className="loading-indicator">
+                <div className="loading-spinner"></div>
+                <span>Refreshing...</span>
+              </div>
+            )}
+            {!ctx.refreshing && ctx.sessionLoading && (
+              <div className="loading-indicator">
+                <div className="loading-spinner"></div>
+                <span>Loading session...</span>
+              </div>
+            )}
+            {!ctx.refreshing && !ctx.sessionLoading && ctx.agentProcessing && (
+              <div className="loading-indicator">
+                <div className="loading-spinner"></div>
+                <span>Agent is thinking...</span>
+              </div>
+            )}
+            {ctx.sessionId && (
+              <div className="chat-session-id" aria-label="Session ID">
+                <span>Session ID: {ctx.sessionId}</span>
+                <button
+                  type="button"
+                  className="icon-button-small"
+                  aria-label={
+                    ctx.isSessionSaved ? "Session saved" : "Save session"
+                  }
+                  title={
+                    ctx.isSessionSaved
+                      ? "Session already saved"
+                      : "Save session"
+                  }
+                  onClick={ctx.onSaveSession}
+                  disabled={!ctx.onSaveSession || ctx.isSessionSaved}
+                >
+                  <SaveIcon />
+                </button>
+                <button
+                  type="button"
+                  className="icon-button-small"
+                  aria-label="Clear session"
+                  title="Clear session"
+                  onClick={ctx.onClearSession}
+                  disabled={!ctx.onClearSession}
+                >
+                  <TrashIcon />
+                </button>
+              </div>
+            )}
+          </>
+        ),
       }),
-      [], // Created once; Footer reads latest values via footerPropsRef
+      [], // Created once; Footer receives latest values reactively via Virtuoso context prop
     );
 
     return (
@@ -265,7 +251,16 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             itemContent={itemContent}
             components={stableComponents}
             computeItemKey={(_index, message) => message.id}
-            followOutput={(atBottom) => (atBottom ? "auto" : false)}
+            context={{
+              refreshing,
+              sessionLoading,
+              agentProcessing,
+              sessionId,
+              isSessionSaved,
+              onClearSession,
+              onSaveSession,
+            }}
+            followOutput={(atBottom) => (atBottom ? "smooth" : false)}
             increaseViewportBy={{ top: 300, bottom: 300 }}
             style={{ height: "100%" }}
           />


### PR DESCRIPTION
## Summary

Two UX regressions in `ChatWindow.tsx` that together make the live streaming experience feel broken:

1. `followOutput` used `"auto"` (instant teleport) causing stroboscopic snap-jumps on every streaming token (~150–500ms), while the manual scroll-to-bottom button already used `"smooth"`.
2. `stableComponents.Footer` read props through a mutable `footerPropsRef` with no reactive subscription. Virtuoso only re-renders Footer on list-state changes, so the "Agent is thinking..." spinner could lag or never appear when `agentProcessing` changed without a new message arriving.

## Root Cause

- **Snap-jump**: `followOutput` returned `"auto"` — instantaneous scroll — instead of `"smooth"` already used by `scrollToBottom`.
- **Stale spinner**: `footerPropsRef` is mutated on every render but mutations do not trigger a React re-render of the Footer closure. Virtuoso's built-in `context` prop is the correct reactive solution.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/components/ChatWindow.tsx` | Remove `footerPropsRef` + mutation; add `ChatWindowContext` type; rewrite Footer to use `context` prop; add `context` to `<Virtuoso>`; change `followOutput` to `"smooth"` |
| `packages/frontend/src/components/ChatWindow.test.tsx` | Update `followOutputCapture` type, `MockVirtuosoProps` interface, `MockVirtuoso` body to forward `context`, and test assertion from `"auto"` to `"smooth"` |

## Testing

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 29 ChatWindow unit tests pass (`npx vitest run src/components/ChatWindow`)
- [x] Full QA gate passes (`make qa-quick`: lint + format + unit tests)
- [x] `stableComponents` referential-stability test still passes (useMemo deps `[]` unchanged)

## Validation

```bash
cd packages/frontend && npx tsc --noEmit
npx vitest run src/components/ChatWindow
cd ../.. && make qa-quick
```

## Issue

Fixes #604

<details>
<summary>Implementation Details</summary>

### Deviations from plan

- **`context?: any` → `context?: Record<string, unknown>`** in `MockVirtuosoProps` and `Footer` component type in test file. The investigation plan used `any` but the project's ESLint rules forbid `@typescript-eslint/no-explicit-any`. Using `Record<string, unknown>` is equivalent for the mock and satisfies the linter.
- All other steps followed exactly as specified in the investigation comment.

</details>

_Automated implementation from investigation artifact (.agents/issues/issue-604.md)_