### PR TITLE
fix: register integration pytest marker; ci: warn on oversized source/test files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,59 @@ jobs:
       - name: Run QA (lint + format + unit tests with warnings)
         run: make qa-quick
 
+      - name: Check source file sizes
+        run: |
+          find packages/frontend/src packages/pybackend \
+            \( -name "*.ts" -o -name "*.tsx" -o -name "*.py" \) \
+            ! -path "*/node_modules/*" ! -path "*/.venv/*" \
+            ! -name "*.test.*" ! -name "test_*" \
+          | while read f; do
+              lines=$(wc -l < "$f")
+              if [ "$lines" -gt 500 ]; then
+                echo "::warning file=${f}::${f} has ${lines} lines (guideline: 500)"
+              fi
+            done
+
+      - name: Check test file sizes and test:source ratio
+        run: |
+          # --- Absolute size: both frontend and backend ---
+          find packages/frontend/src packages/pybackend/tests \
+            \( -name "*.test.tsx" -o -name "*.test.ts" -o -name "test_*.py" \) \
+            ! -path "*/node_modules/*" ! -path "*/.venv/*" \
+          | while read tf; do
+              lines=$(wc -l < "$tf")
+              if [ "$lines" -gt 500 ]; then
+                echo "::warning file=${tf}::${tf} has ${lines} lines (guideline: 500)"
+              fi
+            done
+
+          # --- Test:source ratio: TypeScript ---
+          find packages/frontend/src -name "*.test.tsx" -o -name "*.test.ts" \
+          | while read tf; do
+              src="${tf%.test.*}.tsx"
+              [ -f "$src" ] || src="${tf%.test.*}.ts"
+              if [ -f "$src" ]; then
+                tlines=$(wc -l < "$tf"); slines=$(wc -l < "$src")
+                ratio=$(( tlines / (slines + 1) ))
+                if [ "$ratio" -gt 2 ]; then
+                  echo "::warning file=${tf}::Test:source ratio ${ratio}:1 exceeds 2:1 (${tlines} test vs ${slines} source lines)"
+                fi
+              fi
+            done
+
+          # --- Test:source ratio: Python ---
+          find packages/pybackend/tests/unit -name "test_*.py" | while read tf; do
+              module=$(basename "$tf" | sed 's/^test_//')
+              src=$(find packages/pybackend -maxdepth 1 -name "$module" ! -path "*/tests/*")
+              if [ -f "$src" ]; then
+                tlines=$(wc -l < "$tf"); slines=$(wc -l < "$src")
+                ratio=$(( tlines / (slines + 1) ))
+                if [ "$ratio" -gt 2 ]; then
+                  echo "::warning file=${tf}::Test:source ratio ${ratio}:1 exceeds 2:1 (${tlines} test vs ${slines} source lines)"
+                fi
+              fi
+            done
+
       - name: Run security audit
         run: make security-audit
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,25 @@ lint:
 			exit $$status; \
 		fi; \
 	fi
+	@echo "🔍 Checking source file sizes (warning only)..."
+	@find packages/frontend/src packages/pybackend \
+	  \( -name "*.ts" -o -name "*.tsx" -o -name "*.py" \) \
+	  ! -path "*/node_modules/*" ! -path "*/.venv/*" ! -path "*/__pycache__/*" \
+	  ! -name "*.test.*" ! -name "test_*" \
+	  | xargs wc -l 2>/dev/null \
+	  | awk '$$1 > 500 && $$2 != "total" \
+	    {print "WARNING: " $$2 " has " $$1 " lines (guideline: 500)"}' \
+	  | grep . && echo "Consider decomposing the above files." || true
+	@echo "🔍 Checking test file sizes (warning only)..."
+	@find packages/frontend/src packages/pybackend/tests \
+	  \( -name "*.test.ts" -o -name "*.test.tsx" -o -name "test_*.py" \) \
+	  ! -path "*/node_modules/*" ! -path "*/.venv/*" \
+	  | while read f; do \
+	    lines=$$(wc -l < "$$f"); \
+	    if [ "$$lines" -gt 500 ]; then \
+	      echo "WARNING: $$f has $$lines lines (guideline: 500)"; \
+	    fi; \
+	  done || true
 
 test:
 	@echo "🧪 Running frontend tests..."

--- a/packages/pybackend/pytest.ini
+++ b/packages/pybackend/pytest.ini
@@ -8,4 +8,5 @@ pythonpath = .
 markers =
     unit: Unit tests
     system: System integration tests
+    integration: Integration tests
     slow: Slow running tests


### PR DESCRIPTION
## Issues fixed
- Fixes #717 – register integration pytest marker
- Fixes #663 – ci: warn on source file LOC exceeding 500 lines (lint + CI)
- Fixes #662 – ci: warn on test file LOC and test:source ratio exceeding limits

## Summary of changes
- `packages/pybackend/pytest.ini`: added `integration: Integration tests` to the `markers` list, eliminating `PytestUnknownMarkWarning` under `--strict-markers`.
- `Makefile` (`lint` target): added two non-blocking warning checks — source files (`*.ts`, `*.tsx`, `*.py`, excluding tests) over 500 lines, and test files (`*.test.ts(x)`, `test_*.py`) over 500 lines. Both always exit 0 (warnings only).
- `.github/workflows/tests.yml` (`quality-assurance` job): added matching CI steps using `::warning::` annotations, plus test:source ratio checks (>2:1) for both TypeScript and Python file pairs.

All checks are additive and non-blocking (phase 1 of the ratchet pattern described in the issues) — no existing behavior changes, no files were refactored.

## Validation run
- `cd packages/pybackend && uv run pytest tests/integration/test_opencode_integration.py::TestOpenCodeIntegration::test_run_agent_integration -vv` → 1 passed, no warnings
- `uv run pytest --markers | grep integration` → marker registered
- `make lint` → exit 0; warnings correctly emitted for known oversized files (e.g. `RepositoryPage.tsx` 2902 lines, `app.py` 1916 lines, `test_api.py` 1682 lines, etc.)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"` → YAML parses OK
- `make qa-quick` → 468 passed, 1 skipped, lint/format clean (ran twice: once by coordinator, once by pre-push hook)

## E2E coverage
No dedicated E2E/browser test added — these are dev-tooling/CI-only changes with no user-facing runtime behavior. `make qa-quick` (real lint + real pytest suite, no mocks) serves as the closest equivalent to an E2E check for this type of change.

## Risks / follow-ups
- Low risk: all new checks are non-blocking (exit 0) and purely additive.
- Ratchet enforcement (blocking growth of already-oversized files) is explicitly out of scope for this PR — noted as "Phase 2" in the original issues (#663, #662).
- No unrelated bugs discovered by subagents during implementation.