### PR TITLE
Fix: RepositoryPage auto-loads saved sessions (#623)

### DIFF
--- a/.ghar/issues/completed/issue-623.md
+++ b/.ghar/issues/completed/issue-623.md
@@ -1,0 +1,30 @@
+# Investigation: [Critical] RepositoryPage does not auto-load saved session history on open
+
+**Issue**: #623 (https://github.com/tbrandenburg/made/issues/623)
+**Type**: BUG
+**Investigated**: 2026-06-28T10:16:12Z
+
+## Problem Statement
+
+Opening `RepositoryPage` with a saved `sessionId` could render an empty chat until manual refresh. The initial load path used incremental merge behavior instead of the shared full-replace session loader used by the sibling pages.
+
+## Implementation Summary
+
+- `packages/frontend/src/pages/RepositoryPage.tsx`
+  - Added `useSessionLoader` and `useAgentPolling`.
+  - Replaced the custom initial-load effect with shared session loading.
+  - Switched UI bindings to `sessionLoading`.
+  - Surfaced `sessionError` alongside existing chat errors.
+- `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx`
+  - Added a regression test that verifies saved session history renders on mount.
+  - Updated loading-state test names to match `sessionLoading`.
+  - Extended two timing-sensitive AC496 tests to avoid environment timeout flakiness.
+
+## Validation
+
+- `make qa-quick`
+- `npm exec vitest run src/pages/__tests__/RepositoryPage.test.tsx`
+
+## Notes
+
+Archived after implementation and validation on branch `fix/issue-623-repositorypage-auto-load`.

--- a/packages/frontend/src/hooks/useSessionLoader.ts
+++ b/packages/frontend/src/hooks/useSessionLoader.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatMessage } from "../types/chat";
 import type { ChatHistoryResponse } from "./useApi";
 import { mapHistoryToMessages } from "../utils/chat";
