### PR TITLE
Fix: Cancel path cleanup_key alias lookup (#638)

### DIFF
--- a/.agents/issues/completed/issue-638.md
+++ b/.agents/issues/completed/issue-638.md
@@ -1,0 +1,25 @@
+# Issue 638: Cancel path misses cleanup_key alias for live process lookup
+
+Type: BUG
+
+## Problem Statement
+
+`cancel_agent_message()` can miss a live process after persisted-state fallback because process and event lookup only uses aliases derived from `lock_key`. When fallback resolves a distinct `cleanup_key`, that key is not searched. If cancel then fails to find a live process, cleanup only clears `cleanup_key`, leaving the seeded `lock_key` stale in memory and on disk.
+
+## Implementation Plan
+
+1. Add `cleanup_key` to the set of keys searched in `_active_processes` and `_cancel_events`.
+2. Clear both `cleanup_key` and `lock_key` when cancel cannot find a live process.
+3. Add regression tests for:
+   - finding a live process under `cleanup_key`
+   - clearing both aliases on stale process cleanup
+
+## Validation
+
+- `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -x -v -k "cancel"`
+- `uv run --project packages/pybackend ruff check packages/pybackend/agent_service.py packages/pybackend/tests/unit/test_unit.py`
+- `make qa-quick`
+
+## Notes
+
+Archived from the issue investigation comment for #638.

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -2102,8 +2102,12 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
     await waitFor(() => {
       const statusMock = vi.mocked(api.getRepositoryAgentStatus).mock;
       const historyMock = vi.mocked(api.getRepositoryAgentHistory).mock;
-      const statusIndex = statusMock.calls.findIndex((call) => call[1] === "session-b");
-      const historyIndex = historyMock.calls.findIndex((call) => call[1] === "session-b");
+      const statusIndex = statusMock.calls.findIndex(
+        (call) => call[1] === "session-b",
+      );
+      const historyIndex = historyMock.calls.findIndex(
+        (call) => call[1] === "session-b",
+      );
       expect(statusIndex).toBeGreaterThanOrEqual(0);
       expect(historyIndex).toBeGreaterThanOrEqual(0);
       expect(statusMock.invocationCallOrder[statusIndex]).toBeLessThan(

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -316,9 +316,8 @@ def cancel_agent_message(lock_key: str) -> bool:
         started_at = persisted_started
 
     with _processing_lock:
-        related = _get_related_processing_keys(lock_key)
-        related.add(cleanup_key)
-        for key in related:
+        related = [cleanup_key, *_get_related_processing_keys(lock_key)]
+        for key in dict.fromkeys(related):
             if cancel_event is None:
                 cancel_event = _cancel_events.get(key)
             if process is None:
@@ -331,9 +330,8 @@ def cancel_agent_message(lock_key: str) -> bool:
         return False
 
     with _processing_lock:
-        related = _get_related_processing_keys(lock_key)
-        related.add(cleanup_key)
-        for key in related:
+        related = [cleanup_key, *_get_related_processing_keys(lock_key)]
+        for key in dict.fromkeys(related):
             _cancelled_channels.add(key)
             _processing_channels.pop(key, None)
             _cancel_events.pop(key, None)

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -317,6 +317,7 @@ def cancel_agent_message(lock_key: str) -> bool:
 
     with _processing_lock:
         related = _get_related_processing_keys(lock_key)
+        related.add(cleanup_key)
         for key in related:
             if cancel_event is None:
                 cancel_event = _cancel_events.get(key)
@@ -325,10 +326,13 @@ def cancel_agent_message(lock_key: str) -> bool:
 
     if process is None or process.poll() is not None:
         _clear_channel_processing(cleanup_key)
+        if cleanup_key != lock_key:
+            _clear_channel_processing(lock_key)
         return False
 
     with _processing_lock:
         related = _get_related_processing_keys(lock_key)
+        related.add(cleanup_key)
         for key in related:
             _cancelled_channels.add(key)
             _processing_channels.pop(key, None)

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -964,6 +964,73 @@ class TestAgentService:
         with _processing_lock:
             assert lock_key not in _processing_channels
 
+    def test_cancel_agent_message_finds_process_under_cleanup_key(self):
+        """cancel_agent_message must find a live process stored under cleanup_key."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+        from agent_service import (
+            cancel_agent_message,
+            _processing_channels,
+            _active_processes,
+            _cancel_events,
+            _processing_lock,
+        )
+
+        lock_key = "cancel-cleanup-lock-001"
+        cleanup_key = "cancel-cleanup-persisted-001"
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+
+        try:
+            with _processing_lock:
+                _active_processes[cleanup_key] = mock_proc
+                _cancel_events[cleanup_key] = MagicMock()
+
+            with patch("agent_service._load_processing_state") as mock_load:
+                mock_load.return_value = {cleanup_key: datetime.now(UTC)}
+                with patch("agent_service._dump_processing_state"):
+                    assert cancel_agent_message(lock_key) is True
+
+            mock_proc.terminate.assert_called_once()
+            with _processing_lock:
+                assert lock_key not in _processing_channels
+                assert cleanup_key not in _processing_channels
+                assert cleanup_key not in _active_processes
+                assert cleanup_key not in _cancel_events
+        finally:
+            with _processing_lock:
+                _active_processes.pop(cleanup_key, None)
+                _cancel_events.pop(cleanup_key, None)
+                _processing_channels.pop(lock_key, None)
+                _processing_channels.pop(cleanup_key, None)
+
+    def test_cancel_agent_message_clears_both_aliases_on_stale_process(self):
+        """cancel_agent_message must clear both lock_key and cleanup_key when the process is gone."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+        from agent_service import (
+            cancel_agent_message,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        lock_key = "cancel-stale-lock-001"
+        cleanup_key = "cancel-stale-persisted-001"
+
+        try:
+            with patch("agent_service._load_processing_state") as mock_load:
+                mock_load.return_value = {cleanup_key: datetime.now(UTC)}
+                with patch("agent_service._dump_processing_state"):
+                    assert cancel_agent_message(lock_key) is False
+
+            with _processing_lock:
+                assert lock_key not in _processing_channels
+                assert cleanup_key not in _processing_channels
+        finally:
+            with _processing_lock:
+                _processing_channels.pop(lock_key, None)
+                _processing_channels.pop(cleanup_key, None)
+
     def test_cancel_agent_message_not_found_when_no_process(self):
         """cancel_agent_message must return False when no live process can be resolved."""
         from unittest.mock import patch
@@ -1127,11 +1194,8 @@ class TestAgentService:
 
     def test_get_channel_status_ignores_stale_persisted_entry(self):
         """get_channel_status must not report processing for entries beyond the TTL."""
-        from datetime import UTC, datetime, timedelta
         from unittest.mock import patch
-        from agent_service import get_channel_status, _MAX_PROCESSING_AGE
-
-        stale_time = datetime.now(UTC) - _MAX_PROCESSING_AGE - timedelta(minutes=1)
+        from agent_service import get_channel_status
 
         with patch("agent_service._load_processing_state") as mock_load:
             mock_load.return_value = {}  # stale entry already filtered by _load


### PR DESCRIPTION
## Summary

`cancel_agent_message()` now searches the resolved `cleanup_key` first, so persisted-state fallback can find a live process deterministically and clean up both aliases on success or failure.

## Root Cause

The cancel path only searched aliases derived from `lock_key`, then relied on set iteration order when `cleanup_key` was added. That allowed stale aliases to win and could miss the live process or leave cleanup behind.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/agent_service.py` | Prefer `cleanup_key` first during cancel lookup and cleanup, while still clearing both aliases on stale-process failure. |
| `packages/pybackend/tests/unit/test_unit.py` | Added regressions for `cleanup_key` process lookup and stale alias cleanup. |
| `.agents/issues/completed/issue-638.md` | Archived the issue artifact. |

## Testing

- [x] `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -x -v -k "cancel"`
- [x] `uv run --project packages/pybackend ruff check packages/pybackend/agent_service.py packages/pybackend/tests/unit/test_unit.py`
- [x] `make qa-quick`

## Validation

```bash
uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -x -v -k "cancel" && make qa-quick
```

## Issue

Fixes #638

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #638

### Deviations from plan:

None

</details>

_Automated implementation from investigation artifact_
