### PR TITLE
fix: make session processing detection authoritative (#686 #687 #688)

### DIFF
--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -353,8 +353,8 @@ describe("useChatSession", () => {
     });
 
     expect(getHistory).toHaveBeenCalledTimes(1);
-    // getStatus is no longer called from onHistoryLoaded (fix #674); the history
-    // response's `processing` field drives polling instead.
-    expect(getStatus).not.toHaveBeenCalled();
+    // Fix #686: getStatus is now always called once from onHistoryLoaded to probe
+    // the authoritative backend state, regardless of history.processing.
+    expect(getStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -177,11 +177,11 @@ export function useChatSession({
     sessionId,
     setChat,
     getHistory,
-    onHistoryLoaded: (history: ChatHistoryResponse) => {
-      if (history.processing !== undefined) {
-        setChatAgentProcessing(history.processing);
-      }
+    onHistoryLoaded: () => {
       setAgentStatus(null);
+      // Always probe backend for authoritative status on initial load (#686).
+      // Do not trust history.processing alone — it may be stale.
+      void refreshAgentStatus();
     },
   });
 
@@ -258,11 +258,8 @@ export function useChatSession({
       const mapped = mapHistoryToMessages(history.messages || []);
       setChat(mapped);
       setAgentStatus(null);
-      if (history.processing !== undefined) {
-        setChatAgentProcessing(history.processing);
-      } else {
-        await refreshAgentStatus(sessionIdAtCall);
-      }
+      // Always probe backend for authoritative status on manual refresh (#686).
+      await refreshAgentStatus(sessionIdAtCall);
     } catch (error) {
       setChat(chatBeforeRefresh);
       console.error("Failed to load session history", error);
@@ -335,7 +332,15 @@ export function useChatSession({
         setAgentStatus(null);
         onActivateAgentTab?.();
         await syncChatHistory(new AbortController().signal);
-        setChatAgentProcessing(reply.processing ?? false);
+        // Fix #687: never clear the optimistic `true` from a potentially stale
+        // reply.processing value. If the reply says running, trust it; otherwise
+        // let refreshAgentStatus() confirm the real state so we don't prematurely
+        // clear the spinner before the polling loop has had a chance to confirm.
+        if (reply.processing === true) {
+          setChatAgentProcessing(true);
+        } else {
+          await refreshAgentStatus(reply.sessionId ?? sessionId ?? undefined);
+        }
       } catch (error) {
         if (sendRequestIdRef.current !== sendRequestId) return;
         console.error("Failed to contact agent", error);

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -213,6 +213,21 @@ def _remove_process(lock_key: str) -> None:
     _save_process_registry()
 
 
+def _cleanup_process_locked(lock_key: str) -> None:
+    """Atomically clean all 4 in-memory structures + registry for a process.
+
+    Caller MUST hold ``_processing_lock``.  Registry persistence is deferred:
+    call ``_dump_processing_state()`` (or set ``needs_dump = True``) after
+    releasing the lock.
+    """
+    for key in _get_related_processing_keys(lock_key):
+        _processing_channels.pop(key, None)
+        _cancelled_channels.discard(key)
+        _active_processes.pop(key, None)
+        _cancel_events.pop(key, None)
+    _remove_process_locked(lock_key)
+
+
 def _dump_processing_state() -> None:
     _save_process_registry()
 
@@ -541,93 +556,84 @@ def cancel_agent_message(lock_key: str) -> bool:
 def get_channel_status(lock_key: str) -> dict[str, object]:
     needs_dump = False
     session_id = lock_key
-    registry_confirmed = False
 
+    # --- STEP 0: Resolve session_id up-front (both forward and reverse) ---
+    # Do this before any state checks so `session_id` is correct for the entire
+    # function, including the ps-scan fallback at the bottom.
     with _processing_lock:
-        started_at = _processing_channels.get(lock_key)
-
-        # Fallback 1: reverse lookup via _conversation_sessions mapping.
-        # Handles the case where lock_key is a session_id but processing was
-        # stored under the channel name (first-message key mismatch).
-        if started_at is None:
-            for ch, sid in list(_conversation_sessions.items()):
-                if sid == lock_key:
-                    started_at = _processing_channels.get(ch)
-                    if started_at is not None:
-                        # Propagate so future lookups are direct
-                        _processing_channels[lock_key] = started_at
-                    break
-
+        # Forward: lock_key is a channel name → get its associated session_id.
         if lock_key in _conversation_sessions:
             session_id = _conversation_sessions[lock_key]
+        # Reverse: lock_key might itself be a session_id stored under a channel
+        # key in _processing_channels.  Propagate so future lookups are direct.
+        elif lock_key not in _processing_channels:
+            for ch, sid in list(_conversation_sessions.items()):
+                if sid == lock_key and ch in _processing_channels:
+                    _processing_channels[lock_key] = _processing_channels[ch]
+                    break
 
-        needs_disk_fallback = started_at is None
+    # --- STEP 1: _active_processes (live Popen – most authoritative) ---
+    # A Popen object never lies: poll() == None means the process is alive.
+    with _processing_lock:
+        process = _active_processes.get(lock_key)
+        if process is not None:
+            if process.poll() is None:
+                return {"running": True}
+            # Process confirmed exited – atomically clean all 4 structures + registry.
+            _cleanup_process_locked(lock_key)
+            needs_dump = True
 
+    # --- STEP 2: _processing_channels + registry pid cross-check ---
+    # An in-memory entry exists but there is no live Popen.  Cross-check the
+    # registry to confirm whether the underlying pid is still alive.
+    with _processing_lock:
+        started_at = _processing_channels.get(lock_key)
         if started_at is not None:
-            process = _active_processes.get(lock_key)
-            # Only clean up if we can confirm the process has exited
-            if process is not None and process.poll() is not None:
-                for key in _get_related_processing_keys(lock_key):
-                    _processing_channels.pop(key, None)
-                    _cancelled_channels.discard(key)
-                    _active_processes.pop(key, None)
-                    _cancel_events.pop(key, None)
+            registry_entry = _find_process_registry_entry_locked(lock_key)
+            if registry_entry is not None:
+                if _is_pid_alive(registry_entry[1].get("pid")):
+                    session_val = registry_entry[1].get("sessionId")
+                    if isinstance(session_val, str):
+                        session_id = session_val
+                    if needs_dump:
+                        # Registry cleanup already persisted above; flush now.
+                        pass
+                    return {"running": True}
+                # Registry pid is dead – stale entry; clean up atomically.
+                _cleanup_process_locked(lock_key)
                 needs_dump = True
                 started_at = None
-            elif process is None:
-                registry_entry = _find_process_registry_entry_locked(lock_key)
-                if registry_entry is not None and not _is_pid_alive(
-                    registry_entry[1].get("pid")
-                ):
-                    _remove_process_locked(lock_key)
-                    for key in _get_related_processing_keys(lock_key):
-                        _processing_channels.pop(key, None)
-                        _cancelled_channels.discard(key)
-                        _active_processes.pop(key, None)
-                        _cancel_events.pop(key, None)
-                    needs_dump = True
-                    started_at = None
-                elif registry_entry is not None:
-                    started_str = registry_entry[1].get("startedAt")
-                    if isinstance(started_str, str):
-                        try:
-                            started_at = datetime.fromisoformat(started_str)
-                        except (TypeError, ValueError):
-                            started_at = datetime.now(UTC)
-                    else:
-                        started_at = datetime.now(UTC)
-                    _processing_channels[lock_key] = started_at
-                    session_value = registry_entry[1].get("sessionId")
-                    if isinstance(session_value, str):
-                        session_id = session_value
-                    registry_confirmed = True
+            # No registry entry: in-memory entry exists but pid unknown.
+            # Fall through to ps scan to let the OS be the tie-breaker.
 
-    # Fallback 2: persisted state (survives backend restart) — outside the lock
-    # to avoid blocking all threads on file I/O.
-    if needs_disk_fallback and started_at is None:
+    # --- STEP 3: Registry-only fallback (e.g. after backend restart) ---
+    # Nothing in memory, but a persisted registry entry may exist from a prior run.
+    if started_at is None:
         registry_entry = _find_process_registry_entry(lock_key)
-        if registry_entry is not None and _is_pid_alive(registry_entry[1].get("pid")):
-            started_str = registry_entry[1].get("startedAt")
-            if isinstance(started_str, str):
-                try:
-                    started_at = datetime.fromisoformat(started_str)
-                except (TypeError, ValueError):
+        if registry_entry is not None:
+            if _is_pid_alive(registry_entry[1].get("pid")):
+                started_str = registry_entry[1].get("startedAt")
+                if isinstance(started_str, str):
+                    try:
+                        started_at = datetime.fromisoformat(started_str)
+                    except (TypeError, ValueError):
+                        started_at = datetime.now(UTC)
+                else:
                     started_at = datetime.now(UTC)
-            else:
-                started_at = datetime.now(UTC)
-            _processing_channels[lock_key] = started_at
-            session_id = (
-                registry_entry[1].get("sessionId")
-                if isinstance(registry_entry[1].get("sessionId"), str)
-                else session_id
-            )
-            registry_confirmed = True
-        elif registry_entry is not None:
+                session_val = registry_entry[1].get("sessionId")
+                if isinstance(session_val, str):
+                    session_id = session_val
+                with _processing_lock:
+                    _processing_channels[lock_key] = started_at
+                if needs_dump:
+                    _dump_processing_state()
+                return {"running": True}
+            # Registry pid is dead – remove stale persisted entry.
             _remove_process(lock_key)
 
-    if registry_confirmed:
-        return {"running": True}
-
+    # --- STEP 4: ps scan (last resort) ---
+    # Neither in-memory state nor registry could confirm a live process.  Fall
+    # back to the OS process table using the fully-resolved session_id.
     try:
         processes = _read_running_agent_processes()
     except (OSError, subprocess.SubprocessError) as exc:


### PR DESCRIPTION
## Issues fixed
- Closes #688 — Make backend session processing detection authoritative
- Closes #687 — Keep agent processing true until backend confirms completion
- Closes #686 — Fix session refresh status probe for shared chat sessions

## Summary of changes

### Backend — `packages/pybackend/agent_service.py` (#688)

**Problem:** `get_channel_status()` used 3+ heuristic layers (in-memory, registry, ps scan) that could drift and produce stale false negatives. The reverse session lookup was applied mid-function after state was already read, so `session_id` was wrong for the ps fallback. Stale Popen cleanup removed in-memory state but left the registry dirty.

**Fix:**
- Added `_cleanup_process_locked()` — a single atomic helper that clears all 4 in-memory structures (`_processing_channels`, `_cancelled_channels`, `_active_processes`, `_cancel_events`) plus the registry entry in one locked call.
- Rewrote `get_channel_status()` with an explicit 4-priority design:
  - **Step 0**: resolve `session_id` via `_conversation_sessions` (forward + reverse) *before* any state check
  - **Step 1**: `_active_processes` (live Popen — most authoritative, `poll() is None`)
  - **Step 2**: `_processing_channels` + registry pid cross-check
  - **Step 3**: registry-only fallback for server restarts
  - **Step 4**: ps scan as last resort, now using the correctly-resolved `session_id`

### Frontend — `packages/frontend/src/hooks/useChatSession.ts` (#687 + #686)

**#687 — Premature clear of optimistic processing state:**
- Replaced `setChatAgentProcessing(reply.processing ?? false)` with a conditional: if `reply.processing === true`, trust it; otherwise call `refreshAgentStatus()` to confirm the real state before clearing the spinner.

**#686 — Initial load / refresh trusts stale `history.processing`:**
- `onHistoryLoaded`: always call `refreshAgentStatus()` instead of reading `history.processing` — backend status is now the authoritative source on initial page load.
- `reloadCurrentSession`: always probe status after history loads, removing the conditional fallback pattern.

## Validation

```
make qa-quick
```
- ✅ 467 backend tests passed, 1 skipped
- ✅ 168 frontend tests passed (28 files)
- ✅ Lint + format: no issues
- ✅ Pre-push hook passed on push

## E2E coverage

Existing unit tests for `get_channel_status` cover the key scenarios:
- Exited process clears entry (`test_get_channel_status_clears_exited_process_entry`)
- Registry fallback on restart (`test_get_channel_status_falls_back_to_registry_state`)
- Reverse session lookup (`test_get_channel_status_reverse_lookup_via_conversation_sessions`)
- Dead registry entry ignored (`test_get_channel_status_ignores_dead_registry_entry`)
- `onHistoryLoaded` now always calls `getStatus` (`useChatSession.test.tsx` assertion updated)

## Risks / follow-ups

- The extra `getStatus` call on initial history load adds one HTTP round-trip per session load. This is intentional per the acceptance criteria of #686.
- No unrelated issues found during implementation.