### PR TITLE
Fix: RepositoryPage working tree badge (#649)

### DIFF
--- a/.claude/PRPs/issues/completed/issue-649.md
+++ b/.claude/PRPs/issues/completed/issue-649.md
@@ -1,0 +1,24 @@
+# Issue 649 Archive
+
+**Issue**: #649
+**Title**: RepositoryPage: add working tree clean/dirty badge next to Git badge
+**Type**: ENHANCEMENT
+
+## Summary
+
+Add a working-tree status badge in the RepositoryPage header. Show `Clean` in green when `RepositoryGitStatus.diff` is empty, and `Dirty` in red when diff entries exist.
+
+## Implementation Plan
+
+1. Add `.badge.danger` styling in `packages/frontend/src/styles/index.css`.
+2. Render the clean/dirty badge next to the existing Git badge in `packages/frontend/src/pages/RepositoryPage.tsx`.
+3. Add tests covering clean, dirty, and no-Git behavior in `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx`.
+
+## Validation
+
+- `make qa-quick`
+
+## Notes
+
+- The fix reuses existing `gitStatus` data already loaded by `RepositoryPage`.
+- The initial implementation was adjusted to clear stale git status before loading a different repository.

--- a/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
@@ -3,7 +3,10 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { WorkflowBuilderPanel, type WorkflowDefinition } from "./WorkflowBuilderPanel";
+import {
+  WorkflowBuilderPanel,
+  type WorkflowDefinition,
+} from "./WorkflowBuilderPanel";
 
 const workflows: WorkflowDefinition[] = [
   {
@@ -14,7 +17,12 @@ const workflows: WorkflowDefinition[] = [
     steps: [
       { type: "agent", agent: "planner", prompt: "First step" },
       { type: "bash", run: "echo second" },
-      { type: "vars", varName: "API_KEY", run: "secret", values: { API_KEY: "secret" } },
+      {
+        type: "vars",
+        varName: "API_KEY",
+        run: "secret",
+        values: { API_KEY: "secret" },
+      },
     ],
   },
 ];
@@ -31,9 +39,15 @@ describe("WorkflowBuilderPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove step 1" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Remove step 2" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Remove step 3" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 1" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 3" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -50,11 +64,15 @@ describe("WorkflowBuilderPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove step 2" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "First step" }));
-    expect(screen.getByRole("heading", { name: "Edit Step" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Edit Step" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Remove step 1" }));
 
@@ -70,9 +88,15 @@ describe("WorkflowBuilderPanel", () => {
         },
       ],
     });
