### PR TITLE
Fix: preserve chat agent error status (#653)

### DIFF
--- a/.agents/issues/completed/issue-653.md
+++ b/.agents/issues/completed/issue-653.md
@@ -16,6 +16,7 @@ The same pattern exists in `handleCancel()`: the catch block sets an error messa
 3. Pass `refreshAgentStatus(undefined, true)` from the send-failure path.
 4. Pass `refreshAgentStatus(undefined, true)` from the cancel-failure path.
 5. Add regression tests for send-failure and cancel-failure banner persistence in `packages/frontend/src/hooks/useChatSession.test.tsx`.
+6. Keep cancel-success behavior intact by only preserving status on the cancel error path.
 
 ## Validation
 

--- a/.agents/issues/completed/issue-653.md
+++ b/.agents/issues/completed/issue-653.md
@@ -1,0 +1,24 @@
+# Investigation: Send failures clear the agent error state immediately
+
+**Issue**: #653
+**Type**: BUG
+
+## Problem Statement
+
+When `handleSendMessage` fails, it sets `agentStatus` to an error message and then immediately calls `refreshAgentStatus()`. The helper unconditionally writes `agentStatus`, so the error banner gets cleared before the UI can reliably show it.
+
+The same pattern exists in `handleCancel()`: the catch block sets an error message, but the `finally` block refreshes status and can overwrite that message as well.
+
+## Implementation Plan
+
+1. Add a `preserveStatus` flag to `refreshAgentStatus` in `packages/frontend/src/hooks/useChatSession.ts`.
+2. Guard `setAgentStatus` writes inside `refreshAgentStatus` when `preserveStatus` is true.
+3. Pass `refreshAgentStatus(undefined, true)` from the send-failure path.
+4. Pass `refreshAgentStatus(undefined, true)` from the cancel-failure path.
+5. Add regression tests for send-failure and cancel-failure banner persistence in `packages/frontend/src/hooks/useChatSession.test.tsx`.
+
+## Validation
+
+- `npm --workspace packages/frontend run build`
+- `npm --workspace packages/frontend run test -- src/hooks/useChatSession.test.tsx`
+- `npm --workspace packages/frontend run lint`

--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -202,4 +202,74 @@ describe("useChatSession", () => {
     expect(api.getHistory).toHaveBeenCalledWith("repo", "session-1");
     expect(setChat).toHaveBeenCalled();
   });
+
+  it("preserves the send failure status after refresh", async () => {
+    const sendMessage = vi.fn().mockRejectedValue(new Error("Network error"));
+    const getStatus = vi.fn().mockResolvedValue({ running: false });
+    const api = {
+      sendMessage,
+      getStatus,
+      cancelAgent: vi.fn(),
+      getHistory: vi.fn(),
+      getSessions: vi.fn(),
+    };
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        name: "repo",
+        sessionId: null,
+        setSessionId: vi.fn(),
+        chat: makeChat(),
+        setChat: vi.fn(),
+        setPrompt: vi.fn(),
+        setSelectedAgent: vi.fn(),
+        normalizedSelectedAgent: "default",
+        defaultAgentValue: "default",
+        api,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessage("hello");
+    });
+
+    expect(result.current.agentStatus).toBe("Agent unavailable");
+  });
+
+  it("preserves the cancel failure status after refresh", async () => {
+    const cancelAgent = vi
+      .fn()
+      .mockRejectedValue(new Error("cancel failed"));
+    const getStatus = vi.fn().mockResolvedValue({ running: false });
+    const api = {
+      sendMessage: vi.fn(),
+      getStatus,
+      cancelAgent,
+      getHistory: vi.fn(),
+      getSessions: vi.fn(),
+    };
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        name: "repo",
+        sessionId: null,
+        setSessionId: vi.fn(),
+        chat: makeChat(),
+        setChat: vi.fn(),
+        setPrompt: vi.fn(),
+        setSelectedAgent: vi.fn(),
+        normalizedSelectedAgent: "default",
+        defaultAgentValue: "default",
+        api,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleCancel();
+    });
+
+    expect(result.current.agentStatus).toBe(
+      "Unable to cancel the agent request.",
+    );
+  });
 });

--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -272,4 +272,37 @@ describe("useChatSession", () => {
       "Unable to cancel the agent request.",
     );
   });
