### PR TITLE
fix: resolve false busy-agent 409 and stale processing state (#690 #691 #692 #693)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,9 @@ It runs `make qa-quick` (lint + format + unit-test) automatically before every `
 - Codex Cloud sandboxes may time out; ensure startup completes promptly.
 - Keep build output small and dependencies clean to reduce setup time.
 - Always test locally before expecting preview success.
+
+## Lessons Learned
+
+- 2026-06-29: `_processing_channels` cleanup in `agent_service.py` is deferred to polling — any code path that skips polling can leave stale lock keys. Prevention: always verify cleanup happens on the write path (success path of `send_agent_message`), not only on the read path (`get_channel_status`). When adding new async state, ask "what cleans this up if the reader never arrives?"
+- 2026-06-29: In parallel subagent workflows, group all changes to a single high-contention file (e.g. `agent_service.py`) under one subagent. Splitting them across agents on the same branch always risks merge conflicts. Frontend and backend can safely run in parallel as they share no files.
+- 2026-06-29: When frontend error detection relies on HTTP status codes, ensure the API layer actually preserves and exposes them. A plain `throw new Error(body)` discards status; a typed `HttpError` with a `status` field is the correct pattern.

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -1,6 +1,15 @@
 const API_BASE =
   (import.meta.env?.VITE_API_BASE as string | undefined) || "/api";
 
+export class HttpError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
 const inflightRequests = new Map<string, Promise<unknown>>();
 
 async function request<T>(
@@ -64,7 +73,7 @@ async function executeRequest<T>(
           continue;
         }
 
-        throw new Error(message || "Request failed");
+        throw new HttpError(message || "Request failed", response.status);
       }
 
       if (response.status === 204) {
@@ -95,7 +104,7 @@ async function executeRequest<T>(
     }
   }
 
-  throw new Error("Maximum retry attempts exceeded");
+  throw new HttpError("Maximum retry attempts exceeded", 0);
 }
 
 async function requestForm<T>(
@@ -135,7 +144,7 @@ async function requestForm<T>(
           continue;
         }
 
-        throw new Error(message || "Request failed");
+        throw new HttpError(message || "Request failed", response.status);
       }
 
       if (response.status === 204) {
@@ -166,7 +175,7 @@ async function requestForm<T>(
     }
   }
 
