### PR TITLE
Fix: Sync migrated session storage into React state after legacy key migration (#617)

### DIFF
--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -127,11 +127,22 @@ export const ConstitutionPage: React.FC = () => {
       if (oldSession && !localStorage.getItem(sessionStorageKey)) {
         localStorage.setItem(sessionStorageKey, oldSession);
         localStorage.removeItem(oldSessionKey);
+        setSessionId(oldSession);
       }
       const oldSaved = localStorage.getItem(oldSavedSessionKey);
       if (oldSaved && !localStorage.getItem(savedSessionStorageKey)) {
         localStorage.setItem(savedSessionStorageKey, oldSaved);
         localStorage.removeItem(oldSavedSessionKey);
+        try {
+          const parsed = JSON.parse(oldSaved);
+          if (Array.isArray(parsed)) {
+            setSavedSessionIds(
+              parsed.filter((entry): entry is string => typeof entry === "string"),
+            );
+          }
+        } catch {
+          // ignore parse error — localStorage data already written for next load
+        }
       }
     } catch {
       // localStorage unavailable

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -123,11 +123,22 @@ export const KnowledgeArtefactPage: React.FC = () => {
       if (oldSession && !localStorage.getItem(sessionStorageKey)) {
         localStorage.setItem(sessionStorageKey, oldSession);
         localStorage.removeItem(oldSessionKey);
+        setSessionId(oldSession);
       }
       const oldSaved = localStorage.getItem(oldSavedSessionKey);
       if (oldSaved && !localStorage.getItem(savedSessionStorageKey)) {
         localStorage.setItem(savedSessionStorageKey, oldSaved);
         localStorage.removeItem(oldSavedSessionKey);
+        try {
+          const parsed = JSON.parse(oldSaved);
+          if (Array.isArray(parsed)) {
+            setSavedSessionIds(
+              parsed.filter((entry): entry is string => typeof entry === "string"),
+            );
+          }
+        } catch {
+          // ignore parse error — localStorage data already written for next load
+        }
       }
     } catch {
       // localStorage unavailable

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -454,11 +454,22 @@ export const RepositoryPage: React.FC = () => {
       if (oldSession && !localStorage.getItem(sessionStorageKey)) {
         localStorage.setItem(sessionStorageKey, oldSession);
         localStorage.removeItem(oldSessionKey);
+        setSessionId(oldSession);
       }
       const oldSaved = localStorage.getItem(oldSavedSessionKey);
       if (oldSaved && !localStorage.getItem(savedSessionStorageKey)) {
         localStorage.setItem(savedSessionStorageKey, oldSaved);
         localStorage.removeItem(oldSavedSessionKey);
+        try {
+          const parsed = JSON.parse(oldSaved);
+          if (Array.isArray(parsed)) {
+            setSavedSessionIds(
+              parsed.filter((entry): entry is string => typeof entry === "string"),
+            );
+          }
+        } catch {
+          // ignore parse error — localStorage data already written for next load
+        }
       }
     } catch {
       // localStorage unavailable

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -112,11 +112,22 @@ export const TaskPage: React.FC = () => {
       if (oldSession && !localStorage.getItem(sessionStorageKey)) {
         localStorage.setItem(sessionStorageKey, oldSession);
         localStorage.removeItem(oldSessionKey);
+        setSessionId(oldSession);
       }
       const oldSaved = localStorage.getItem(oldSavedSessionKey);
       if (oldSaved && !localStorage.getItem(savedSessionStorageKey)) {
         localStorage.setItem(savedSessionStorageKey, oldSaved);
         localStorage.removeItem(oldSavedSessionKey);
+        try {
+          const parsed = JSON.parse(oldSaved);
+          if (Array.isArray(parsed)) {
+            setSavedSessionIds(
+              parsed.filter((entry): entry is string => typeof entry === "string"),
+            );
+          }
+        } catch {
+          // ignore parse error — localStorage data already written for next load
+        }
       }
     } catch {
       // localStorage unavailable

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -5527,5 +5527,19 @@ describe("useAgentCli session key namespacing (Issue #611)", () => {
     );
     // Old key is removed.
     expect(localStorage.getItem("repository-session-test-repo")).toBeNull();
+
+    // After migration, the React state should be synced so the
+    // repository agent history API is called with the migrated sessionId.
+    await waitFor(
+      () => {
+        expect(api.getRepositoryAgentHistory).toHaveBeenCalledWith(
+          "test-repo",
+          "session-legacy",
+          undefined,
+          expect.anything(),
+        );
+      },
+      { timeout: 2000 },
+    );
   });
 });


### PR DESCRIPTION
## Summary

The migration useEffect blocks in RepositoryPage, ConstitutionPage, KnowledgeArtefactPage, and TaskPage copy values from legacy un-namespaced localStorage keys into the new agentCli-namespaced keys after mount, but they never call the React state setters. Users upgrading from the old key layout see a blank/default session on the first render after migration because the in-memory React state and localStorage diverge until the next page remount.

## Root Cause

The migration effects were written to directly mutate localStorage but neglected to synchronize the in-memory React state. The hooks `usePersistentString` and `usePersistentStringList` initialize from the new (empty) key during render, and only re-sync when `storageKey` changes. Since the migration runs in a `useEffect` after render and the `storageKey` is stable from first render, the localStorage values are never picked up by React state.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Added `setSessionId()` and `setSavedSessionIds()` calls in migration effect |
| `packages/frontend/src/pages/ConstitutionPage.tsx` | Added `setSessionId()` and `setSavedSessionIds()` calls in migration effect |
| `packages/frontend/src/pages/KnowledgeArtefactPage.tsx` | Added `setSessionId()` and `setSavedSessionIds()` calls in migration effect |
| `packages/frontend/src/pages/TaskPage.tsx` | Added `setSessionId()` and `setSavedSessionIds()` calls in migration effect |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Added React state sync assertion to existing migration test |

## Testing

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Unit tests pass (137 tests, including updated migration test)
- [x] Lint passes (`npm run lint`)

## Validation

```bash
cd packages/frontend
npx vitest run --reporter=verbose src/pages/__tests__/RepositoryPage.test.tsx
npx tsc --noEmit
npm run lint
```

## Issue

Fixes #617

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.agents/issues/issue-617.md`

### Deviations from plan:

None

</details>

_Automated implementation from investigation artifact_