-    expect(screen.queryByRole("heading", { name: "Edit Step" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Remove step 1" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Remove step 3" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Edit Step" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove step 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove step 3" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the editor aligned when deleting a step before the active one", async () => {
@@ -88,14 +112,18 @@ describe("WorkflowBuilderPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove step 2" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "echo second" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove step 1" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Edit Step" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Edit Step" }),
+      ).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText("Command or Prompt"), {

--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -237,9 +237,7 @@ describe("useChatSession", () => {
   });
 
   it("preserves the cancel failure status after refresh", async () => {
-    const cancelAgent = vi
-      .fn()
-      .mockRejectedValue(new Error("cancel failed"));
+    const cancelAgent = vi.fn().mockRejectedValue(new Error("cancel failed"));
     const getStatus = vi.fn().mockResolvedValue({ running: false });
     const api = {
       sendMessage: vi.fn(),

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -967,7 +967,14 @@ export const RepositoryPage: React.FC = () => {
   }, [name]);
 
   const loadGitStatus = useCallback(() => {
-    if (!name || !repository?.hasGit) return;
+    if (!name || !repository?.hasGit) {
+      setGitStatus(null);
+      setGitStatusError(null);
+      return;
+    }
+
+    setGitStatus(null);
+    setGitStatusError(null);
     setGitStatusLoading(true);
     api
       .getRepositoryGitStatus(name)
@@ -2561,6 +2568,13 @@ export const RepositoryPage: React.FC = () => {
           </span>
           {repository.hasGit && repository.branch && (
             <span className="badge">{repository.branch}</span>
+          )}
+          {repository.hasGit && gitStatus && (
+            <span
+              className={`badge ${gitStatus.diff.length === 0 ? "success" : "danger"}`}
+            >
+              {gitStatus.diff.length === 0 ? "Clean" : "Dirty"}
+            </span>
           )}
         </div>
       ) : null}

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -18,6 +18,7 @@ import {
   ChatHistoryMessage,
   ChatHistoryResponse,
   ChatSession,
+  type RepositorySummary,
 } from "../../hooks/useApi";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { TaskPage } from "../TaskPage";
@@ -94,6 +95,20 @@ const sessionB: ChatSession = {
 };
 
 const emptyHistory = { sessionId: "", messages: [] };
+
+const mockRepository = (
+  overrides: Partial<RepositorySummary> = {},
+): RepositorySummary => ({
+  name: "test-repo",
+  path: "/tmp/test-repo",
+  hasGit: true,
+  isWorktreeChild: false,
+  lastCommit: "abc123",
+  branch: "main",
+  technology: "TypeScript",
+  license: "MIT",
+  ...overrides,
+});
 
 function renderPage(initialEntries = ["/repositories/test-repo?tab=agent"]) {
   return render(
@@ -5169,6 +5184,88 @@ describe("RepositoryPage skeleton states", () => {
       screen.getByRole("button", { name: /git/i }),
       "FAIL: Git tab button not rendered before repository loads",
     ).toBeInTheDocument();
+  });
+});
+
+describe("RepositoryPage working tree badge", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.mocked(api.getRepositoryAgentHistory).mockResolvedValue(emptyHistory);
+    vi.mocked(api.getRepositoryAgentSessions).mockResolvedValue({
+      sessions: [],
+    });
+    localStorage.clear();
+  });
+
+  it("shows Clean badge when git status diff is empty", async () => {
+    vi.mocked(api.getRepository).mockResolvedValue(mockRepository());
+    vi.mocked(api.getRepositoryGitStatus).mockResolvedValue({
+      branch: "main",
+      aheadBehind: { ahead: 0, behind: 0 },
+      lineStats: { green: 0, red: 0 },
+      lastCommit: { id: "abc123", date: "2026-01-01T00:00:00Z" },
+      counts: {
+        issues: 0,
+        pullRequests: 0,
+        branches: 1,
+        worktrees: 0,
+      },
+      links: {
+        repo: null,
+        issues: null,
+        pulls: null,
+        branches: null,
+        commit: null,
+      },
+      diff: [],
+    });
+
+    renderPage(["/repositories/test-repo"]);
+
+    expect(await screen.findByText("Clean")).toHaveClass("success");
+  });
+
+  it("shows Dirty badge when git status diff has entries", async () => {
+    vi.mocked(api.getRepository).mockResolvedValue(mockRepository());
+    vi.mocked(api.getRepositoryGitStatus).mockResolvedValue({
+      branch: "main",
+      aheadBehind: { ahead: 0, behind: 0 },
+      lineStats: { green: 2, red: 1 },
+      lastCommit: { id: "abc123", date: "2026-01-01T00:00:00Z" },
+      counts: {
+        issues: 0,
+        pullRequests: 0,
+        branches: 1,
+        worktrees: 0,
+      },
+      links: {
+        repo: null,
+        issues: null,
+        pulls: null,
+        branches: null,
+        commit: null,
+      },
+      diff: [{ path: "src/index.ts", green: 2, red: 1 }],
+    });
+
+    renderPage(["/repositories/test-repo"]);
+
+    expect(await screen.findByText("Dirty")).toHaveClass("danger");
+  });
+
+  it("does not render the badge when the repository has no Git", async () => {
+    vi.mocked(api.getRepository).mockResolvedValue(
+      mockRepository({ hasGit: false, branch: null }),
+    );
+
+    renderPage(["/repositories/test-repo"]);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Clean")).not.toBeInTheDocument();
+      expect(screen.queryByText("Dirty")).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -266,6 +266,11 @@ textarea {
   color: var(--warning);
 }
 
+.badge.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
+}
+
 .badge.external {
   background: rgba(239, 68, 68, 0.16);
   color: #fca5a5;


### PR DESCRIPTION
## Summary

RepositoryPage shows Git/No Git and branch metadata, but not whether the working tree has local changes. This adds a Clean/Dirty badge next to the Git badge in the header.

## Root Cause

The header meta row never rendered `gitStatus.diff`, even though `RepositoryPage` already fetched and stored git status on mount.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/RepositoryPage.tsx` | Render Clean/Dirty badge and clear stale git status before reload |
| `packages/frontend/src/styles/index.css` | Added `.badge.danger` styling |
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Added tests for clean, dirty, and no-Git cases |
| `.claude/PRPs/issues/completed/issue-649.md` | Archived investigation artifact |

## Testing

- [x] `make qa-quick`
- [ ] Frontend file-level Vitest run did not complete within the available command timeout

## Validation

```bash
make qa-quick
```

## Issue

Fixes #649

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue 649 investigation comment

### Deviations from plan:

- Cleared stale git status before reload to prevent the badge from showing a previous repository state while the next repository loads.

</details>


_Automated implementation from investigation artifact_