-  throw new Error("Maximum retry attempts exceeded");
+  throw new HttpError("Maximum retry attempts exceeded", 0);
 }
 
 export type AgentReply = {

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -3,6 +3,7 @@ import type { Dispatch, SetStateAction } from "react";
 import type { ChatMessage } from "../types/chat";
 import { mapHistoryToMessages, mergeChatMessages } from "../utils/chat";
 import type { AgentReply, ChatHistoryResponse, ChatSession } from "./useApi";
+import { HttpError } from "./useApi";
 import { useAgentPolling } from "./useAgentPolling";
 import { useSessionLoader, type GetHistoryFn } from "./useSessionLoader";
 
@@ -344,8 +345,7 @@ export function useChatSession({
       } catch (error) {
         if (sendRequestIdRef.current !== sendRequestId) return;
         console.error("Failed to contact agent", error);
-        const errorMessage = error instanceof Error ? error.message : "";
-        const busy = errorMessage.toLowerCase().includes("processing");
+        const busy = error instanceof HttpError && error.status === 409;
         setAgentStatus(
           busy
             ? "Agent is still processing the previous message."

--- a/packages/pybackend/agent_service.py
+++ b/packages/pybackend/agent_service.py
@@ -56,9 +56,18 @@ def _load_process_registry() -> None:
         if not isinstance(data, dict):
             raise ValueError("Invalid registry payload")
 
+        # Support new wrapper format: {"registry": {...}, "conversationSessions": {...}}
+        # Fall back to old flat format for backward compatibility.
+        if "registry" in data and isinstance(data["registry"], dict):
+            registry_data: dict = data["registry"]
+            sessions_data: dict = data.get("conversationSessions") or {}
+        else:
+            registry_data = data
+            sessions_data = {}
+
         now = datetime.now(UTC)
         fresh: dict[str, dict[str, object]] = {}
-        for key, value in data.items():
+        for key, value in registry_data.items():
             if not isinstance(key, str):
                 continue
 
@@ -116,6 +125,11 @@ def _load_process_registry() -> None:
         with _processing_lock:
             _process_registry.clear()
             _process_registry.update(fresh)
+            # Restore conversation sessions from persisted data (issue #691)
+            if isinstance(sessions_data, dict):
+                for k, v in sessions_data.items():
+                    if isinstance(k, str) and isinstance(v, str):
+                        _conversation_sessions[k] = v
     except Exception:
         logger.warning("Failed to load agent process registry", exc_info=True)
         with _processing_lock:
@@ -126,8 +140,13 @@ def _save_process_registry() -> None:
     path = _get_registry_path()
     try:
         with _processing_lock:
-            snapshot = dict(_process_registry)
-        path.write_text(json.dumps(snapshot, indent=2))
+            registry_snapshot = dict(_process_registry)
+            sessions_snapshot = dict(_conversation_sessions)
+        payload = {
+            "registry": registry_snapshot,
+            "conversationSessions": sessions_snapshot,
+        }
+        path.write_text(json.dumps(payload, indent=2))
     except Exception:
         logger.warning("Failed to persist agent process registry", exc_info=True)
 
@@ -251,10 +270,46 @@ def _load_processing_state() -> dict[str, datetime]:
 
         if now - started_at_dt < _MAX_PROCESSING_AGE:
             state[key] = started_at_dt
+
+    # Populate _processing_channels from the loaded registry so that
+    # stale-entry detection works correctly after a backend restart.
+    with _processing_lock:
+        _processing_channels.update(state)
+
     return state
 
 
-_load_process_registry()
+def _purge_dead_processing_entries() -> None:
+    """Remove stale entries from _processing_channels at startup.
+
+    An entry is considered stale when there is no positive evidence of a live
+    process: no live Popen in ``_active_processes`` AND no live PID in the
+    registry.  Should be called once after ``_load_processing_state()``.
+    """
+    with _processing_lock:
+        keys = list(_processing_channels.keys())
+    for key in keys:
+        with _processing_lock:
+            if key not in _processing_channels:
+                continue  # Already removed by a previous iteration
+            process = _active_processes.get(key)
+            if process is not None and process.poll() is None:
+                continue  # Live Popen: keep
+            registry_entry = _find_process_registry_entry_locked(key)
+            if registry_entry is not None and _is_pid_alive(
+                registry_entry[1].get("pid")
+            ):
+                continue  # Live PID in registry: keep
+            # No positive evidence of a live process: remove stale entry
+            _processing_channels.pop(key, None)
+            _cancelled_channels.discard(key)
+            _active_processes.pop(key, None)
+            _cancel_events.pop(key, None)
+
+
+# Populate _processing_channels and purge dead entries at module load.
+_load_processing_state()
+_purge_dead_processing_entries()
 
 
 def _get_related_processing_keys(lock_key: str) -> set[str]:
@@ -411,14 +466,16 @@ def _mark_channel_processing(channel: str) -> bool:
     with _processing_lock:
         if channel in _processing_channels:
             process = _active_processes.get(channel)
-            # Only replace if we can confirm the process has exited (stale entry)
-            if process is None or process.poll() is None:
-                registry_entry = _find_process_registry_entry_locked(channel)
-                if registry_entry is None or _is_pid_alive(
-                    registry_entry[1].get("pid")
-                ):
-                    return False  # Truly busy or in-flight; reject
-            # Process confirmed exited: clean up stale entry and re-mark
+            # Positive evidence check: live Popen → truly busy
+            if process is not None and process.poll() is None:
+                return False
+            # No live Popen: check registry for a live PID
+            registry_entry = _find_process_registry_entry_locked(channel)
+            if registry_entry is not None and _is_pid_alive(
+                registry_entry[1].get("pid")
+            ):
+                return False  # Live PID in registry: truly busy
+            # No positive evidence of a live process: treat entry as stale
             _processing_channels.pop(channel, None)
             _cancelled_channels.discard(channel)
             _active_processes.pop(channel, None)

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -440,10 +440,22 @@ class TestAgentService:
 
     def test_same_session_blocked_while_processing(self):
         """A single session sending a second message before first completes must raise ChannelBusyError."""
-        from agent_service import _mark_channel_processing, _clear_channel_processing, ChannelBusyError
+        from unittest.mock import MagicMock
+        from agent_service import (
+            _mark_channel_processing,
+            _clear_channel_processing,
+            _active_processes,
+            _processing_lock,
+            ChannelBusyError,
+        )
 
-        # Given: lock for session X is already held
+        # Given: lock for session X is already held AND a live process is registered
+        # (simulating the in-flight state where the agent process is running)
         assert _mark_channel_processing("ses_X") is True
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # process still running
+        with _processing_lock:
+            _active_processes["ses_X"] = mock_proc
         try:
             # When: same session tries to send another message
             with pytest.raises(ChannelBusyError):


### PR DESCRIPTION
## Issues Fixed

- Closes #690 — False 409 on first message: stale `_processing_channels` entry after successful agent run
- Closes #691 — `_conversation_sessions` lost on backend restart causes permanent orphan lock key
- Closes #692 — Frontend detects busy-agent by string-sniffing instead of HTTP status code
- Closes #693 — No TTL / startup purge for stale entries in `_processing_channels`

## Summary of Changes

### Backend — `packages/pybackend/agent_service.py`

**#690 — Positive-evidence check in `_mark_channel_processing`**

The old code returned `False` (busy) when a stale entry was present but no process data existed — treating absence of evidence as evidence of busyness. The fix inverts the logic: only return `False` when there is **positive** evidence of a live process (live `Popen.poll() is None` OR live PID in registry). Any other state is treated as stale and cleaned up.

**#691 — Persist `_conversation_sessions` across restarts**

`_save_process_registry` / `_load_process_registry` now use a wrapper format `{"registry": {...}, "conversationSessions": {...}}`. Old flat-format files are detected and loaded transparently. Preserves the `channel → session_id` mapping needed for correct cleanup after restart.

**#693 — Startup purge of dead entries**

New `_purge_dead_processing_entries()` called at module load after `_load_processing_state()`. Removes any `_processing_channels` entry with no positive evidence of a live process.

### Frontend — `useApi.ts` + `useChatSession.ts`

**#692 — `HttpError` class with HTTP status code**

Added exported `HttpError extends Error` with `status: number`. `useChatSession` detects busy-agent via `error instanceof HttpError && error.status === 409` instead of substring-matching the error message.

### Tests — `test_unit.py`

Updated `test_same_session_blocked_while_processing` to register a mock live Popen — matching the new positive-evidence contract.

## Validation

```
make qa-quick
Result: 467 passed, 1 skipped — all clean
```

Frontend test count identical to `main` baseline — zero new failures.

## Risks / Follow-ups

- `agent_processing.json` format changes from flat to wrapped; backward-compat branch handles existing files.
- `downloadRepositoryFolderZip` in `useApi.ts:486` still throws plain `Error` — minor follow-up if uniform `HttpError` propagation is desired.
