### PR TITLE
fix(frontend): stop chat session poll storms

### DIFF
--- a/packages/frontend/src/components/ChatWindow.test.tsx
+++ b/packages/frontend/src/components/ChatWindow.test.tsx
@@ -101,13 +101,7 @@ describe("ChatWindow", () => {
   });
 
   it("shows empty message when chat is empty", () => {
-    render(
-      <ChatWindow
-        chat={[]}
-        running={false}
-        emptyMessage="No messages"
-      />,
-    );
+    render(<ChatWindow chat={[]} running={false} emptyMessage="No messages" />);
     expect(screen.getByText("No messages")).toBeInTheDocument();
   });
 
@@ -118,11 +112,7 @@ describe("ChatWindow", () => {
 
   it("renders loading indicator in the virtualized footer for non-empty chat", () => {
     render(
-      <ChatWindow
-        chat={[makeMessage()]}
-        running
-        emptyMessage="No messages"
-      />,
+      <ChatWindow chat={[makeMessage()]} running emptyMessage="No messages" />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
@@ -317,29 +307,19 @@ describe("ChatWindow", () => {
 
   it("toggles loading indicator when running changes at runtime (empty chat)", () => {
     const { rerender } = render(
-      <ChatWindow
-        chat={[]}
-        running={false}
-        emptyMessage="No messages"
-      />,
+      <ChatWindow chat={[]} running={false} emptyMessage="No messages" />,
     );
 
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
     expect(screen.getByText("No messages")).toBeInTheDocument();
 
-    rerender(
-      <ChatWindow chat={[]} running emptyMessage="No messages" />,
-    );
+    rerender(<ChatWindow chat={[]} running emptyMessage="No messages" />);
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
     expect(screen.queryByText("No messages")).not.toBeInTheDocument();
 
     rerender(
-      <ChatWindow
-        chat={[]}
-        running={false}
-        emptyMessage="No messages"
-      />,
+      <ChatWindow chat={[]} running={false} emptyMessage="No messages" />,
     );
 
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
@@ -358,11 +338,7 @@ describe("ChatWindow", () => {
     expect(screen.queryByText("Agent is thinking...")).not.toBeInTheDocument();
 
     rerender(
-      <ChatWindow
-        chat={[makeMessage()]}
-        running
-        emptyMessage="No messages"
-      />,
+      <ChatWindow chat={[makeMessage()]} running emptyMessage="No messages" />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
@@ -386,11 +362,7 @@ describe("ChatWindow", () => {
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
 
     rerender(
-      <ChatWindow
-        chat={[makeMessage()]}
-        running
-        emptyMessage="No messages"
-      />,
+      <ChatWindow chat={[makeMessage()]} running emptyMessage="No messages" />,
     );
 
     expect(screen.getByText("Agent is thinking...")).toBeInTheDocument();
@@ -626,11 +598,7 @@ describe("ChatWindow", () => {
 
   it("followOutput returns false when user is scrolled up (no auto-scroll on streaming arrival)", () => {
     render(
-      <ChatWindow
-        chat={[makeMessage()]}
-        running
-        emptyMessage="No messages"
-      />,
+      <ChatWindow chat={[makeMessage()]} running emptyMessage="No messages" />,
     );
 
     const cb = followOutputCapture.current;

--- a/packages/frontend/src/components/ChatWindow.tsx
+++ b/packages/frontend/src/components/ChatWindow.tsx
@@ -210,14 +210,12 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
                 <span>Loading session...</span>
               </div>
             )}
-              {!ctx?.refreshing &&
-              !ctx?.sessionLoading &&
-              ctx?.running && (
-                <div className="loading-indicator">
-                  <div className="loading-spinner"></div>
-                  <span>Agent is thinking...</span>
-                </div>
-              )}
+            {!ctx?.refreshing && !ctx?.sessionLoading && ctx?.running && (
+              <div className="loading-indicator">
+                <div className="loading-spinner"></div>
+                <span>Agent is thinking...</span>
+              </div>
+            )}
             {ctx?.sessionId && (
               <div className="chat-session-id" aria-label="Session ID">
                 <span>Session ID: {ctx.sessionId}</span>
@@ -291,19 +289,15 @@ export const ChatWindow: React.FC<ChatWindowProps> = React.memo(
             <span>Loading session...</span>
           </div>
         )}
-        {chat.length === 0 &&
-          !refreshing &&
-          !sessionLoading &&
-          running && (
-            <div className="loading-indicator">
-              <div className="loading-spinner"></div>
-              <span>Agent is thinking...</span>
-            </div>
-          )}
-        {chat.length === 0 &&
-          !refreshing &&
-          !sessionLoading &&
-          !running && <div className="empty">{emptyMessage}</div>}
+        {chat.length === 0 && !refreshing && !sessionLoading && running && (
+          <div className="loading-indicator">
+            <div className="loading-spinner"></div>
+            <span>Agent is thinking...</span>
+          </div>
+        )}
+        {chat.length === 0 && !refreshing && !sessionLoading && !running && (
+          <div className="empty">{emptyMessage}</div>
+        )}
         {chat.length === 0 && sessionId && (
           <div className="chat-session-id" aria-label="Session ID">
             <span>Session ID: {sessionId}</span>

--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useChatSession } from "./useChatSession";
 import type { ChatMessage } from "../types/chat";
@@ -302,5 +302,58 @@ describe("useChatSession", () => {
     });
 
     expect(result.current.agentStatus).toBeNull();
+  });
+
+  it("does not restart loading when the api wrapper identity changes", async () => {
+    const chat = makeChat();
+    const setChat = vi.fn();
+    const setSessionId = vi.fn();
+    const setPrompt = vi.fn();
+    const setSelectedAgent = vi.fn();
+    const sendMessage = vi.fn();
+    const getStatus = vi.fn().mockResolvedValue({ running: false });
+    const cancelAgent = vi.fn();
+    const getHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      messages: [],
+    });
+    const getSessions = vi.fn();
+
+    const makeApi = () => ({
+      sendMessage,
+      getStatus,
+      cancelAgent,
+      getHistory,
+      getSessions,
+    });
+
+    const { rerender } = renderHook(
+      ({ api }) =>
+        useChatSession({
+          name: "repo",
+          sessionId: "session-1",
+          setSessionId,
+          chat,
+          setChat,
+          setPrompt,
+          setSelectedAgent,
+          normalizedSelectedAgent: "default",
+          defaultAgentValue: "default",
+          api,
+        }),
+      { initialProps: { api: makeApi() } },
+    );
+
+    await waitFor(() => expect(getHistory).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getStatus).toHaveBeenCalledTimes(1));
+
+    rerender({ api: makeApi() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getHistory).toHaveBeenCalledTimes(1);
+    expect(getStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -99,6 +99,13 @@ export function useChatSession({
   onClearSessionOnly,
   onClearSessionAndHistory,
 }: UseChatSessionParams): UseChatSessionResult {
+  const {
+    sendMessage,
+    getStatus,
+    cancelAgent,
+    getHistory: getHistoryApi,
+    getSessions,
+  } = api;
   const [agentStatus, setAgentStatus] = useState<string | null>(null);
   const [chatAgentProcessing, setChatAgentProcessing] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -139,7 +146,7 @@ export function useChatSession({
       }
 
       try {
-        const status = await api.getStatus(name, targetSessionId);
+        const status = await getStatus(name, targetSessionId);
         if (sessionIdRef.current !== targetSessionId) return false;
         setChatAgentProcessing(status.running);
         if (!preserveStatus) {
@@ -155,13 +162,13 @@ export function useChatSession({
         return null;
       }
     },
-    [api, isExternal, name, sessionId],
+    [getStatus, isExternal, name, sessionId],
   );
 
   const getHistory: GetHistoryFn = useCallback(
     (agentName: string, agentSessionId: string, signal?: AbortSignal) =>
-      api.getHistory(agentName, agentSessionId, undefined, signal),
-    [api],
+      getHistoryApi(agentName, agentSessionId, undefined, signal),
+    [getHistoryApi],
   );
 
   const {
@@ -190,7 +197,7 @@ export function useChatSession({
         : undefined;
 
       try {
-        const history = await api.getHistory(
+        const history = await getHistoryApi(
           name,
           sessionId,
           startTimestamp,
@@ -209,7 +216,7 @@ export function useChatSession({
         console.error("Failed to sync chat history", error);
       }
     },
-    [api, isExternal, name, sessionId, setChat],
+    [getHistoryApi, isExternal, name, sessionId, setChat],
   );
 
   useAgentPolling({
@@ -229,7 +236,7 @@ export function useChatSession({
     setChat([]);
 
     try {
-      const history = await api.getHistory(name, sessionIdAtCall);
+      const history = await getHistoryApi(name, sessionIdAtCall);
       if (sessionIdRef.current !== sessionIdAtCall) return;
       const mapped = mapHistoryToMessages(history.messages || []);
       setChat(mapped);
@@ -252,8 +259,8 @@ export function useChatSession({
       isRefreshingRef.current = false;
     }
   }, [
-    api,
     clearSessionHistoryError,
+    getHistoryApi,
     isExternal,
     name,
     refreshAgentStatus,
@@ -296,7 +303,7 @@ export function useChatSession({
           normalizedSelectedAgent !== defaultAgentValue
             ? normalizedSelectedAgent.trim()
             : undefined;
-        const reply = await api.sendMessage(
+        const reply = await sendMessage(
           name,
           promptWithPolicy,
           sessionId || undefined,
@@ -328,7 +335,6 @@ export function useChatSession({
       }
     },
     [
-      api,
       appendPolicy,
       defaultAgentValue,
       defaultModelValue,
@@ -338,6 +344,7 @@ export function useChatSession({
       normalizedSelectedModel,
       onActivateAgentTab,
       refreshAgentStatus,
+      sendMessage,
       setPrompt,
       sessionId,
       setChat,
@@ -351,7 +358,7 @@ export function useChatSession({
     setIsCancelingAgent(true);
     let preserveStatus = false;
     try {
-      await api.cancelAgent(name, sessionId || undefined);
+      await cancelAgent(name, sessionId || undefined);
     } catch (error) {
       console.error("Failed to cancel agent request", error);
       setAgentStatus("Unable to cancel the agent request.");
@@ -360,7 +367,14 @@ export function useChatSession({
       await refreshAgentStatus(undefined, preserveStatus);
       setIsCancelingAgent(false);
     }
-  }, [api, isCancelingAgent, isExternal, name, refreshAgentStatus, sessionId]);
+  }, [
+    cancelAgent,
+    isCancelingAgent,
+    isExternal,
+    name,
+    refreshAgentStatus,
+    sessionId,
+  ]);
 
   const openSessionModal = useCallback(async () => {
     if (!name || isExternal) return;
@@ -368,7 +382,7 @@ export function useChatSession({
     setSessionModalOpen(true);
     setSessionListLoading(true);
     try {
-      const response = await api.getSessions(name, 10);
+      const response = await getSessions(name, 10);
       setSessionOptions(response.sessions || []);
       setSessionListError(null);
     } catch (error) {
@@ -379,7 +393,7 @@ export function useChatSession({
     } finally {
       setSessionListLoading(false);
     }
-  }, [api, isExternal, name]);
+  }, [getSessions, isExternal, name]);
 
   const closeSessionModal = useCallback(() => {
     setSessionModalOpen(false);


### PR DESCRIPTION
## Summary
- Stabilize chat-session hook dependencies so a fresh API wrapper object no longer restarts session loading/polling
- Add a regression test for wrapper identity churn

## Verification
- make qa-quick
- npm --workspace packages/frontend run test:serial -- src/hooks/useChatSession.test.tsx src/hooks/useAgentPolling.test.ts
- npm --workspace packages/frontend exec eslint src/hooks/useChatSession.ts src/hooks/useChatSession.test.tsx