### PR TITLE
Fix: RepositoryPage test cleanup (#654)

### DIFF
--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1111,60 +1111,17 @@ describe("RepositoryPage refreshAgentStatus guard (AC497)", () => {
 
   // ── P1: AC7 cross-page ───────────────────────────────────────────────
 
-  it("P1 (AC7): all 4 pages skip status API call when sessionId is null", async () => {
-    const pageConfigs = [
-      {
-        name: "RepositoryPage",
-        entry: "/repositories/test-repo",
-        route: "/repositories/:name/*",
-        el: <RepositoryPage />,
-        apiSpy: api.getRepositoryAgentStatus,
-      },
-      {
-        name: "TaskPage",
-        entry: "/tasks/test-task",
-        route: "/tasks/:name",
-        el: <TaskPage />,
-        apiSpy: api.getTaskAgentStatus,
-      },
-      {
-        name: "KnowledgeArtefactPage",
-        entry: "/knowledge/test-knowledge",
-        route: "/knowledge/:name",
-        el: <KnowledgeArtefactPage />,
-        apiSpy: api.getKnowledgeAgentStatus,
-      },
-      {
-        name: "ConstitutionPage",
-        entry: "/constitutions/test-constitution",
-        route: "/constitutions/:name",
-        el: <ConstitutionPage />,
-        apiSpy: api.getConstitutionAgentStatus,
-      },
-    ];
+  it("P1 (AC7): status API skipped when sessionId is null", async () => {
+    vi.mocked(api.getRepositoryAgentStatus).mockClear();
 
-    for (const page of pageConfigs) {
-      const spy = page.apiSpy;
-      vi.mocked(spy).mockClear();
+    renderPage(["/repositories/test-repo?tab=agent"]);
 
-      const { unmount } = render(
-        <MemoryRouter initialEntries={[page.entry]}>
-          <Routes>
-            <Route path={page.route} element={page.el} />
-          </Routes>
-        </MemoryRouter>,
-      );
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
 
-      await new Promise<void>((resolve) => setTimeout(resolve, 300));
-
-      expect(
-        vi.mocked(spy),
-        `FAIL (AC7): ${page.name} — status API was called without sessionId — !sessionId guard missing`,
-      ).not.toHaveBeenCalled();
-
-      unmount();
-      await new Promise<void>((resolve) => setTimeout(resolve, 50));
-    }
+    expect(
+      api.getRepositoryAgentStatus,
+      "FAIL (AC7): status API was called without sessionId — !sessionId guard missing in useChatSession",
+    ).not.toHaveBeenCalled();
   });
 
   // ── P2: AC8 isExternal ordering ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Compress the redundant null-session status-call matrix in `RepositoryPage.test.tsx` to a single representative RepositoryPage assertion.

## Root Cause

The null-session guard is implemented in shared `useChatSession` code, so the 4-page matrix duplicated the same behavior check.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx` | Reduced the P1 AC7 matrix to one RepositoryPage assertion |

## Testing

- [x] `npm --workspace packages/frontend run lint`
- [x] `npx vitest run --no-file-parallelism src/pages/__tests__/RepositoryPage.test.tsx -t "status API skipped when sessionId is null" --reporter=verbose`

## Validation

```bash
make test-frontend FILE=src/pages/__tests__/RepositoryPage.test.tsx
npm --workspace packages/frontend run lint
npx vitest run --no-file-parallelism src/pages/__tests__/RepositoryPage.test.tsx -t "status API skipped when sessionId is null" --reporter=verbose
```

## Issue

Fixes #654

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue comment implementation plan for #654

### Deviations from plan:

- Kept the RepositoryPage representative assertion only, because removing page imports was invalid: the file still references TaskPage, KnowledgeArtefactPage, and ConstitutionPage elsewhere.
- Used `/repositories/test-repo?tab=agent` to keep the agent-tab path aligned with the page wiring.

</details>

_Automated implementation from investigation artifact