### PR TITLE
Fix: shared send invalidation for bootstrap session switches (#652)

### DIFF
--- a/.claude/PRPs/issues/completed/issue-652.md
+++ b/.claude/PRPs/issues/completed/issue-652.md
@@ -1,0 +1,31 @@
+# Issue 652 Archive
+
+**Issue**: #652 - Shared send invalidation does not cover bootstrap session switches
+**Type**: BUG
+
+## Problem Statement
+
+`RepositoryPage` invalidated a page-local send request ref during bootstrap/session switching, but `handleSendMessage` now lives in `useChatSession` and checks the hook-local ref. A send started before a bootstrap switch could therefore resolve into the wrong session state.
+
+## Root Cause
+
+The invalidation path stayed in the page after the send logic moved into the shared hook.
+
+## Implementation Plan
+
+1. Expose `invalidatePendingRequests()` from `useChatSession`.
+2. Remove the orphaned page-local `sendRequestIdRef` from `RepositoryPage`.
+3. Call the hook-level invalidation during bootstrap session switching.
+4. Update the stale-reply test comment to reflect the new path.
+
+## Validation
+
+```bash
+npm --workspace packages/frontend run build
+npm --workspace packages/frontend run lint
+make qa-quick
+```
+
+## Status
+
+Archived after implementation.

--- a/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
@@ -3,7 +3,10 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { WorkflowBuilderPanel, type WorkflowDefinition } from "./WorkflowBuilderPanel";
+import {
+  WorkflowBuilderPanel,
+  type WorkflowDefinition,
+} from "./WorkflowBuilderPanel";
 
 const workflows: WorkflowDefinition[] = [
   {
@@ -14,7 +17,12 @@ const workflows: WorkflowDefinition[] = [
     steps: [
       { type: "agent", agent: "planner", prompt: "First step" },
       { type: "bash", run: "echo second" },
-      { type: "vars", varName: "API_KEY", run: "secret", values: { API_KEY: "secret" } },
+      {
+        type: "vars",
+        varName: "API_KEY",
+        run: "secret",
+        values: { API_KEY: "secret" },
+      },
     ],
   },
 ];
@@ -31,9 +39,15 @@ describe("WorkflowBuilderPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove step 1" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Remove step 2" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Remove step 3" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 1" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 3" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -50,11 +64,15 @@ describe("WorkflowBuilderPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove step 2" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "First step" }));
-    expect(screen.getByRole("heading", { name: "Edit Step" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Edit Step" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Remove step 1" }));
 
@@ -70,9 +88,15 @@ describe("WorkflowBuilderPanel", () => {
         },
       ],
     });
-    expect(screen.queryByRole("heading", { name: "Edit Step" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Remove step 1" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Remove step 3" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Edit Step" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove step 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove step 3" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the editor aligned when deleting a step before the active one", async () => {
@@ -88,14 +112,18 @@ describe("WorkflowBuilderPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove step 2" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "echo second" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove step 1" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Edit Step" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Edit Step" }),
+      ).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText("Command or Prompt"), {

--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -237,9 +237,7 @@ describe("useChatSession", () => {
   });
 
   it("preserves the cancel failure status after refresh", async () => {
-    const cancelAgent = vi
-      .fn()
-      .mockRejectedValue(new Error("cancel failed"));
+    const cancelAgent = vi.fn().mockRejectedValue(new Error("cancel failed"));
     const getStatus = vi.fn().mockResolvedValue({ running: false });
     const api = {
       sendMessage: vi.fn(),

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -66,6 +66,7 @@ export interface UseChatSessionResult {
     options?: { clearPrompt?: boolean },
   ) => Promise<void>;
   handleSessionSelect: (session: ChatSession) => void;
+  invalidatePendingRequests: () => void;
   isCancelingAgent: boolean;
   isRefreshing: boolean;
   openClearSessionModal: () => void;
@@ -384,6 +385,10 @@ export function useChatSession({
     setSessionModalOpen(false);
   }, []);
 
+  const invalidatePendingRequests = useCallback(() => {
+    sendRequestIdRef.current += 1;
+  }, []);
+
   const handleSessionSelect = useCallback(
     (session: ChatSession) => {
       if (!name || isExternal) return;
@@ -455,6 +460,7 @@ export function useChatSession({
     handleClearSessionOnly,
     handleSendMessage,
     handleSessionSelect,
+    invalidatePendingRequests,
     isCancelingAgent,
     isRefreshing,
     openClearSessionModal,

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -603,7 +603,6 @@ export const RepositoryPage: React.FC = () => {
     args: "",
   });
   const chatWindowRef = useRef<ChatWindowHandle>(null);
-  const sendRequestIdRef = useRef(0);
   const lastSentPromptRef = useRef("");
   const copyAllMessages = useCallback(() => {
     if (!navigator.clipboard || !chat.length) return;
@@ -646,6 +645,7 @@ export const RepositoryPage: React.FC = () => {
     handleClearSessionOnly,
     handleSendMessage: sendChatMessage,
     handleSessionSelect,
+    invalidatePendingRequests,
     isCancelingAgent,
     isRefreshing,
     openClearSessionModal,
@@ -718,7 +718,7 @@ export const RepositoryPage: React.FC = () => {
       }
       setSessionId(incomingSessionId);
       setChat([]);
-      sendRequestIdRef.current += 1;
+      invalidatePendingRequests();
       try {
         localStorage.setItem(sessionStorageKey, incomingSessionId);
       } catch {
@@ -753,7 +753,14 @@ export const RepositoryPage: React.FC = () => {
       textarea?.focus();
       textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
     });
-  }, [location.pathname, name, searchParams, sessionId, setSessionId]);
+  }, [
+    invalidatePendingRequests,
+    location.pathname,
+    name,
+    searchParams,
+    sessionId,
+    setSessionId,
+  ]);
 
   useEffect(() => {
     const tab = searchParams.get("tab");

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1933,7 +1933,7 @@ describe("RepositoryPage stale-reply guard (AC495)", () => {
     });
 
     // Bootstrap switch to session B — triggers useLayoutEffect which
-    // increments sendRequestIdRef so stale reply will be discarded
+    // invalidates pending requests so stale reply will be discarded
     await router.navigate(
       "/repositories/test-repo?tab=agent&sessionId=session-b",
     );


### PR DESCRIPTION
## Summary

Bootstrap session switching in `RepositoryPage` was still invalidating a page-local request ref after `handleSendMessage` moved into `useChatSession`. That meant stale replies could resolve into the wrong session state.

## Root Cause

The request-id guard used by `handleSendMessage` lives in `useChatSession`, but the bootstrap/session-switch invalidation remained in `RepositoryPage` and incremented a different ref.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/hooks/useChatSession.ts` | Exposed `invalidatePendingRequests()` from the hook and returns it to callers |
| `packages/frontend/src/pages/RepositoryPage.tsx` | Removed the orphaned page-local ref and switched bootstrap invalidation to the hook-level method |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Updated the stale-reply test comment to match the new invalidation path |
| `.claude/PRPs/issues/completed/issue-652.md` | Archived the investigation artifact |

## Testing

- [x] `npm --workspace packages/frontend run build`
- [x] `npm --workspace packages/frontend run lint`
- [x] `make qa-quick`

## Validation

```bash
npm --workspace packages/frontend run build
npm --workspace packages/frontend run lint
make qa-quick
```

## Issue

Fixes #652

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #652 investigation comment

### Deviations from plan:

- Archived to `.claude/PRPs/issues/completed/issue-652.md` because the requested archive path was not present in the workspace before this change.

</details>

_Automated implementation from investigation artifact_
