### PR TITLE
fix(backend): remove fabricated session IDs from kiro/copilot/codex CLIs

### DIFF
--- a/packages/pybackend/codex_agent_cli.py
+++ b/packages/pybackend/codex_agent_cli.py
@@ -226,7 +226,11 @@ class CodexAgentCLI(AgentCLI):
                             )
 
             if process.returncode == 0:
-                # Process management only - extract session_id but no parsing
+                # Extract session ID from JSON stdout (codex emits thread.started events).
+                # If no session ID is found in stdout, return the input session_id as-is
+                # (may be None) — fabrication is intentionally avoided so callers get an
+                # explicit None rather than a fabricated ID that would silently break
+                # history lookup.
                 extracted_session_id = session_id  # Default to input session_id
                 if stdout:
                     for line in stdout.strip().split("\n"):
@@ -238,10 +242,6 @@ class CodexAgentCLI(AgentCLI):
                                     break
                             except json.JSONDecodeError:
                                 continue
-
-                # Generate session_id if none provided and none extracted
-                if not extracted_session_id:
-                    extracted_session_id = f"codex-{int(datetime.now().timestamp())}"
 
                 return RunResult(
                     success=True,

--- a/packages/pybackend/copilot_agent_cli.py
+++ b/packages/pybackend/copilot_agent_cli.py
@@ -213,14 +213,13 @@ class CopilotAgentCLI(AgentCLI):
                             )
 
             if process.returncode == 0:
-                # Process management only - generate session_id if needed
-                final_session_id = (
-                    session_id or f"copilot-{int(datetime.now().timestamp())}"
-                )
-
+                # copilot CLI does not emit a machine-readable session ID in stdout.
+                # Return the input session_id as-is (may be None); fabrication is
+                # intentionally avoided so callers get an explicit None rather than
+                # a fabricated ID that would silently break history lookup.
                 return RunResult(
                     success=True,
-                    session_id=final_session_id,
+                    session_id=session_id,
                     response_parts=[],  # No response parsing - export API handles content
                 )
             else:

--- a/packages/pybackend/kiro_agent_cli.py
+++ b/packages/pybackend/kiro_agent_cli.py
@@ -5,7 +5,6 @@ import os
 import re
 import sqlite3
 import subprocess
-from datetime import datetime
 from pathlib import Path
 from threading import Event
 from typing import Any, Callable
@@ -180,14 +179,13 @@ class KiroAgentCLI(AgentCLI):
                             )
 
             if process.returncode == 0:
-                # Process management only - generate session_id if needed
-                final_session_id = (
-                    session_id or f"kiro-{int(datetime.now().timestamp())}"
-                )
-
+                # kiro-cli does not emit a machine-readable session ID in stdout.
+                # Return the input session_id as-is (may be None); fabrication is
+                # intentionally avoided so callers get an explicit None rather than
+                # a fabricated ID that would silently break history lookup.
                 return RunResult(
                     success=True,
-                    session_id=final_session_id,
+                    session_id=session_id,
                     response_parts=[],  # No response parsing - export API handles content
                 )
             else:

--- a/packages/pybackend/tests/unit/test_codex_agent_cli.py
+++ b/packages/pybackend/tests/unit/test_codex_agent_cli.py
@@ -84,7 +84,8 @@ invalid json line here
         assert (
             len(result.response_parts) == 0
         )  # No response parsing - export API handles content
-        assert result.session_id is not None  # Process management extracts session_id
+        # No sessionId in stdout and no input session_id → pass-through returns None
+        assert result.session_id is None
 
         # Verify subprocess was called correctly
         mock_run.assert_called_once()

--- a/packages/pybackend/tests/unit/test_copilot_agent_cli.py
+++ b/packages/pybackend/tests/unit/test_copilot_agent_cli.py
@@ -84,7 +84,8 @@ class TestCopilotAgentCLI:
         assert (
             len(result.response_parts) == 0
         )  # No response parsing - export API handles content
-        assert result.session_id is not None  # Process management generates session_id
+        # copilot CLI emits no machine-readable session ID; pass-through returns None
+        assert result.session_id is None
 
     @unittest.mock.patch("subprocess.run")
     def test_run_agent_strips_ansi_codes(self, mock_run):
@@ -104,7 +105,8 @@ class TestCopilotAgentCLI:
         assert (
             len(result.response_parts) == 0
         )  # No response parsing - export API handles content
-        assert result.session_id is not None  # Process management generates session_id
+        # copilot CLI emits no machine-readable session ID; pass-through returns None
+        assert result.session_id is None
 
         # Verify subprocess was called correctly
         mock_run.assert_called_once()

--- a/packages/pybackend/tests/unit/test_kiro_agent_cli.py
+++ b/packages/pybackend/tests/unit/test_kiro_agent_cli.py
@@ -85,7 +85,8 @@ class TestKiroAgentCLI:
         assert (
             len(result.response_parts) == 0
         )  # No response parsing - export API handles content
-        assert result.session_id is not None  # Process management generates session_id
+        # kiro-cli emits no machine-readable session ID; pass-through returns None
+        assert result.session_id is None
 
     @unittest.mock.patch("subprocess.run")
     def test_run_agent_strips_ansi_codes(self, mock_run):
@@ -105,7 +106,8 @@ class TestKiroAgentCLI:
         assert (
             len(result.response_parts) == 0
         )  # No response parsing - export API handles content
-        assert result.session_id is not None  # Process management generates session_id
+        # kiro-cli emits no machine-readable session ID; pass-through returns None
+        assert result.session_id is None
 
         # Verify subprocess was called correctly
         mock_run.assert_called_once()


### PR DESCRIPTION
## Issues Fixed
- Fixes #679

## Summary

`KiroAgentCLI` and `CopilotAgentCLI` do not emit a machine-readable session ID in stdout. Their success path now returns the input `session_id` as-is (pass-through, may be `None`) instead of fabricating a timestamp-based ID (e.g. `kiro-1719000000`).

`CodexAgentCLI` already extracted `thread_id` from JSON stdout. The fabrication fallback that ran when extraction yielded nothing is removed and replaced with the same pass-through pattern.

## Root Cause

Fabricated IDs caused two silent failures on every first message:
1. **History always empty** — fabricated ID stored by MADE, lookup in agent's real storage returns nothing, backend silently returns `{ messages: [] }`
2. **Multi-turn resume broken** — `_session_matches_directory` always returned `False` for fabricated IDs, so every send started a fresh session

## Changes

| File | Change |
|------|--------|
| `kiro_agent_cli.py` | Pass-through `session_id`; removed unused `datetime` import |
| `copilot_agent_cli.py` | Pass-through `session_id` |
| `codex_agent_cli.py` | Remove fabrication fallback; pass-through `session_id` |
| `tests/unit/test_kiro_agent_cli.py` | Assert `session_id is None` when no input provided |
| `tests/unit/test_copilot_agent_cli.py` | Same |
| `tests/unit/test_codex_agent_cli.py` | Same |

## Validation

```
make qa-quick-backend
469 passed, 1 skipped — all green
```

## Notes

- `_session_matches_directory` logic is unchanged in all three CLIs
- If kiro or copilot ever adds machine-readable session ID output, extraction logic (similar to codex `thread_id`) should be added at that point
- A follow-up opportunity exists to audit whether codex's two extraction paths (`sessionId` key vs `thread_id` from `thread.started` events) are consistent with actual CLI output