### PR TITLE
Fix: agent status reflects live process (#626)

### DIFF
--- a/.claude/PRPs/issues/completed/issue-626.md
+++ b/.claude/PRPs/issues/completed/issue-626.md
@@ -1,0 +1,28 @@
+# Investigation: [Critical] Agent status must reflect live CLI process for a session
+
+**Issue**: #626
+**Type**: BUG
+**Investigated**: 2026-06-28
+
+## Problem Statement
+
+`GET /api/*/agent/status` reports whether an agent is processing based on bookkeeping state. That state can drift from the real OS process table, so a session can be reported as active even when the underlying agent CLI is no longer running.
+
+## Root Cause
+
+The status path trusted `_processing_channels`, `_conversation_sessions`, and persisted fallback state without verifying that a live process still existed for the session id.
+
+## Implementation Plan
+
+1. Add a helper in `packages/pybackend/agent_service.py` to check whether a process for a session id is running.
+2. Update `get_channel_status()` to gate `processing: true` on that live-process lookup.
+3. Add unit tests for stale bookkeeping, live process confirmation, and session-id resolution.
+
+## Validation
+
+- `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k "get_channel_status or is_process_running_for_session" -v`
+- `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit -x`
+
+## Notes
+
+The issue was fixed in `packages/pybackend/agent_service.py` and covered by unit tests in `packages/pybackend/tests/unit/test_unit.py`.

--- a/packages/frontend/src/hooks/usePersistentString.test.tsx
+++ b/packages/frontend/src/hooks/usePersistentString.test.tsx
@@ -67,13 +67,21 @@ describe("usePersistentString", () => {
 
   it("preserves the current value when only the bootstrap key changes", async () => {
     const { getByTestId, rerender } = render(
-      <TestComponent storageKey={undefined} scopeKey="repo-a" initialValue="boot" />,
+      <TestComponent
+        storageKey={undefined}
+        scopeKey="repo-a"
+        initialValue="boot"
+      />,
     );
 
     expect(getByTestId("value").textContent).toBe("boot");
 
     rerender(
-      <TestComponent storageKey="repo-a-bootstrap" scopeKey="repo-a" initialValue="boot" />,
+      <TestComponent
+        storageKey="repo-a-bootstrap"
+        scopeKey="repo-a"
+        initialValue="boot"
+      />,
     );
 
     expect(getByTestId("value").textContent).toBe("boot");
@@ -86,7 +94,11 @@ describe("usePersistentString", () => {
     );
 
     rerender(
-      <TestComponent storageKey="test-key" scopeKey="repo-a" setNextValue="user-value" />,
+      <TestComponent
+        storageKey="test-key"
+        scopeKey="repo-a"
+        setNextValue="user-value"
+      />,
     );
 
     expect(localStorage.getItem("test-key")).toBe("user-value");

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -137,7 +137,9 @@ export const ConstitutionPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -133,7 +133,9 @@ export const KnowledgeArtefactPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -464,7 +464,9 @@ export const RepositoryPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -122,7 +122,9 @@ export const TaskPage: React.FC = () => {
           const parsed = JSON.parse(oldSaved);
           if (Array.isArray(parsed)) {
             setSavedSessionIds(
-              parsed.filter((entry): entry is string => typeof entry === "string"),
+              parsed.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
             );
           }
         } catch {

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1361,7 +1361,9 @@ describe("RepositoryPage reload current session (AC1-AC7)", () => {
 
     // Assert: busy state is hydrated from history
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
     });
   });
 });
@@ -5312,7 +5314,9 @@ describe("RepositoryPage simplified lifecycle (issue #588)", () => {
         undefined,
         expect.anything(),
       );
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -304,6 +304,7 @@ def cancel_agent_message(lock_key: str) -> bool:
 
 def get_channel_status(lock_key: str) -> dict[str, object]:
     needs_dump = False
+    session_id = lock_key
 
     with _processing_lock:
         started_at = _processing_channels.get(lock_key)
@@ -319,6 +320,9 @@ def get_channel_status(lock_key: str) -> dict[str, object]:
                         # Propagate so future lookups are direct
                         _processing_channels[lock_key] = started_at
                     break
+
+        if lock_key in _conversation_sessions:
+            session_id = _conversation_sessions[lock_key]
 
         # Snapshot the session map so we can do disk I/O outside the lock below.
         needs_disk_fallback = started_at is None
@@ -348,11 +352,28 @@ def get_channel_status(lock_key: str) -> dict[str, object]:
             for ch, sid in session_snapshot:
                 if sid == lock_key:
                     persisted_started = persisted.get(ch)
+                    session_id = sid
                     break
         if persisted_started is not None:
             with _processing_lock:
                 _processing_channels[lock_key] = persisted_started
             started_at = persisted_started
+
+    if started_at is not None:
+        try:
+            processes = _read_running_agent_processes()
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning("Failed to inspect process table for status: %s", exc)
+        else:
+            if not _is_process_running_for_session(session_id, processes=processes):
+                with _processing_lock:
+                    for key in _get_related_processing_keys(lock_key):
+                        _processing_channels.pop(key, None)
+                        _cancelled_channels.discard(key)
+                        _active_processes.pop(key, None)
+                        _cancel_events.pop(key, None)
+                needs_dump = True
+                started_at = None
 
     if needs_dump:
         _dump_processing_state()
@@ -372,20 +393,15 @@ def _get_registered_agent_executables() -> set[str]:
     return executable_names
 
 
-def list_running_agent_processes() -> list[dict[str, object]]:
-    """List currently running agent CLI processes from the OS process table."""
+def _read_running_agent_processes() -> list[dict[str, object]]:
     executable_names = _get_registered_agent_executables()
     if not executable_names:
         return []
 
-    try:
-        ps_output = subprocess.check_output(
-            ["ps", "-eo", "pid=,ppid=,comm=,args="],
-            text=True,
-        )
-    except subprocess.SubprocessError as exc:
-        logger.warning("Failed to inspect process table: %s", exc)
-        return []
+    ps_output = subprocess.check_output(
+        ["ps", "-eo", "pid=,ppid=,comm=,args="],
+        text=True,
+    )
 
     processes: list[dict[str, object]] = []
     for raw_line in ps_output.splitlines():
@@ -425,6 +441,31 @@ def list_running_agent_processes() -> list[dict[str, object]]:
         )
 
     return sorted(processes, key=lambda item: int(item["pid"]))
+
+
+def list_running_agent_processes() -> list[dict[str, object]]:
+    """List currently running agent CLI processes from the OS process table."""
+    try:
+        return _read_running_agent_processes()
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("Failed to inspect process table: %s", exc)
+        return []
+
+
+def _is_process_running_for_session(
+    session_id: str,
+    *,
+    processes: list[dict[str, object]] | None = None,
+) -> bool:
+    """Check whether an agent CLI process with the given session_id is running."""
+    running_processes = (
+        processes if processes is not None else list_running_agent_processes()
+    )
+    for proc in running_processes:
+        command = proc.get("command", "")
+        if isinstance(command, str) and session_id in command:
+            return True
+    return False
 
 
 def terminate_agent_process(pid: int) -> bool:

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -584,6 +584,155 @@ class TestAgentService:
         assert status["processing"] is False
         assert channel not in _processing_channels
 
+    def test_get_channel_status_returns_false_when_no_os_process(self):
+        """get_channel_status must clear stale bookkeeping when no live process exists."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            get_channel_status,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        lock_key = "ghost-session-789"
+        try:
+            with _processing_lock:
+                _processing_channels[lock_key] = datetime.now(UTC)
+
+            with patch("agent_service._read_running_agent_processes", return_value=[]):
+                with patch("agent_service._dump_processing_state"):
+                    status = get_channel_status(lock_key)
+
+            assert status["processing"] is False
+            assert status["startedAt"] is None
+            with _processing_lock:
+                assert lock_key not in _processing_channels
+        finally:
+            with _processing_lock:
+                _processing_channels.pop(lock_key, None)
+
+    def test_get_channel_status_returns_true_when_os_process_confirmed(self):
+        """get_channel_status must keep processing=True when a live process is found."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            get_channel_status,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        lock_key = "live-session-789"
+        try:
+            with _processing_lock:
+                _processing_channels[lock_key] = datetime.now(UTC)
+
+            with patch(
+                "agent_service._read_running_agent_processes",
+                return_value=[
+                    {
+                        "pid": 1,
+                        "command": f"agent --session {lock_key}",
+                        "workingDirectory": None,
+                    }
+                ],
+            ):
+                with patch("agent_service._dump_processing_state"):
+                    status = get_channel_status(lock_key)
+
+            assert status["processing"] is True
+            assert status["startedAt"] is not None
+        finally:
+            with _processing_lock:
+                _processing_channels.pop(lock_key, None)
+
+    def test_get_channel_status_uses_working_directory_on_restart(self):
+        """get_channel_status must keep processing=True for a restarted session that still has a matching command line."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            get_channel_status,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        channel = "restart-repo"
+        try:
+            with _processing_lock:
+                _processing_channels[channel] = datetime.now(UTC)
+
+            with patch("agent_service._load_processing_state", return_value={channel: datetime.now(UTC)}):
+                with patch(
+                    "agent_service._read_running_agent_processes",
+                    return_value=[
+                        {
+                            "pid": 1,
+                            "command": f"agent --session {channel}",
+                            "workingDirectory": None,
+                        }
+                    ],
+                ):
+                    with patch("agent_service._dump_processing_state"):
+                        status = get_channel_status(channel)
+
+            assert status["processing"] is True
+        finally:
+            with _processing_lock:
+                _processing_channels.pop(channel, None)
+
+    def test_get_channel_status_uses_session_id_for_channel_lookup(self):
+        """get_channel_status must resolve the session id before checking the OS process table."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            get_channel_status,
+            _conversation_sessions,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        channel = "lookup-repo"
+        session_id = "lookup-session-123"
+        try:
+            with _processing_lock:
+                _conversation_sessions[channel] = session_id
+                _processing_channels[channel] = datetime.now(UTC)
+
+            fake_processes = [
+                {
+                    "pid": 2,
+                    "command": f"agent --session {session_id}",
+                    "workingDirectory": None,
+                }
+            ]
+            with patch(
+                "agent_service._read_running_agent_processes",
+                return_value=fake_processes,
+            ):
+                with patch("agent_service._dump_processing_state"):
+                    status = get_channel_status(channel)
+
+            assert status["processing"] is True
+        finally:
+            with _processing_lock:
+                _conversation_sessions.pop(channel, None)
+                _processing_channels.pop(channel, None)
+                _processing_channels.pop(session_id, None)
+
+    def test_is_process_running_for_session_matches_command_line(self):
+        """_is_process_running_for_session must match session_id in command lines."""
+        from unittest.mock import patch
+        from agent_service import _is_process_running_for_session
+
+        fake_processes = [
+            {"pid": 1001, "command": "opencode run -s ses_abc123 --format json"},
+            {"pid": 1002, "command": "pi --print --mode json --session pi-xyz"},
+        ]
+
+        with patch("agent_service.list_running_agent_processes", return_value=fake_processes):
+            assert _is_process_running_for_session("ses_abc123") is True
+            assert _is_process_running_for_session("pi-xyz") is True
+            assert _is_process_running_for_session("nonexistent-session") is False
+
     @patch("agent_service.get_agent_cli")
     def test_list_chat_sessions(self, mock_get_cli):
         """Test listing chat sessions with success and error scenarios."""
@@ -695,6 +844,7 @@ class TestAgentService:
     def test_get_channel_status_reverse_lookup_via_conversation_sessions(self):
         """get_channel_status must find processing entry by reverse lookup when lock_key is a session_id."""
         from datetime import UTC, datetime
+        from unittest.mock import patch
         from agent_service import (
             get_channel_status,
             _conversation_sessions,
@@ -709,7 +859,8 @@ class TestAgentService:
                 _conversation_sessions[channel] = session_id
                 _processing_channels[channel] = datetime.now(UTC)
 
-            status = get_channel_status(session_id)
+            with patch("agent_service._is_process_running_for_session", return_value=True):
+                status = get_channel_status(session_id)
 
             assert status["processing"] is True
             # session_id key should now be populated (propagated by get_channel_status)
@@ -739,8 +890,18 @@ class TestAgentService:
 
         with patch("agent_service._load_processing_state") as mock_load:
             mock_load.return_value = {lock_key: datetime.now(UTC)}
-            with patch("agent_service._dump_processing_state"):
-                status = get_channel_status(lock_key)
+            with patch(
+                "agent_service._read_running_agent_processes",
+                return_value=[
+                    {
+                        "pid": 3,
+                        "command": f"agent --session {lock_key}",
+                        "workingDirectory": None,
+                    }
+                ],
+            ):
+                with patch("agent_service._dump_processing_state"):
+                    status = get_channel_status(lock_key)
 
         assert status["processing"] is True
         assert status["startedAt"] is not None


### PR DESCRIPTION
## Summary

`GET /api/*/agent/status` could report a session as processing based only on bookkeeping state, which could drift from the actual live agent CLI process.

## Root Cause

The status path trusted `_processing_channels`, `_conversation_sessions`, and persisted fallback state without verifying that a live process still existed for the session id.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/agent_service.py` | Added live-process verification for status and kept stale bookkeeping cleanup intact |
| `packages/pybackend/tests/unit/test_unit.py` | Added coverage for stale state, live state, and session lookup paths |
| `.claude/PRPs/issues/completed/issue-626.md` | Archived the issue investigation artifact |

## Testing

- [x] `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k "get_channel_status or is_process_running_for_session" -v`
- [x] `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -v`
- [x] `make qa-quick`

## Validation

```bash
uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k "get_channel_status or is_process_running_for_session" -v && uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -v && make qa-quick
```

## Issue

Fixes #626

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`issue-626.md`

### Deviations from plan:

Used the repository's current status/session bookkeeping flow and preserved the existing public API contract.

</details>

_Automated implementation from investigation artifact_
