### PR TITLE
fix(session): resolve polling race conditions and abort signal bypass

### DIFF
--- a/packages/frontend/src/hooks/useApi.test.ts
+++ b/packages/frontend/src/hooks/useApi.test.ts
@@ -146,6 +146,31 @@ describe("GET request deduplication", () => {
     vi.clearAllMocks();
   });
 
+  it("should bypass dedup and issue a new fetch when AbortSignal is provided", async () => {
+    const mockResponse = () =>
+      new Response(JSON.stringify({ messages: [], nextTimestamp: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    window.fetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockResponse()));
+
+    const controller = new AbortController();
+    await Promise.all([
+      api.getRepositoryAgentHistory("my-repo", "ses_1"),
+      api.getRepositoryAgentHistory(
+        "my-repo",
+        "ses_1",
+        undefined,
+        controller.signal,
+      ),
+    ]);
+
+    // Two distinct fetches: one from dedup path, one bypassing it via signal
+    expect(window.fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("should issue only one fetch for concurrent identical GET requests", async () => {
     window.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ agents: [] }), {

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -10,6 +10,10 @@ async function request<T>(
   const method = (options.method ?? "GET").toUpperCase();
 
   if (method === "GET") {
+    // Requests with an AbortSignal need independent cancellation — skip dedup
+    if (options.signal) {
+      return executeRequest<T>(endpoint, options);
+    }
     const key = `GET:${endpoint}`;
     const inflight = inflightRequests.get(key) as Promise<T> | undefined;
     if (inflight) return inflight;

--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -345,7 +345,6 @@ describe("useChatSession", () => {
     );
 
     await waitFor(() => expect(getHistory).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(getStatus).toHaveBeenCalledTimes(1));
 
     rerender({ api: makeApi() });
 
@@ -354,6 +353,8 @@ describe("useChatSession", () => {
     });
 
     expect(getHistory).toHaveBeenCalledTimes(1);
-    expect(getStatus).toHaveBeenCalledTimes(1);
+    // getStatus is no longer called from onHistoryLoaded (fix #674); the history
+    // response's `processing` field drives polling instead.
+    expect(getStatus).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -185,7 +185,6 @@ export function useChatSession({
         setChatAgentProcessing(history.processing);
       }
       setAgentStatus(null);
-      void refreshAgentStatus(history.sessionId);
     },
   });
 
@@ -317,6 +316,7 @@ export function useChatSession({
         }
         setAgentStatus(null);
         onActivateAgentTab?.();
+        await syncChatHistory(new AbortController().signal);
         await refreshAgentStatus(reply.sessionId ?? sessionId);
       } catch (error) {
         if (sendRequestIdRef.current !== sendRequestId) return;
@@ -349,6 +349,7 @@ export function useChatSession({
       sessionId,
       setChat,
       setSessionId,
+      syncChatHistory,
     ],
   );
 

--- a/packages/frontend/src/hooks/useSessionLoader.ts
+++ b/packages/frontend/src/hooks/useSessionLoader.ts
@@ -67,7 +67,6 @@ export function useSessionLoader({
 
     setSessionLoading(true);
     setSessionError(null);
-    setChat([]);
 
     const controller = new AbortController();
 

--- a/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
+++ b/packages/frontend/src/pages/__tests__/RepositoryPage.test.tsx
@@ -1,7 +1,15 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
 import "@testing-library/jest-dom/vitest";
 import {
   cleanup,

--- a/packages/pybackend/opencode_database_agent_cli.py
+++ b/packages/pybackend/opencode_database_agent_cli.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import re
-import time
 from pathlib import Path
 from typing import Any, Callable
 from threading import Event
@@ -574,10 +573,6 @@ class OpenCodeDatabaseAgentCLI(AgentCLI):
                                     break
                             except json.JSONDecodeError:
                                 continue
-
-                # Generate session_id if none provided and none extracted
-                if not extracted_session_id:
-                    extracted_session_id = f"opencode-{int(time.time())}"
 
                 return RunResult(
                     success=True,


### PR DESCRIPTION
## Summary

Fixes five session handling issues (#672, #673, #674, #675, #676) identified in the chat polling lifecycle. These were causing agent responses to never render, request storms, and stale session IDs propagating to the frontend.

## Changes

### Backend
- **#672** `opencode_database_agent_cli.py`: Remove fake `opencode-{timestamp}` session ID fallback. When the CLI emits no `sessionID`, the variable now stays as the caller's original `session_id` — no broken ID is ever stored by the frontend.

### Frontend
- **#676** `useApi.ts`: Bypass the GET inflight dedup cache when the request carries an `AbortSignal`. Previously the shared promise ignored the second caller's signal, silently breaking abort-on-cleanup in `useSessionLoader` and `useAgentPolling`.

- **#674** `useChatSession.ts`: Remove the redundant `void refreshAgentStatus(history.sessionId)` from `onHistoryLoaded`. The history response already embeds `processing`; the extra call created a race that prematurely stopped polling when the agent finished between the two requests.

- **#673** `useSessionLoader.ts`: Remove `setChat([])` before re-fetch. Stale messages now stay visible during the in-flight reload instead of flashing blank + spinner.

- **#675** `useChatSession.ts`: Add `await syncChatHistory(...)` before `refreshAgentStatus` in `handleSendMessage`. Ensures at least one history sync happens after every send, catching fast-completing agents that finish before the first polling tick.

## Tests

- New: `useApi.test.ts` — verifies signal-carrying requests bypass the inflight map (two distinct fetches)
- Updated: `useChatSession.test.tsx` — reflects that `getStatus` is no longer called from `onHistoryLoaded`
- All 467 backend unit tests pass
- All 168 frontend unit tests pass (28 files)
- All 3 Playwright E2E tests pass

Closes #672, #673, #674, #675, #676