@@ -21,6 +21,7 @@ interface UseSessionLoaderParams {
 interface UseSessionLoaderResult {
   sessionLoading: boolean;
   sessionError: string | null;
+  clearSessionError: () => void;
 }
 
 /**
@@ -41,9 +42,14 @@ export function useSessionLoader({
   getHistory,
   onHistoryLoaded,
 }: UseSessionLoaderParams): UseSessionLoaderResult {
-  const [sessionLoading, setSessionLoading] = useState(false);
+  const [sessionLoading, setSessionLoading] = useState(() =>
+    Boolean(name && sessionId),
+  );
   const [sessionError, setSessionError] = useState<string | null>(null);
   const onHistoryLoadedRef = useRef(onHistoryLoaded);
+  const clearSessionError = useCallback(() => {
+    setSessionError(null);
+  }, []);
 
   useEffect(() => {
     onHistoryLoadedRef.current = onHistoryLoaded;
@@ -90,5 +96,5 @@ export function useSessionLoader({
     };
   }, [name, sessionId, getHistory, setChat]);
 
-  return { sessionLoading, sessionError };
+  return { sessionLoading, sessionError, clearSessionError };
 }

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -1250,7 +1250,7 @@ export const RepositoryPage: React.FC = () => {
     [],
   );
 
-  const { sessionLoading, sessionError } = useSessionLoader({
+  const { sessionLoading, sessionError, clearSessionError } = useSessionLoader({
     name,
     sessionId,
     setChat,
@@ -1317,6 +1317,7 @@ export const RepositoryPage: React.FC = () => {
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
+    clearSessionError();
     lastKnownTimestampRef.current = undefined;
     const chatBeforeRefresh = chatRef.current;
     setChat([]);
@@ -1350,7 +1351,14 @@ export const RepositoryPage: React.FC = () => {
       setIsRefreshing(false);
       isRefreshingRef.current = false;
     }
-  }, [name, sessionId, setChat, setChatError, setIsAgentBusy]);
+  }, [
+    name,
+    sessionId,
+    setChat,
+    setChatError,
+    setIsAgentBusy,
+    clearSessionError,
+  ]);
 
   const handleSendMessage = async (prompt?: string) => {
     if (!name) return;

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -35,6 +35,8 @@ import { usePersistentChat } from "../hooks/usePersistentChat";
 import { usePersistentString } from "../hooks/usePersistentString";
 import { usePersistentStringList } from "../hooks/usePersistentStringList";
 import { useAgentCli } from "../hooks/useAgentCli";
+import { useSessionLoader } from "../hooks/useSessionLoader";
+import { useAgentPolling } from "../hooks/useAgentPolling";
 import {
   api,
   CommandDefinition,
@@ -498,11 +500,6 @@ export const RepositoryPage: React.FC = () => {
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [chatError, setChatError] = useState<string | null>(null);
   const [isAgentBusy, setIsAgentBusy] = useState(false);
-  // Initialize from sessionId so history loading state is correct on first render
-  // for persisted sessions (avoids brief flash of stale localStorage content).
-  const [isLoadingHistory, setIsLoadingHistory] = useState(() =>
-    Boolean(sessionId),
-  );
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const savedSessionTitles = useMemo(
@@ -667,7 +664,6 @@ export const RepositoryPage: React.FC = () => {
         return;
       }
       setChatError(null);
-      setIsLoadingHistory(true);
       setSessionId(incomingSessionId);
       setChat([]);
       sendRequestIdRef.current += 1;
@@ -1239,17 +1235,43 @@ export const RepositoryPage: React.FC = () => {
     [name, sessionId],
   );
 
+  const getRepositoryHistory = useCallback(
+    (
+      repositoryName: string,
+      repositorySessionId: string,
+      signal?: AbortSignal,
+    ) =>
+      api.getRepositoryAgentHistory(
+        repositoryName,
+        repositorySessionId,
+        undefined,
+        signal,
+      ),
+    [],
+  );
+
+  const { sessionLoading, sessionError } = useSessionLoader({
+    name,
+    sessionId,
+    setChat,
+    getHistory: getRepositoryHistory,
+    onHistoryLoaded: (history) => {
+      if (history.processing !== undefined) {
+        setIsAgentBusy(history.processing);
+      }
+      void refreshAgentStatus();
+    },
+  });
+
   const syncChatHistory = useCallback(
-    async (signal?: AbortSignal, fullFetch?: boolean): Promise<boolean> => {
-      if (!name || !sessionId) return false;
+    async (signal: AbortSignal): Promise<void> => {
+      if (!name || !sessionId) return;
       console.info("[ChatHistory] Request started");
       try {
         setChatError(null);
-        const startTimestamp = fullFetch
-          ? undefined
-          : lastKnownTimestampRef.current
-            ? lastKnownTimestampRef.current + 1
-            : undefined;
+        const startTimestamp = lastKnownTimestampRef.current
+          ? lastKnownTimestampRef.current + 1
+          : undefined;
         const history = await api.getRepositoryAgentHistory(
           name,
           sessionId,
@@ -1257,15 +1279,11 @@ export const RepositoryPage: React.FC = () => {
           signal,
         );
 
-        if (signal?.aborted) return false;
-
-        if (fullFetch && history.processing !== undefined) {
-          setIsAgentBusy(history.processing);
-        }
+        if (signal.aborted) return;
 
         if (!history.messages?.length) {
           console.info("[ChatHistory] Request completed with no new messages");
-          return true;
+          return;
         }
 
         setChat((previousChat) => {
@@ -1273,10 +1291,9 @@ export const RepositoryPage: React.FC = () => {
           console.info("[ChatHistory] Request completed; merge finished");
           return mergeChatMessages(previousChat, mapped);
         });
-        return true;
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
-          return false;
+          return;
         }
         console.error("Failed to load chat history", error);
         const message =
@@ -1284,63 +1301,16 @@ export const RepositoryPage: React.FC = () => {
             ? error.message
             : "Failed to load chat history";
         setChatError(message);
-        return false;
       }
     },
-    [name, sessionId, setChat, setChatError, setIsAgentBusy],
+    [name, sessionId, setChat, setChatError],
   );
 
-  // On mount (or sessionId change): always fetch history + check status
-  useEffect(() => {
-    if (!name || !sessionId) return;
-    setIsLoadingHistory(true);
-    setChat([]);
-    const controller = new AbortController();
-    const run = async () => {
-      const ok = await syncChatHistory(controller.signal, true);
-      if (controller.signal.aborted) return;
-      if (!ok) {
-        // Fetch failed (not aborted); clear loading so the error message is visible
-        setIsLoadingHistory(false);
-        return;
-      }
-      await refreshAgentStatus();
-      setIsLoadingHistory(false);
-    };
-    run();
-    return () => {
-      controller.abort();
-    };
-  }, [name, sessionId, syncChatHistory, setChat]);
-
-  // When agent is busy: poll status every 5s + sync history
-  useEffect(() => {
-    if (!isAgentBusy || !name || !sessionId) return;
-
-    const controller = new AbortController();
-    let timeoutId: number | undefined;
-
-    const tick = async () => {
-      // boolean return from syncChatHistory is intentionally ignored here:
-      // polling must still check agent status regardless of history fetch result
-      await syncChatHistory(controller.signal);
-      if (controller.signal.aborted) return;
-      const stillProcessing = await refreshAgentStatus();
-      if (controller.signal.aborted) return;
-      // null = network error; keep polling. false = agent done; stop.
-      if (stillProcessing === false) return;
-      timeoutId = window.setTimeout(tick, 5000);
-    };
-
-    tick();
-
-    return () => {
-      controller.abort(); // No argument — preserves DOMException('AbortError') shape
-      if (timeoutId !== undefined) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [isAgentBusy, name, sessionId, syncChatHistory, refreshAgentStatus]);
+  useAgentPolling({
+    isProcessing: isAgentBusy,
+    syncHistory: syncChatHistory,
+    checkStatus: refreshAgentStatus,
+  });
 
   const reloadCurrentSession = useCallback(async () => {
     if (!name || !sessionId || isRefreshingRef.current) return;
@@ -1462,7 +1432,6 @@ export const RepositoryPage: React.FC = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
     setIsAgentBusy(false);
-    setIsLoadingHistory(false);
     setChatError(null);
     setPendingPrompt(lastSentPromptRef.current);
     lastSentPromptRef.current = "";
@@ -1474,7 +1443,6 @@ export const RepositoryPage: React.FC = () => {
     sendRequestIdRef.current += 1;
     setSessionId(null);
     setIsAgentBusy(false);
-    setIsLoadingHistory(false);
     setChatError(null);
     setPendingPrompt(lastSentPromptRef.current);
     lastSentPromptRef.current = "";
@@ -1498,7 +1466,6 @@ export const RepositoryPage: React.FC = () => {
     setSessionModalOpen(false);
     setChatError(null);
     setChat([]);
-    setIsLoadingHistory(true);
     setIsAgentBusy(false);
     setSessionId(session.id);
   };
@@ -2061,7 +2028,7 @@ export const RepositoryPage: React.FC = () => {
                   onClick={reloadCurrentSession}
                   aria-label="Refresh current session"
                   title="Refresh current session"
-                  disabled={isAgentBusy || isLoadingHistory || isRefreshing}
+                  disabled={isAgentBusy || sessionLoading || isRefreshing}
                 >
                   <RefreshIcon />
                 </button>
@@ -2099,7 +2066,7 @@ export const RepositoryPage: React.FC = () => {
             chatWindowRef={chatWindowRef}
             agentProcessing={isAgentBusy}
             refreshing={isRefreshing}
-            sessionLoading={isLoadingHistory}
+            sessionLoading={sessionLoading}
             emptyMessage="No conversation yet."
             sessionId={sessionId}
             onClearSession={() => setClearSessionModalOpen(true)}
@@ -2109,7 +2076,9 @@ export const RepositoryPage: React.FC = () => {
             )}
             markdownOptions={chatMarkdownOptions}
           />
-          {chatError && <div className="alert">{chatError}</div>}
+          {(chatError || sessionError) && (
+            <div className="alert">{chatError ?? sessionError}</div>
+          )}
           <MentionPathTextarea
             id={chatInputId}
             value={pendingPrompt}
@@ -2125,7 +2094,7 @@ export const RepositoryPage: React.FC = () => {
                 selectId="agent-select"
                 selectedAgent={normalizedSelectedAgent}
                 onChange={setSelectedAgent}
-                disabled={isAgentBusy || isLoadingHistory}
+                disabled={isAgentBusy || sessionLoading}
                 repositoryName={name || undefined}
               />
               <label className="model-select" htmlFor="agent-model-select">
@@ -2133,7 +2102,7 @@ export const RepositoryPage: React.FC = () => {
                   id="agent-model-select"
                   value={normalizedSelectedModel}
                   onChange={(event) => setSelectedModel(event.target.value)}
-                  disabled={isAgentBusy || isLoadingHistory}
+                  disabled={isAgentBusy || sessionLoading}
                   aria-label="Model"
                 >
                   {MODEL_OPTIONS.map((option) => (
@@ -2158,7 +2127,7 @@ export const RepositoryPage: React.FC = () => {
                   className="primary"
                   onClick={() => handleSendMessage()}
                   disabled={
-                    !pendingPrompt.trim() || isLoadingHistory || isAgentBusy
+                    !pendingPrompt.trim() || sessionLoading || isAgentBusy
                   }
                 >
                   Send

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -140,6 +140,36 @@ describe("RepositoryPage session selection", () => {
     });
   });
 
+  it("AC2b: page hydrates saved session history on mount", async () => {
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue({
+      sessionId: "session-b",
+      messages: [
+        {
+          role: "assistant",
+          type: "text",
+          content: "Saved session greeting",
+          timestamp: "2026-01-02T00:00:00Z",
+        },
+      ],
+      processing: false,
+    });
+    vi.mocked(api.getRepositoryAgentStatus).mockResolvedValue({
+      processing: false,
+      startedAt: null,
+    });
+
+    renderPage(["/repositories/test-repo?tab=agent&sessionId=session-b"]);
+
+    await waitFor(() => {
+      expect(api.getRepositoryAgentHistory).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      await screen.findByText("Saved session greeting"),
+      "FAIL (AC2b): saved session history did not render on mount — useSessionLoader may not be wiring setChat",
+    ).toBeInTheDocument();
+  });
+
   // AC7: inverted — same-session re-select MUST trigger full history fetch
   it("AC7: re-selecting the same active session triggers full refresh (fails on unfixed code: guard returns early)", async () => {
     vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
@@ -538,7 +568,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
         "Send should be enabled after clear",
       ).not.toBeDisabled();
     });
-  });
+  }, 20000);
 
   // ── AC496-2 ────────────────────────────────────────────────────────────
 
@@ -768,7 +798,7 @@ describe("RepositoryPage clear session loading state (AC496)", () => {
         screen.queryByText("Session ID: old-session-id"),
       ).not.toBeInTheDocument();
     });
-  });
+  }, 20000);
 
   // ── AC496-ADV2: failed send after clear recovers on retry ──────────────
 
@@ -2102,8 +2132,12 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
     await waitFor(() => {
       const statusMock = vi.mocked(api.getRepositoryAgentStatus).mock;
       const historyMock = vi.mocked(api.getRepositoryAgentHistory).mock;
-      const statusIndex = statusMock.calls.findIndex((call) => call[1] === "session-b");
-      const historyIndex = historyMock.calls.findIndex((call) => call[1] === "session-b");
+      const statusIndex = statusMock.calls.findIndex(
+        (call) => call[1] === "session-b",
+      );
+      const historyIndex = historyMock.calls.findIndex(
+        (call) => call[1] === "session-b",
+      );
       expect(statusIndex).toBeGreaterThanOrEqual(0);
       expect(historyIndex).toBeGreaterThanOrEqual(0);
       expect(statusMock.invocationCallOrder[statusIndex]).toBeLessThan(
@@ -5331,7 +5365,7 @@ describe("RepositoryPage simplified lifecycle (issue #588)", () => {
     localStorage.clear();
   });
 
-  it("AC588-1: mounts without sessionId — isLoadingHistory=false, Send enabled when prompt typed", () => {
+  it("AC588-1: mounts without sessionId — sessionLoading=false, Send enabled when prompt typed", () => {
     renderPage(["/repositories/test-repo?tab=agent"]);
     const textarea = screen.getByPlaceholderText(
       "Describe the change or ask the agent...",
@@ -5476,7 +5510,7 @@ describe("RepositoryPage simplified lifecycle (issue #588)", () => {
     });
   });
 
-  it("AC588-6: disables Send during isLoadingHistory=true", async () => {
+  it("AC588-6: disables Send during sessionLoading=true", async () => {
     let resolveHistory!: (v: ChatHistoryResponse) => void;
     vi.mocked(api.getRepositoryAgentHistory).mockReturnValueOnce(
       new Promise<ChatHistoryResponse>((resolve) => {


### PR DESCRIPTION
## Summary

Opening `RepositoryPage` with a saved `sessionId` could still show an empty chat until the user manually refreshed the current session. The page now uses the shared session loader pattern used by the sibling agent pages.

## Root Cause

`RepositoryPage` kept a custom initial-load path that did not use the shared `useSessionLoader` flow, so saved sessions were not hydrated the same way as the other agent pages.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Adopted `useSessionLoader` and `useAgentPolling`, switched UI bindings to `sessionLoading`, and surfaced `sessionError` |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Added a saved-session hydration regression test and updated timing-sensitive AC496 cases |
| `.ghar/issues/completed/issue-623.md` | Archived the investigation artifact |

## Testing

- [x] `make qa-quick`
- [x] `npm exec vitest run src/pages/__tests__/RepositoryPage.test.tsx`

## Validation

```bash
make qa-quick
```

## Issue

Fixes #623

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation artifact for issue #623

### Deviations from plan:

Archived to `.ghar/issues/completed/issue-623.md` because the repo did not contain the artifact path referenced in the investigation comment.

</details>

_Automated implementation from investigation artifact_