+
+  it("clears stale status after a successful cancel", async () => {
+    const cancelAgent = vi.fn().mockResolvedValue(undefined);
+    const getStatus = vi.fn().mockResolvedValue({ running: false });
+    const api = {
+      sendMessage: vi.fn(),
+      getStatus,
+      cancelAgent,
+      getHistory: vi.fn(),
+      getSessions: vi.fn(),
+    };
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        name: "repo",
+        sessionId: null,
+        setSessionId: vi.fn(),
+        chat: makeChat(),
+        setChat: vi.fn(),
+        setPrompt: vi.fn(),
+        setSelectedAgent: vi.fn(),
+        normalizedSelectedAgent: "default",
+        defaultAgentValue: "default",
+        api,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleCancel();
+    });
+
+    expect(result.current.agentStatus).toBeNull();
+  });
 });

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -348,13 +348,15 @@ export function useChatSession({
     if (!name || isExternal || isCancelingAgent) return;
 
     setIsCancelingAgent(true);
+    let preserveStatus = false;
     try {
       await api.cancelAgent(name, sessionId || undefined);
     } catch (error) {
       console.error("Failed to cancel agent request", error);
       setAgentStatus("Unable to cancel the agent request.");
+      preserveStatus = true;
     } finally {
-      await refreshAgentStatus(undefined, true);
+      await refreshAgentStatus(undefined, preserveStatus);
       setIsCancelingAgent(false);
     }
   }, [api, isCancelingAgent, isExternal, name, refreshAgentStatus, sessionId]);

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -127,11 +127,13 @@ export function useChatSession({
   }, [lastKnownTimestamp]);
 
   const refreshAgentStatus = useCallback(
-    async (targetSessionId = sessionId) => {
+    async (targetSessionId = sessionId, preserveStatus = false) => {
       if (!name || isExternal) return false;
       if (!targetSessionId) {
         setChatAgentProcessing(false);
-        setAgentStatus(null);
+        if (!preserveStatus) {
+          setAgentStatus(null);
+        }
         return false;
       }
 
@@ -139,11 +141,13 @@ export function useChatSession({
         const status = await api.getStatus(name, targetSessionId);
         if (sessionIdRef.current !== targetSessionId) return false;
         setChatAgentProcessing(status.running);
-        setAgentStatus(
-          status.running
-            ? "Agent is still processing the previous message."
-            : null,
-        );
+        if (!preserveStatus) {
+          setAgentStatus(
+            status.running
+              ? "Agent is still processing the previous message."
+              : null,
+          );
+        }
         return status.running;
       } catch (error) {
         console.error("Failed to load agent status", error);
@@ -316,7 +320,7 @@ export function useChatSession({
             ? "Agent is still processing the previous message."
             : "Agent unavailable",
         );
-        const processing = await refreshAgentStatus();
+        const processing = await refreshAgentStatus(undefined, true);
         if (processing === false) {
           setChatAgentProcessing(false);
         }
@@ -350,7 +354,7 @@ export function useChatSession({
       console.error("Failed to cancel agent request", error);
       setAgentStatus("Unable to cancel the agent request.");
     } finally {
-      await refreshAgentStatus();
+      await refreshAgentStatus(undefined, true);
       setIsCancelingAgent(false);
     }
   }, [api, isCancelingAgent, isExternal, name, refreshAgentStatus, sessionId]);


### PR DESCRIPTION
## Summary

Send and cancel failures were immediately followed by a status refresh that cleared the visible error banner.

## Root Cause

`refreshAgentStatus` always wrote `agentStatus`, so error-path messages were overwritten as soon as the helper completed.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/hooks/useChatSession.ts` | Added a preserve-status option and used it for send/cancel failure refreshes |
| `packages/frontend/src/hooks/useChatSession.test.tsx` | Added regression tests for send failure, cancel failure, and cancel success |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes

## Validation

```bash
npm --workspace packages/frontend run build
npm --workspace packages/frontend run test -- src/hooks/useChatSession.test.tsx
npm --workspace packages/frontend run lint
```

## Issue

Fixes #653

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact

`.agents/issues/completed/issue-653.md`

### Deviations from plan

None

</details>

_Automated implementation from investigation artifact_