### PR TITLE
Fix: cross-route state leak in usePersistentString (#616)

### DIFF
--- a/.claude/PRPs/issues/completed/issue-616.md
+++ b/.claude/PRPs/issues/completed/issue-616.md
@@ -1,0 +1,21 @@
+# Issue 616
+
+Title: Fix cross-route state leak in `usePersistentString` when storage key changes
+
+Type: BUG
+
+Implementation summary:
+- Added optional `scopeKey` handling to `usePersistentString`.
+- Reset route-scoped values cleanly when the entity scope changes.
+- Preserved the `agentCli` bootstrap transition behavior.
+- Passed route scope through Repository, Task, KnowledgeArtefact, and Constitution pages.
+- Added regression tests for route-scope reset and bootstrap preservation.
+
+Validation:
+- `npm --workspace packages/frontend exec vitest run src/hooks/usePersistentString.test.tsx`
+- `npm --workspace packages/frontend test`
+- `npm --workspace packages/frontend exec tsc --noEmit`
+- `npm --workspace packages/frontend run lint`
+
+Notes:
+- The original artifact file was not present in the workspace, so this archive was created from the investigation plan captured on issue #616.

--- a/packages/frontend/src/hooks/usePersistentString.test.tsx
+++ b/packages/frontend/src/hooks/usePersistentString.test.tsx
@@ -1,0 +1,94 @@
+import { render } from "@testing-library/react";
+import { useEffect } from "react";
+import { describe, expect, it } from "vitest";
+import { usePersistentString } from "./usePersistentString";
+
+const TestComponent = ({
+  storageKey,
+  initialValue,
+  scopeKey,
+  setNextValue,
+}: {
+  storageKey: string | undefined;
+  initialValue?: string | null;
+  scopeKey?: string;
+  setNextValue?: string | null;
+}) => {
+  const [value, setValue] = usePersistentString(
+    storageKey,
+    initialValue ?? null,
+    scopeKey,
+  );
+
+  useEffect(() => {
+    if (setNextValue !== undefined) {
+      setValue(setNextValue);
+    }
+  }, [setNextValue, setValue]);
+
+  return <div data-testid="value">{value ?? ""}</div>;
+};
+
+describe("usePersistentString", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("reads the stored value on mount", () => {
+    localStorage.setItem("test-key", "stored-value");
+
+    const { getByTestId } = render(
+      <TestComponent storageKey="test-key" scopeKey="repo-a" />,
+    );
+
+    expect(getByTestId("value").textContent).toBe("stored-value");
+  });
+
+  it("resets to initialValue when the route scope changes to a new empty key", () => {
+    localStorage.setItem("repo-a", "stale-value");
+
+    const { getByTestId, rerender } = render(
+      <TestComponent storageKey="repo-a" scopeKey="repo-a" />,
+    );
+
+    expect(getByTestId("value").textContent).toBe("stale-value");
+
+    rerender(
+      <TestComponent
+        storageKey="repo-b"
+        scopeKey="repo-b"
+        initialValue={null}
+      />,
+    );
+
+    expect(getByTestId("value").textContent).toBe("");
+    expect(localStorage.getItem("repo-b")).toBeNull();
+  });
+
+  it("preserves the current value when only the bootstrap key changes", async () => {
+    const { getByTestId, rerender } = render(
+      <TestComponent storageKey={undefined} scopeKey="repo-a" initialValue="boot" />,
+    );
+
+    expect(getByTestId("value").textContent).toBe("boot");
+
+    rerender(
+      <TestComponent storageKey="repo-a-bootstrap" scopeKey="repo-a" initialValue="boot" />,
+    );
+
+    expect(getByTestId("value").textContent).toBe("boot");
+    expect(localStorage.getItem("repo-a-bootstrap")).toBeNull();
+  });
+
+  it("persists user updates to localStorage", () => {
+    const { rerender } = render(
+      <TestComponent storageKey="test-key" scopeKey="repo-a" />,
+    );
+
+    rerender(
+      <TestComponent storageKey="test-key" scopeKey="repo-a" setNextValue="user-value" />,
+    );
+
+    expect(localStorage.getItem("test-key")).toBe("user-value");
+  });
+});

