### PR TITLE
fix(frontend): resolve stale refs, dual sync, and alert severity anti-patterns

### DIFF
--- a/packages/frontend/src/hooks/useChatSession.test.tsx
+++ b/packages/frontend/src/hooks/useChatSession.test.tsx
@@ -233,7 +233,10 @@ describe("useChatSession", () => {
       await result.current.handleSendMessage("hello");
     });
 
-    expect(result.current.agentState).toEqual({ status: "error", message: "Agent unavailable" });
+    expect(result.current.agentState).toEqual({
+      status: "error",
+      message: "Agent unavailable",
+    });
   });
 
   it("resets to idle after cancel failure when agent not running", async () => {

--- a/packages/frontend/src/hooks/useChatSession.ts
+++ b/packages/frontend/src/hooks/useChatSession.ts
@@ -115,7 +115,10 @@ export function useChatSession({
   // Stable setters that return the previous state reference when logically unchanged,
   // preventing spurious re-renders when consumers pass new inline api object literals.
   const setIdle = useCallback(
-    () => setAgentState((prev) => (prev.status === "idle" ? prev : { status: "idle" })),
+    () =>
+      setAgentState((prev) =>
+        prev.status === "idle" ? prev : { status: "idle" },
+      ),
     [],
   );
   const setProcessing = useCallback(
@@ -136,7 +139,12 @@ export function useChatSession({
   );
   const [isRefreshing, setIsRefreshing] = useState(false);
   const isRefreshingRef = useRef(false);
+  const setRefreshing = useCallback((value: boolean) => {
+    isRefreshingRef.current = value;
+    setIsRefreshing(value);
+  }, []);
   const [isCancelingAgent, setIsCancelingAgent] = useState(false);
+  const isCancelingAgentRef = useRef(false);
   const [sessionModalOpen, setSessionModalOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<ChatSession[]>([]);
   const [sessionListError, setSessionListError] = useState<string | null>(null);
@@ -155,13 +163,10 @@ export function useChatSession({
     return Number.isFinite(parsed) ? parsed : undefined;
   }, [chat]);
   const lastKnownTimestampRef = useRef<number | undefined>(lastKnownTimestamp);
-
-  useEffect(() => {
-    lastKnownTimestampRef.current = lastKnownTimestamp;
-  }, [lastKnownTimestamp]);
+  lastKnownTimestampRef.current = lastKnownTimestamp;
 
   const refreshAgentStatus = useCallback(
-    async (targetSessionId = sessionId): Promise<boolean | null> => {
+    async (targetSessionId = sessionIdRef.current): Promise<boolean | null> => {
       if (!name || isExternal) return false;
       if (!targetSessionId) {
         // No session yet — don't kill the spinner; caller will set sessionId soon.
@@ -171,14 +176,15 @@ export function useChatSession({
       try {
         const status = await getStatus(name, targetSessionId);
         if (sessionIdRef.current !== targetSessionId) return false;
-        if (status.running) setProcessing(); else setIdle();
+        if (status.running) setProcessing();
+        else setIdle();
         return status.running;
       } catch (error) {
         console.error("Failed to load agent status", error);
         return null;
       }
     },
-    [getStatus, isExternal, name, sessionId, setIdle, setProcessing],
+    [getStatus, isExternal, name, setIdle, setProcessing],
   );
 
   const getHistory: GetHistoryFn = useCallback(
@@ -268,10 +274,13 @@ export function useChatSession({
 
     const sessionIdAtCall = sessionId;
     isRefreshingRef.current = true;
-    setIsRefreshing(true);
+    setRefreshing(true);
     clearSessionHistoryError();
-    const chatBeforeRefresh = chatRef.current;
-    setChat([]);
+    let chatBeforeRefresh: ChatMessage[] = [];
+    setChat((prev) => {
+      chatBeforeRefresh = prev;
+      return [];
+    });
 
     try {
       const history = await getHistoryApi(name, sessionIdAtCall);
@@ -290,8 +299,7 @@ export function useChatSession({
           : "Failed to load session history";
       setError(message);
     } finally {
-      setIsRefreshing(false);
-      isRefreshingRef.current = false;
+      setRefreshing(false);
     }
   }, [
     clearSessionHistoryError,
@@ -303,6 +311,7 @@ export function useChatSession({
     setChat,
     setError,
     setIdle,
+    setRefreshing,
   ]);
 
   const handleSendMessage = useCallback(
@@ -399,8 +408,9 @@ export function useChatSession({
   );
 
   const handleCancel = useCallback(async () => {
-    if (!name || isExternal || isCancelingAgent) return;
+    if (!name || isExternal || isCancelingAgentRef.current) return;
 
+    isCancelingAgentRef.current = true;
     setIsCancelingAgent(true);
     try {
       await cancelAgent(name, sessionId || undefined);
@@ -409,17 +419,10 @@ export function useChatSession({
       setError("Unable to cancel the agent request.");
     } finally {
       await refreshAgentStatus();
+      isCancelingAgentRef.current = false;
       setIsCancelingAgent(false);
     }
-  }, [
-    cancelAgent,
-    isCancelingAgent,
-    isExternal,
-    name,
-    refreshAgentStatus,
-    sessionId,
-    setError,
-  ]);
+  }, [cancelAgent, isExternal, name, refreshAgentStatus, sessionId, setError]);
 
   const openSessionModal = useCallback(async () => {
     if (!name || isExternal) return;
@@ -486,7 +489,13 @@ export function useChatSession({
     setSelectedAgent(defaultAgentValue);
     onClearSessionOnly?.();
     setClearSessionModalOpen(false);
-  }, [defaultAgentValue, onClearSessionOnly, setIdle, setSelectedAgent, setSessionId]);
+  }, [
+    defaultAgentValue,
+    onClearSessionOnly,
+    setIdle,
+    setSelectedAgent,
+    setSessionId,
+  ]);
 
   const handleClearSessionAndHistory = useCallback(() => {
     sendRequestIdRef.current += 1;

--- a/packages/frontend/src/pages/ConstitutionPage.tsx
+++ b/packages/frontend/src/pages/ConstitutionPage.tsx
@@ -159,7 +159,11 @@ export const ConstitutionPage: React.FC = () => {
   );
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");
-  const [status, setStatus] = useState<string | null>(null);
+  type StatusState = {
+    message: string;
+    type: "success" | "error" | "info";
+  } | null;
+  const [status, setStatus] = useState<StatusState>(null);
   const [mentionCommandPaths, setMentionCommandPaths] = useState<string[]>([]);
   const [externalPath, setExternalPath] = useState<string | null>(null);
   const chatWindowRef = useRef<ChatWindowHandle>(null);
@@ -313,7 +317,10 @@ export const ConstitutionPage: React.FC = () => {
     }
     if (isExternal) {
       if (!linkedExternalMatter) {
-        setStatus("Linked external constitution not found");
+        setStatus({
+          message: "Linked external constitution not found",
+          type: "error",
+        });
         return;
       }
       setExternalPath(linkedExternalMatter.path);
@@ -326,7 +333,10 @@ export const ConstitutionPage: React.FC = () => {
         })
         .catch((error) => {
           console.error("Failed to load external constitution", error);
-          setStatus("Failed to load linked external constitution file");
+          setStatus({
+            message: "Failed to load linked external constitution file",
+            type: "error",
+          });
         });
       return;
     }
@@ -338,7 +348,7 @@ export const ConstitutionPage: React.FC = () => {
       })
       .catch((error) => {
         console.error("Failed to load constitution", error);
-        setStatus("Failed to load constitution");
+        setStatus({ message: "Failed to load constitution", type: "error" });
       });
   }, [isExternal, linkedExternalMatter, name, navigate]);
 
@@ -347,7 +357,10 @@ export const ConstitutionPage: React.FC = () => {
     try {
       if (isExternal) {
         if (!externalPath) {
-          setStatus("Missing external constitution path");
+          setStatus({
+            message: "Missing external constitution path",
+            type: "error",
+          });
           return;
         }
         await api.writeExternalMatter({
@@ -356,14 +369,14 @@ export const ConstitutionPage: React.FC = () => {
           frontmatter,
         });
         saveExternalMatter("constitution", name, content, frontmatter);
-        setStatus("Saved successfully");
+        setStatus({ message: "Saved successfully", type: "success" });
         return;
       }
       await api.saveConstitution(name, { content, frontmatter });
-      setStatus("Saved successfully");
+      setStatus({ message: "Saved successfully", type: "success" });
     } catch (error) {
       console.error("Failed to save constitution", error);
-      setStatus("Save failed");
+      setStatus({ message: "Save failed", type: "error" });
     }
   };
 
@@ -569,9 +582,8 @@ export const ConstitutionPage: React.FC = () => {
               )}
               markdownOptions={chatMarkdownOptions}
             />
-            {(agentStatus || sessionError) && (
-              <div className="alert">{agentStatus ?? sessionError}</div>
-            )}
+            {agentStatus && <div className="alert">{agentStatus}</div>}
+            {sessionError && <div className="alert error">{sessionError}</div>}
             <MentionPathTextarea
               id={chatInputId}
               value={prompt}
@@ -647,21 +659,7 @@ export const ConstitutionPage: React.FC = () => {
       <h1>
         Constitution: {isExternal ? (linkedExternalMatter?.name ?? name) : name}
       </h1>
-      {status && (
-        <div
-          className={`alert ${
-            status.includes("successfully")
-              ? "success"
-              : status.includes("failed") ||
-                  status.includes("Failed") ||
-                  status.includes("unavailable")
-                ? "error"
-                : ""
-          }`}
-        >
-          {status}
-        </div>
-      )}
+      {status && <div className={`alert ${status.type}`}>{status.message}</div>}
       <TabView tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
       <ClearSessionModal
         open={clearSessionModalOpen}

--- a/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
+++ b/packages/frontend/src/pages/KnowledgeArtefactPage.tsx
@@ -155,7 +155,11 @@ export const KnowledgeArtefactPage: React.FC = () => {
   );
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");
-  const [status, setStatus] = useState<string | null>(null);
+  type StatusState = {
+    message: string;
+    type: "success" | "error" | "info";
+  } | null;
+  const [status, setStatus] = useState<StatusState>(null);
   const [mentionCommandPaths, setMentionCommandPaths] = useState<string[]>([]);
   const [externalPath, setExternalPath] = useState<string | null>(null);
   const chatWindowRef = useRef<ChatWindowHandle>(null);
@@ -309,7 +313,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
     }
     if (isExternal) {
       if (!linkedExternalMatter) {
-        setStatus("Linked external artefact not found");
+        setStatus({
+          message: "Linked external artefact not found",
+          type: "error",
+        });
         return;
       }
       setExternalPath(linkedExternalMatter.path);
@@ -322,7 +329,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
         })
         .catch((error) => {
           console.error("Failed to load external artefact", error);
-          setStatus("Failed to load linked external artefact file");
+          setStatus({
+            message: "Failed to load linked external artefact file",
+            type: "error",
+          });
         });
       return;
     }
@@ -334,7 +344,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       })
       .catch((error) => {
         console.error("Failed to load artefact", error);
-        setStatus("Failed to load artefact");
+        setStatus({ message: "Failed to load artefact", type: "error" });
       });
   }, [isExternal, linkedExternalMatter, name, navigate]);
 
@@ -343,7 +353,10 @@ export const KnowledgeArtefactPage: React.FC = () => {
     try {
       if (isExternal) {
         if (!externalPath) {
-          setStatus("Missing external artefact path");
+          setStatus({
+            message: "Missing external artefact path",
+            type: "error",
+          });
           return;
         }
         await api.writeExternalMatter({
@@ -352,14 +365,14 @@ export const KnowledgeArtefactPage: React.FC = () => {
           frontmatter,
         });
         saveExternalMatter("knowledge", name, content, frontmatter);
-        setStatus("Saved successfully");
+        setStatus({ message: "Saved successfully", type: "success" });
         return;
       }
       await api.saveKnowledge(name, { content, frontmatter });
-      setStatus("Saved successfully");
+      setStatus({ message: "Saved successfully", type: "success" });
     } catch (error) {
       console.error("Failed to save artefact", error);
-      setStatus("Save failed");
+      setStatus({ message: "Save failed", type: "error" });
     }
   };
 
@@ -582,9 +595,8 @@ export const KnowledgeArtefactPage: React.FC = () => {
             )}
             markdownOptions={chatMarkdownOptions}
           />
-          {(agentStatus || sessionError) && (
-            <div className="alert">{agentStatus ?? sessionError}</div>
-          )}
+          {agentStatus && <div className="alert">{agentStatus}</div>}
+          {sessionError && <div className="alert error">{sessionError}</div>}
           <MentionPathTextarea
             id={chatInputId}
             value={prompt}
@@ -662,19 +674,7 @@ export const KnowledgeArtefactPage: React.FC = () => {
       <h1>
         Artefact: {isExternal ? (linkedExternalMatter?.name ?? name) : name}
       </h1>
-      {status && (
-        <div
-          className={`alert ${
-            status.includes("successfully")
-              ? "success"
-              : status.includes("failed") || status.includes("Failed")
-                ? "error"
-                : ""
-          }`}
-        >
-          {status}
-        </div>
-      )}
+      {status && <div className={`alert ${status.type}`}>{status.message}</div>}
       <TabView
         tabs={visibleTabs}
         activeTab={activeTab}

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -781,7 +781,11 @@ export const RepositoryPage: React.FC = () => {
     [name, selectedFile],
   );
   const [editorContent, setEditorContent] = useState("");
-  const [editorStatus, setEditorStatus] = useState<string | null>(null);
+  type EditorStatusState = {
+    message: string;
+    type: "success" | "error" | "info";
+  } | null;
+  const [editorStatus, setEditorStatus] = useState<EditorStatusState>(null);
   const [fileGitDetails, setFileGitDetails] =
     useState<RepositoryFileGitDetails | null>(null);
   const [fileGitDetailsLoading, setFileGitDetailsLoading] = useState(false);
@@ -1029,7 +1033,7 @@ export const RepositoryPage: React.FC = () => {
           return { pid: entry.pid, running: response.running };
         } catch (error) {
           console.error("Failed to fetch harness status", error);
-          return { pid: entry.pid, running: false };
+          return { pid: entry.pid, running: undefined };
         }
       }),
     );
@@ -1177,7 +1181,7 @@ export const RepositoryPage: React.FC = () => {
       setActiveTab("editor");
     } catch (error) {
       console.error("Failed to open file", error);
-      setEditorStatus("Unable to open file");
+      setEditorStatus({ message: "Unable to open file", type: "error" });
     } finally {
       setLoadingFile(false);
     }
@@ -1401,14 +1405,14 @@ export const RepositoryPage: React.FC = () => {
     if (!name || !selectedFile) return;
     try {
       await api.saveRepositoryFile(name, selectedFile, editorContent);
-      setEditorStatus("Saved successfully");
+      setEditorStatus({ message: "Saved successfully", type: "success" });
       refreshFiles();
       if (repository?.hasGit) {
         void loadGitStatus();
         void loadFileGitDetails(selectedFile);
       }
     } catch (error) {
-      setEditorStatus("Failed to save file");
+      setEditorStatus({ message: "Failed to save file", type: "error" });
       console.error("Failed to save file", error);
     }
   };
@@ -1845,9 +1849,8 @@ export const RepositoryPage: React.FC = () => {
             )}
             markdownOptions={chatMarkdownOptions}
           />
-          {(agentStatus || sessionError) && (
-            <div className="alert">{agentStatus ?? sessionError}</div>
-          )}
+          {agentStatus && <div className="alert">{agentStatus}</div>}
+          {sessionError && <div className="alert error">{sessionError}</div>}
           <MentionPathTextarea
             id={chatInputId}
             value={pendingPrompt}
@@ -2385,17 +2388,8 @@ export const RepositoryPage: React.FC = () => {
             >
               {loadingFile && <div className="alert">Loading file...</div>}
               {editorStatus && (
-                <div
-                  className={`alert ${
-                    editorStatus.includes("successfully")
-                      ? "success"
-                      : editorStatus.includes("Failed") ||
-                          editorStatus.includes("failed")
-                        ? "error"
-                        : ""
-                  }`}
-                >
-                  {editorStatus}
+                <div className={`alert ${editorStatus.type}`}>
+                  {editorStatus.message}
                 </div>
               )}
               <textarea

--- a/packages/frontend/src/pages/TaskPage.tsx
+++ b/packages/frontend/src/pages/TaskPage.tsx
@@ -144,7 +144,11 @@ export const TaskPage: React.FC = () => {
   );
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
   const [prompt, setPrompt] = useState("");
-  const [status, setStatus] = useState<string | null>(null);
+  type StatusState = {
+    message: string;
+    type: "success" | "error" | "info";
+  } | null;
+  const [status, setStatus] = useState<StatusState>(null);
   const [mentionCommandPaths, setMentionCommandPaths] = useState<string[]>([]);
   const chatWindowRef = useRef<ChatWindowHandle>(null);
   const chatInputId = "task-agent-prompt";
@@ -288,7 +292,7 @@ export const TaskPage: React.FC = () => {
       })
       .catch((error) => {
         console.error("Failed to load task", error);
-        setStatus("Failed to load task");
+        setStatus({ message: "Failed to load task", type: "error" });
       });
   }, [name, navigate]);
 
@@ -296,10 +300,10 @@ export const TaskPage: React.FC = () => {
     if (!name) return;
     try {
       await api.saveTask(name, { content, frontmatter });
-      setStatus("Saved successfully");
+      setStatus({ message: "Saved successfully", type: "success" });
     } catch (error) {
       console.error("Failed to save task", error);
-      setStatus("Save failed");
+      setStatus({ message: "Save failed", type: "error" });
     }
   };
 
@@ -360,21 +364,7 @@ export const TaskPage: React.FC = () => {
   return (
     <div className="page">
       <h1>Task: {name}</h1>
-      {status && (
-        <div
-          className={`alert ${
-            status.includes("successfully")
-              ? "success"
-              : status.includes("failed") ||
-                  status.includes("Failed") ||
-                  status.includes("unavailable")
-                ? "error"
-                : ""
-          }`}
-        >
-          {status}
-        </div>
-      )}
+      {status && <div className={`alert ${status.type}`}>{status.message}</div>}
       <TabView
         tabs={[
           {
@@ -528,8 +518,9 @@ export const TaskPage: React.FC = () => {
                   )}
                   markdownOptions={chatMarkdownOptions}
                 />
-                {(agentStatus || sessionError) && (
-                  <div className="alert">{agentStatus ?? sessionError}</div>
+                {agentStatus && <div className="alert">{agentStatus}</div>}
+                {sessionError && (
+                  <div className="alert error">{sessionError}</div>
                 )}
                 <MentionPathTextarea
                   id={chatInputId}


### PR DESCRIPTION
## Issues fixed
- Closes #703 — stale ref values in useChatSession cause polling restarts, stale rollback, and redundant fetches
- Closes #702 — isRefreshingRef+isRefreshing manually synced; isCancelingAgent guard has double-click race
- Closes #704 — alert severity derived from string-matching; harness network error misreported as Finished; sessionError silently suppressed

## Summary of changes

### useChatSession.ts (#703, #702)
- `refreshAgentStatus` now reads `sessionIdRef.current` instead of closed-over `sessionId`; removed `sessionId` from `useCallback` dep array — stops polling being torn down and restarted on every successful send
- `chatBeforeRefresh` snapshot taken atomically inside a `setChat` functional updater, preventing concurrent `syncChatHistory` messages from being silently dropped on rollback
- `lastKnownTimestampRef` assigned at render time (not in `useEffect`), consistent with `chatRef`/`sessionIdRef`
- Introduced `setRefreshing(value)` helper to atomically sync `isRefreshingRef` and `isRefreshing` state — eliminates risk of manual paired assignments diverging
- Added `isCancelingAgentRef` backing the `handleCancel` guard (synchronous read, immune to React state batching); prevents double-click race

### KnowledgeArtefactPage, ConstitutionPage, TaskPage, RepositoryPage (#704)
- Replaced `status.includes('successfully')` / `status.includes('Failed')` CSS ternary with typed `StatusState { message: string; type: 'success' | 'error' | 'info' }`; all call sites set explicit `type`
- `getHarnessStatus` catch branch now returns `{ pid, running: undefined }` instead of `false` — shows pending UI instead of misleading 'Finished' on network error
- `agentStatus ?? sessionError` replaced with two independent alert divs — `sessionError` is never dropped when both are set

## Validation
```
make qa-quick          # 468 passed, 1 skipped — ESLint clean, ruff clean
npx playwright test    # 3/3 E2E passed (running services on :3000 and :5173 reused)
```

## Follow-up (noted, not fixed)
- `chatRef` in `useChatSession.ts` is now dead code after #703-2 (no longer read anywhere); safe to remove in a separate cleanup PR