### PR TITLE
fix: add quality warnings and robust OpenCode help test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: make install
       
-      - name: Run QA (lint + format + unit tests)
+      - name: Run QA (lint + format + unit tests with warnings)
         run: make qa-quick
 
       - name: Run security audit

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,18 @@ lint:
 	npm run lint
 	@echo "🔍 Running backend ruff linter..."
 	cd $(PYBACKEND_DIR) && uv run ruff check *.py
+	@echo "🔍 Checking backend function complexity (warning only)..."
+	@cd $(PYBACKEND_DIR) && \
+	if uv run ruff check --select C901 *.py; then \
+		true; \
+	else \
+		status=$$?; \
+		if [ $$status -eq 1 ]; then \
+			echo "WARNING: backend function complexity exceeds the configured threshold"; \
+		else \
+			exit $$status; \
+		fi; \
+	fi
 
 test:
 	@echo "🧪 Running frontend tests..."
@@ -85,9 +97,23 @@ test:
 
 unit-test:
 	@echo "🔬 Running frontend unit tests..."
-	npm test
+	@start=$$(date +%s); \
+	npm test; status=$$?; \
+	elapsed=$$(($$(date +%s) - start)); \
+	echo "Frontend unit tests completed in $${elapsed}s"; \
+	if [ $$elapsed -gt 60 ]; then \
+		echo "WARNING: frontend unit tests exceeded the 60s limit"; \
+	fi; \
+	exit $$status
 	@echo "🔬 Running backend unit tests with coverage..."
-	cd $(PYBACKEND_DIR) && uv sync && uv run pytest -c pytest.cov.ini tests/unit/
+	@start=$$(date +%s); \
+	cd $(PYBACKEND_DIR) && uv sync && uv run pytest -c pytest.cov.ini tests/unit/; status=$$?; \
+	elapsed=$$(($$(date +%s) - start)); \
+	echo "Backend unit tests completed in $${elapsed}s"; \
+	if [ $$elapsed -gt 30 ]; then \
+		echo "WARNING: backend unit tests exceeded the 30s limit"; \
+	fi; \
+	exit $$status
 
 test-frontend:
 	@test -n "$(FILE)" || (echo "Usage: make test-frontend FILE=path [NAME=pattern]" && exit 1)

--- a/packages/frontend/eslint.config.js
+++ b/packages/frontend/eslint.config.js
@@ -26,6 +26,7 @@ export default tseslint.config(
     },
     rules: {
       "react/prop-types": "off",
+      complexity: ["warn", 10],
     },
   },
 );

--- a/packages/pybackend/pyproject.toml
+++ b/packages/pybackend/pyproject.toml
@@ -50,3 +50,6 @@ exclude = [
 
 [tool.uv]
 package = true
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/packages/pybackend/tests/integration/test_opencode_integration.py
+++ b/packages/pybackend/tests/integration/test_opencode_integration.py
@@ -20,9 +20,8 @@ class TestOpenCodeIntegration:
                 ["opencode", "--help"], capture_output=True, text=True, timeout=10
             )
             assert result.returncode == 0
-            assert (
-                "opencode" in result.stdout.lower() or "usage" in result.stdout.lower()
-            )
+            help_output = f"{result.stdout}\n{result.stderr}".lower()
+            assert "opencode" in help_output or "usage" in help_output
         except FileNotFoundError:
             pytest.skip("opencode not available in PATH")
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Issues fixed
- Closes #713: accept OpenCode help output from stdout or stderr.
- Closes #664: add warning-only cyclomatic complexity checks for Ruff and ESLint.
- Closes #661: report frontend/backend unit-test runtime warnings without duplicating test runs.

## Summary
- Combine OpenCode integration-test output streams before validating successful help output.
- Configure Ruff McCabe and ESLint complexity warnings at threshold 10.
- Add 60-second frontend and 30-second backend unit-test timing warnings while preserving failure exit codes.
- Keep the existing QA workflow and test execution path intact.

## Validation
- `make qa-quick` passed: 468 backend tests passed, 1 skipped; frontend tests passed.
- `npm run build --workspace packages/frontend` passed, including TypeScript compilation.
- Focused #713 integration test passed.
- `npm run test:e2e` passed: 4/4 real Chromium tests against existing services on ports 3000/5173.
- `make test` ran 525 tests and exposed one unrelated external OpenCode response failure; tracked separately as #715.

## Risks and follow-ups
- Existing complexity findings remain warnings-only.
- #715 tracks OpenCode runs that return success with an empty response.
- Port check found 3000 and 5173 occupied by existing MADE services; they were reused, not stopped.