### PR TITLE
Fix: Backend cancel should resolve by live session lookup (#629)

### DIFF
--- a/.claude/PRPs/issues/completed/issue-629.md
+++ b/.claude/PRPs/issues/completed/issue-629.md
@@ -1,0 +1,27 @@
+# Investigation: [Critical] Backend cancel should terminate by live session lookup
+
+**Issue**: #629
+**Type**: BUG
+**Investigated**: 2026-06-28T08:35:00Z
+
+### Problem Statement
+
+`POST /api/*/agent/cancel` should cancel by `sessionId` using the same live-session truth as status, but `cancel_agent_message()` still depended on a stale in-memory membership check. If `_processing_channels` lost the entry, cancel returned `404` even when the CLI process was still live.
+
+### Implementation Plan
+
+1. Mirror the status resolution path in `cancel_agent_message()`.
+2. Add reverse session lookup via `_conversation_sessions`.
+3. Add persisted-state fallback via `_load_processing_state()`.
+4. Return not-found when no live process can be resolved.
+5. Add unit tests covering reverse lookup, persisted fallback, not-found behavior, and direct channel-key cancel.
+
+### Validation
+
+- `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -x -v -k "cancel_agent_message"`
+- `make qa-quick`
+
+### Notes
+
+- `get_channel_status()` already used the required fallback chain.
+- The fix was kept local to `packages/pybackend/agent_service.py` and `packages/pybackend/tests/unit/test_unit.py`.

--- a/packages/frontend/src/hooks/usePersistentString.test.tsx
+++ b/packages/frontend/src/hooks/usePersistentString.test.tsx
@@ -67,13 +67,21 @@ describe("usePersistentString", () => {
 
   it("preserves the current value when only the bootstrap key changes", async () => {
     const { getByTestId, rerender } = render(
-      <TestComponent storageKey={undefined} scopeKey="repo-a" initialValue="boot" />,
+      <TestComponent
+        storageKey={undefined}
+        scopeKey="repo-a"
+        initialValue="boot"
+      />,
     );
 
     expect(getByTestId("value").textContent).toBe("boot");
 
     rerender(
-      <TestComponent storageKey="repo-a-bootstrap" scopeKey="repo-a" initialValue="boot" />,
+      <TestComponent
+        storageKey="repo-a-bootstrap"
+        scopeKey="repo-a"
+        initialValue="boot"
+      />,
     );
 
     expect(getByTestId("value").textContent).toBe("boot");
@@ -86,7 +94,11 @@ describe("usePersistentString", () => {
     );
 
     rerender(
-      <TestComponent storageKey="test-key" scopeKey="repo-a" setNextValue="user-value" />,
+      <TestComponent
+        storageKey="test-key"
+        scopeKey="repo-a"
+        setNextValue="user-value"
+      />,
     );
 
     expect(localStorage.getItem("test-key")).toBe("user-value");

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -137,7 +137,9 @@ export const ConstitutionPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -133,7 +133,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -464,7 +464,9 @@ export const RepositoryPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -122,7 +122,9 @@ export const TaskPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1361,7 +1361,9 @@ describe("RepositoryPage reload current session (AC1-AC7)", () => {
 
     // Assert: busy state is hydrated from history
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
     });
   });
 });
@@ -5312,7 +5314,9 @@ describe("RepositoryPage simplified lifecycle (issue #588)", () => {
         undefined,
         expect.anything(),
       );
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -273,32 +273,77 @@ def _was_channel_cancelled(channel: str) -> bool:
 
 def cancel_agent_message(lock_key: str) -> bool:
     """Cancel an active agent message for the given lock key."""
-    with _processing_lock:
-        if lock_key not in _processing_channels:
-            return False
+    session_snapshot: list[tuple[str, str]] = []
+    cancel_event = None
+    process = None
+    cleanup_key = lock_key
+    started_at = None
 
+    with _processing_lock:
+        started_at = _processing_channels.get(lock_key)
+        if started_at is None:
+            # Fallback 1: reverse lookup via _conversation_sessions mapping.
+            for ch, sid in list(_conversation_sessions.items()):
+                if sid == lock_key:
+                    started_at = _processing_channels.get(ch)
+                    if started_at is not None:
+                        _processing_channels[lock_key] = started_at
+                    break
+
+        if started_at is None:
+            session_snapshot = list(_conversation_sessions.items())
+
+    # Fallback 2: persisted state (survives backend restart) — outside the lock
+    # to avoid blocking all threads on file I/O.
+    if started_at is None:
+        persisted = _load_processing_state()
+        persisted_started = persisted.get(lock_key)
+        if persisted_started is None:
+            for ch, sid in session_snapshot:
+                if sid == lock_key:
+                    persisted_started = persisted.get(ch)
+                    cleanup_key = ch
+                    break
+            if persisted_started is None and len(persisted) == 1:
+                cleanup_key = next(iter(persisted))
+                persisted_started = persisted[cleanup_key]
+        else:
+            cleanup_key = lock_key
+        if persisted_started is None:
+            return False
+        with _processing_lock:
+            _processing_channels[lock_key] = persisted_started
+        started_at = persisted_started
+
+    with _processing_lock:
         related = _get_related_processing_keys(lock_key)
-        cancel_event = None
-        process = None
         for key in related:
-            _cancelled_channels.add(key)
             if cancel_event is None:
                 cancel_event = _cancel_events.get(key)
             if process is None:
                 process = _active_processes.get(key)
+
+    if process is None or process.poll() is not None:
+        _clear_channel_processing(cleanup_key)
+        return False
+
+    with _processing_lock:
+        related = _get_related_processing_keys(lock_key)
+        for key in related:
+            _cancelled_channels.add(key)
             _processing_channels.pop(key, None)
             _cancel_events.pop(key, None)
             _active_processes.pop(key, None)
+
     _dump_processing_state()
 
     if cancel_event:
         cancel_event.set()
-    if process and process.poll() is None:
-        process.terminate()
-        try:
-            process.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            process.kill()
+    process.terminate()
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
     return True
 
 

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -745,6 +745,133 @@ class TestAgentService:
         assert status["processing"] is True
         assert status["startedAt"] is not None
 
+    def test_cancel_agent_message_by_session_id_reverse_lookup(self):
+        """cancel_agent_message must find processing entry by reverse lookup when lock_key is a session_id."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock
+        from agent_service import (
+            cancel_agent_message,
+            _conversation_sessions,
+            _processing_channels,
+            _active_processes,
+            _cancel_events,
+            _processing_lock,
+        )
+
+        channel = "cancel-reverse-lookup-repo"
+        session_id = "cancel-reverse-session-123"
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        try:
+            with _processing_lock:
+                _conversation_sessions[channel] = session_id
+                _processing_channels[channel] = datetime.now(UTC)
+                _active_processes[channel] = mock_proc
+                _cancel_events[channel] = MagicMock()
+
+            assert cancel_agent_message(session_id) is True
+            mock_proc.terminate.assert_called_once()
+        finally:
+            with _processing_lock:
+                _conversation_sessions.pop(channel, None)
+                _processing_channels.pop(channel, None)
+                _processing_channels.pop(session_id, None)
+                _active_processes.pop(channel, None)
+                _cancel_events.pop(channel, None)
+
+    def test_cancel_agent_message_falls_back_to_persisted_state(self):
+        """cancel_agent_message must restore state from disk, but still return not found when no live process exists."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            cancel_agent_message,
+            _processing_channels,
+            _active_processes,
+            _processing_lock,
+        )
+
+        lock_key = "cancel-persisted-session-456"
+        with _processing_lock:
+            _processing_channels.pop(lock_key, None)
+            _active_processes.pop(lock_key, None)
+
+        with patch("agent_service._load_processing_state") as mock_load:
+            mock_load.return_value = {lock_key: datetime.now(UTC)}
+            with patch("agent_service._dump_processing_state"):
+                assert cancel_agent_message(lock_key) is False
+
+        with _processing_lock:
+            assert lock_key not in _processing_channels
+
+    def test_cancel_agent_message_not_found_when_no_process(self):
+        """cancel_agent_message must return False when no live process can be resolved."""
+        from unittest.mock import patch
+        from agent_service import (
+            cancel_agent_message,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        lock_key = "cancel-nonexistent-session-789"
+        with _processing_lock:
+            _processing_channels.pop(lock_key, None)
+
+        with patch("agent_service._load_processing_state") as mock_load:
+            mock_load.return_value = {}
+            with patch("agent_service._dump_processing_state"):
+                assert cancel_agent_message(lock_key) is False
+
+    def test_cancel_agent_message_clears_single_persisted_entry_when_session_unknown(self):
+        """cancel_agent_message must clear a uniquely identifiable stale persisted entry even if the session map is empty."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            cancel_agent_message,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        lock_key = "cancel-persisted-orphan-999"
+        with _processing_lock:
+            _processing_channels.pop(lock_key, None)
+
+        with patch("agent_service._load_processing_state") as mock_load:
+            mock_load.return_value = {lock_key: datetime.now(UTC)}
+            with patch("agent_service._dump_processing_state"):
+                assert cancel_agent_message(lock_key) is False
+
+        with _processing_lock:
+            assert lock_key not in _processing_channels
+
+    def test_cancel_agent_message_by_channel_key_direct(self):
+        """cancel_agent_message must still work with the direct channel key."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock
+        from agent_service import (
+            cancel_agent_message,
+            _processing_channels,
+            _active_processes,
+            _cancel_events,
+            _processing_lock,
+        )
+
+        channel = "cancel-direct-channel"
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        try:
+            with _processing_lock:
+                _processing_channels[channel] = datetime.now(UTC)
+                _active_processes[channel] = mock_proc
+                _cancel_events[channel] = MagicMock()
+
+            assert cancel_agent_message(channel) is True
+            mock_proc.terminate.assert_called_once()
+        finally:
+            with _processing_lock:
+                _processing_channels.pop(channel, None)
+                _active_processes.pop(channel, None)
+                _cancel_events.pop(channel, None)
+
     def test_alias_cleanup_removes_all_related_keys_on_process_exit(self):
         """get_channel_status cleanup must remove both channel and session_id keys when process exits."""
         from datetime import UTC, datetime


### PR DESCRIPTION
## Summary

Cancel now resolves the live agent process using the same session/channel fallback chain as status, instead of failing only because the in-memory processing map lost the entry.

## Root Cause

`cancel_agent_message()` stopped after a single membership check in `_processing_channels`, while `get_channel_status()` already handled reverse session lookup and persisted-state fallback.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/agent_service.py` | Added reverse lookup and persisted-state fallback, preserved live-process termination, and kept stale cleanup safe. |
| `packages/pybackend/tests/unit/test_unit.py` | Added regression tests for reverse lookup, persisted fallback, not-found behavior, stale persisted cleanup, and direct cancel. |
| `.claude/PRPs/issues/completed/issue-629.md` | Archived the investigation artifact. |

## Testing

- [x] `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -x -v -k "cancel_agent_message"`
- [x] `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_api.py -x -v -k "repository_agent_cancel"`
- [x] `make qa-quick`

## Validation

```bash
uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -x -v -k "cancel_agent_message" && make qa-quick
```

## Issue

Fixes #629

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #629

### Deviations from plan:

Kept cancel strict: it returns not-found when no live process exists, while still cleaning up stale persisted state when it can be uniquely identified.

</details>

_Automated implementation from investigation artifact_