--- a/packages/frontend/src/hooks/usePersistentString.test.tsx
+++ b/packages/frontend/src/hooks/usePersistentString.test.tsx
@@ -77,7 +77,7 @@ describe("usePersistentString", () => {
     );
 
     expect(getByTestId("value").textContent).toBe("boot");
-    expect(localStorage.getItem("repo-a-bootstrap")).toBeNull();
+    expect(localStorage.getItem("repo-a-bootstrap")).toBe("boot");
   });
 
   it("persists user updates to localStorage", () => {

--- a/packages/frontend/src/hooks/usePersistentString.ts
+++ b/packages/frontend/src/hooks/usePersistentString.ts
@@ -1,9 +1,13 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export const usePersistentString = (
   storageKey: string | undefined,
   initialValue: string | null = null,
+  scopeKey?: string,
 ) => {
+  const lastScopeKeyRef = useRef(scopeKey);
+  const skipPersistRef = useRef(false);
+
   const readValue = useCallback(() => {
     if (!storageKey) return initialValue;
     try {
@@ -19,23 +23,32 @@ export const usePersistentString = (
 
   useEffect(() => {
     if (!storageKey) {
-      // Key is unknown (e.g. agentCli not yet loaded). Keep the current
-      // in-memory value — don't reset. The persist effect is also a no-op
-      // while storageKey is undefined, so no spurious localStorage writes occur.
+      lastScopeKeyRef.current = scopeKey;
       return;
     }
+
     const stored = readValue();
-    // Prefer the stored localStorage entry when it exists.
-    // If storage is empty, keep the current in-memory value (e.g. set from a
-    // URL bootstrap param while the key was still resolving) rather than
-    // resetting to initialValue — the persist effect will write it on next tick.
+    const scopeChanged = lastScopeKeyRef.current !== scopeKey;
+    lastScopeKeyRef.current = scopeKey;
+
     if (stored !== null) {
       setValue(stored);
+      skipPersistRef.current = true;
+      return;
     }
-  }, [initialValue, readValue, storageKey]);
+
+    if (scopeChanged) {
+      skipPersistRef.current = true;
+      setValue(initialValue);
+    }
+  }, [initialValue, readValue, scopeKey, storageKey]);
 
   useEffect(() => {
     if (!storageKey) return;
+    if (skipPersistRef.current) {
+      skipPersistRef.current = false;
+      return;
+    }
     try {
       if (value) {
         localStorage.setItem(storageKey, value);

--- a/packages/frontend/src/hooks/usePersistentString.ts
+++ b/packages/frontend/src/hooks/usePersistentString.ts
@@ -8,16 +8,20 @@ export const usePersistentString = (
   const lastScopeKeyRef = useRef(scopeKey);
   const skipPersistRef = useRef(false);
 
-  const readValue = useCallback(() => {
-    if (!storageKey) return initialValue;
+  const readStoredValue = useCallback(() => {
+    if (!storageKey) return null;
     try {
-      const stored = localStorage.getItem(storageKey);
-      return stored ?? initialValue;
+      return localStorage.getItem(storageKey);
     } catch (error) {
       console.warn("Failed to read value from localStorage", error);
-      return initialValue;
+      return null;
     }
-  }, [initialValue, storageKey]);
+  }, [storageKey]);
+
+  const readValue = useCallback(() => {
+    const stored = readStoredValue();
+    return stored ?? initialValue;
+  }, [initialValue, readStoredValue]);
 
   const [value, setValue] = useState<string | null>(readValue);
 
@@ -27,7 +31,7 @@ export const usePersistentString = (
       return;
     }
 
-    const stored = readValue();
+    const stored = readStoredValue();
     const scopeChanged = lastScopeKeyRef.current !== scopeKey;
     lastScopeKeyRef.current = scopeKey;
 

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -100,7 +100,11 @@ export const ConstitutionPage: React.FC = () => {
     [name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
-  const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [sessionId, setSessionId] = usePersistentString(
+    sessionStorageKey,
+    null,
+    name,
+  );
   const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
     savedSessionStorageKey,
   );
@@ -142,6 +146,7 @@ export const ConstitutionPage: React.FC = () => {
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
+    name,
   );
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -98,7 +98,11 @@ export const KnowledgeArtefactPage: React.FC = () => {
     [name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
-  const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [sessionId, setSessionId] = usePersistentString(
+    sessionStorageKey,
+    null,
+    name,
+  );
   const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
     savedSessionStorageKey,
   );
@@ -138,6 +142,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
+    name,
   );
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -429,7 +429,11 @@ export const RepositoryPage: React.FC = () => {
     [name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
-  const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [sessionId, setSessionId] = usePersistentString(
+    sessionStorageKey,
+    null,
+    name,
+  );
   const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
     savedSessionStorageKey,
   );
@@ -470,10 +474,12 @@ export const RepositoryPage: React.FC = () => {
   const [selectedModel, setSelectedModel] = usePersistentString(
     modelStorageKey,
     "default",
+    name,
   );
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
+    name,
   );
   const normalizedSelectedModel = selectedModel ?? "default";
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -88,7 +88,11 @@ export const TaskPage: React.FC = () => {
     [name],
   );
   const [chat, setChat] = usePersistentChat(chatStorageKey);
-  const [sessionId, setSessionId] = usePersistentString(sessionStorageKey);
+  const [sessionId, setSessionId] = usePersistentString(
+    sessionStorageKey,
+    null,
+    name,
+  );
   const [savedSessionIds, setSavedSessionIds] = usePersistentStringList(
     savedSessionStorageKey,
   );
@@ -127,6 +131,7 @@ export const TaskPage: React.FC = () => {
   const [selectedAgent, setSelectedAgent] = usePersistentString(
     agentStorageKey,
     DEFAULT_AGENT_VALUE,
+    name,
   );
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");


### PR DESCRIPTION
## Summary

`usePersistentString` could leak stale route-scoped state across entity navigation when the destination storage key had no stored value.

## Root Cause

The hook treated ordinary route changes and the `agentCli` bootstrap transition the same, so empty destination keys could reuse the prior in-memory value.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/hooks/usePersistentString.ts` | Added scope-aware handling and prevented stale writes on key transitions |
| `packages/frontend/src/hooks/usePersistentString.test.tsx` | Added regression tests for route reset and bootstrap preservation |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Passed route scope into persistent session/model/agent state |
| `packages/frontend/src/pages/TaskPage.tsx` | Passed route scope into persistent session/agent state |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Passed route scope into persistent session/agent state |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Passed route scope into persistent session/agent state |

## Testing

- [x] `npm --workspace packages/frontend exec vitest run src/hooks/usePersistentString.test.tsx`
- [x] `npm --workspace packages/frontend test`
- [x] `npm --workspace packages/frontend exec tsc --noEmit`
- [x] `npm --workspace packages/frontend run lint`

## Validation

```bash
npm --workspace packages/frontend exec vitest run src/hooks/usePersistentString.test.tsx && npm --workspace packages/frontend test && npm --workspace packages/frontend exec tsc --noEmit && npm --workspace packages/frontend run lint
```

## Issue

Fixes #616

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.agents/issues/issue-616.md`

### Deviations from plan:

- The original artifact file was not present in the workspace, so the completed archive was recreated from the issue investigation comment.
- The environment did not provide `make`, so validation used the equivalent frontend commands directly.

</details>

_Automated implementation from investigation artifact_