### PR TITLE
Fix: stale cleanup_key lookup orphaning live agent process (#641)

### DIFF
--- a/.agents/issues/completed/issue-641.md
+++ b/.agents/issues/completed/issue-641.md
@@ -1,0 +1,23 @@
+# Investigation: Fix stale cleanup_key lookup orphaning live agent process
+
+**Issue**: #641
+**Type**: BUG
+
+## Problem Statement
+
+`cancel_agent_message()` can trust a stale persisted cleanup alias and miss a live subprocess that is still registered under a different alias. When that happens, cleanup can orphan the live process.
+
+## Implementation Plan
+
+1. In `packages/pybackend/agent_service.py`, update the persisted-state fallback inside `cancel_agent_message()` to prefer the running alias when resolving cancel targets.
+2. Add a regression test in `packages/pybackend/tests/unit/test_unit.py` for the stale cleanup alias plus live process case.
+
+## Validation
+
+- `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k "cancel_agent_message" -v`
+- `uv run --project packages/pybackend ruff check packages/pybackend/agent_service.py packages/pybackend/tests/unit/test_unit.py`
+- `make qa-quick`
+
+## Test Cases
+
+- stale persisted cleanup alias with a live process under another alias is resolved correctly

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -305,7 +305,8 @@ def cancel_agent_message(lock_key: str) -> bool:
                     cleanup_key = ch
                     break
             if persisted_started is None and len(persisted) == 1:
-                cleanup_key = next(iter(persisted))
+                candidate = next(iter(persisted))
+                cleanup_key = candidate
                 persisted_started = persisted[cleanup_key]
         else:
             cleanup_key = lock_key
@@ -318,10 +319,17 @@ def cancel_agent_message(lock_key: str) -> bool:
     with _processing_lock:
         related = [cleanup_key, *_get_related_processing_keys(lock_key)]
         for key in dict.fromkeys(related):
+            candidate_cancel_event = _cancel_events.get(key)
+            candidate_process = _active_processes.get(key)
+            if candidate_process is not None and candidate_process.poll() is None:
+                cancel_event = candidate_cancel_event
+                process = candidate_process
+                cleanup_key = key
+                break
             if cancel_event is None:
-                cancel_event = _cancel_events.get(key)
+                cancel_event = candidate_cancel_event
             if process is None:
-                process = _active_processes.get(key)
+                process = candidate_process
 
     if process is None or process.poll() is not None:
         _clear_channel_processing(cleanup_key)

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -1094,6 +1094,50 @@ class TestAgentService:
         with _processing_lock:
             assert lock_key not in _processing_channels
 
+    def test_cancel_agent_message_does_not_orphan_live_process_for_stale_lock_key(self):
+        """A stale lock_key must still resolve a live process when a stale cleanup alias exists."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+        from agent_service import (
+            cancel_agent_message,
+            _active_processes,
+            _conversation_sessions,
+            _processing_channels,
+            _processing_lock,
+        )
+
+        cleanup_key = "cancel-stale-cleanup-001"
+        live_key = "cancel-live-persisted-001"
+        stale_lock = "cancel-stale-lock-001"
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 1
+        live_proc = MagicMock()
+        live_proc.poll.return_value = None
+
+        try:
+            with _processing_lock:
+                _conversation_sessions[live_key] = stale_lock
+                _active_processes[cleanup_key] = dead_proc
+                _active_processes[live_key] = live_proc
+
+            with patch("agent_service._load_processing_state") as mock_load:
+                mock_load.return_value = {cleanup_key: datetime.now(UTC)}
+                with patch("agent_service._dump_processing_state"):
+                    assert cancel_agent_message(stale_lock) is True
+
+            live_proc.terminate.assert_called_once()
+            dead_proc.terminate.assert_not_called()
+
+            with _processing_lock:
+                assert live_key not in _active_processes
+                assert stale_lock not in _processing_channels
+        finally:
+            with _processing_lock:
+                _conversation_sessions.pop(live_key, None)
+                _active_processes.pop(cleanup_key, None)
+                _active_processes.pop(live_key, None)
+                _processing_channels.pop(stale_lock, None)
+
     def test_cancel_agent_message_by_channel_key_direct(self):
         """cancel_agent_message must still work with the direct channel key."""
         from datetime import UTC, datetime


### PR DESCRIPTION
## Summary

Prevent `cancel_agent_message()` from orphaning a live subprocess when persisted cleanup state is stale.

## Root Cause

The cancel path could stop on a stale persisted alias and miss a running process tracked under another alias.

## Changes

| File | Change |
|------|--------|
| `packages/pybackend/agent_service.py` | Prefer the running alias when resolving cancel targets from persisted state. |
| `packages/pybackend/tests/unit/test_unit.py` | Added a regression test for stale cleanup alias plus live process state. |
| `.agents/issues/completed/issue-641.md` | Archived the investigation artifact. |

## Testing

- [x] `uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k "cancel_agent_message" -v`
- [x] `uv run --project packages/pybackend ruff check packages/pybackend/agent_service.py packages/pybackend/tests/unit/test_unit.py`
- [x] `make qa-quick`

## Validation

```bash
uv run --project packages/pybackend python -m pytest packages/pybackend/tests/unit/test_unit.py -k "cancel_agent_message" -v && uv run --project packages/pybackend ruff check packages/pybackend/agent_service.py packages/pybackend/tests/unit/test_unit.py && make qa-quick
```

## Issue

Fixes #641

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

` .agents/issues/completed/issue-641.md`

### Deviations from plan:

None

</details>

_Automated implementation from investigation artifact_
