### PR TITLE
Preserve for/while/parallel/params in workflow normalization; add schema endpoint (#727 slice); triage #725

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -72,6 +72,7 @@ from workflow_harness_service import (
     WorkflowParseError,
     WorkflowVerificationError,
 )
+from flowsh_cli.models import workflow_schema_yaml
 from cron_service import (
     force_terminate_job,
     get_cron_clock_status,
@@ -920,6 +921,18 @@ def global_workflows():
         return read_workflows()
     except Exception as exc:
         logger.exception("Failed to list global workflows")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.get("/api/workflows/schema")
+def workflows_schema():
+    try:
+        logger.info("Returning workflows schema")
+        return Response(content=workflow_schema_yaml(), media_type="text/yaml")
+    except Exception as exc:
+        logger.exception("Failed to build workflows schema")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         )

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -1454,6 +1454,14 @@ class TestWorkflowEndpoints:
         assert response.status_code == 200
         assert response.json() == {"workflows": []}
 
+    def test_workflows_schema_returns_flowsh_schema(self):
+        response = client.get("/api/workflows/schema")
+
+        assert response.status_code == 200
+        assert "yaml" in response.headers["content-type"]
+        assert "steps" in response.text
+        assert "WorkflowFile" in response.text or "$defs" in response.text
+
     @patch("app.refresh_cron_clock")
     @patch("app.write_workflows")
     def test_save_global_workflows_success(self, mock_write, mock_refresh):

--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -278,3 +278,106 @@ def test_write_workflows_empty_payload_writes_empty_list(tmp_path):
         write_workflows(payload)
     content = yaml.safe_load((tmp_path / "workflows.yml").read_text())
     assert content["workflows"] == []
+
+
+# ---------------------------------------------------------------------------
+# round-trip — full flowsh-cli schema surface (#727)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_payload_round_trips_full_flowsh_schema(tmp_path):
+    """Regression test for #727: normalization must not silently drop step
+    types (for/while/parallel) or fields (when/params/model/capture/
+    expandPrompt/expandFields/dangerouslySkipPermissions/description) that
+    flowsh-cli's schema supports."""
+    payload = {
+        "workflows": [
+            {
+                "id": "wf_full",
+                "name": "Full schema workflow",
+                "description": "Exercises every supported field",
+                "params": [
+                    {"name": "TARGET_ENV", "description": "Target environment", "required": True}
+                ],
+                "enabled": True,
+                "schedule": "0 6 * * *",
+                "steps": [
+                    {
+                        "type": "agent",
+                        "name": "run-agent",
+                        "when": "$SHOULD_RUN == 1",
+                        "prompt": "Do the thing",
+                        "agent": "opencode",
+                        "model": "claude-sonnet-5",
+                        "command": "run",
+                        "capture": "AGENT_RESULT",
+                        "expandPrompt": True,
+                        "expandFields": True,
+                        "dangerouslySkipPermissions": True,
+                    },
+                    {
+                        "type": "for",
+                        "name": "loop-items",
+                        "when": "$ITEMS != ''",
+                        "in": "ITEMS",
+                        "item": "ITEM",
+                        "steps": [{"type": "bash", "run": "echo $ITEM"}],
+                    },
+                    {
+                        "type": "while",
+                        "name": "loop-while",
+                        "condition": "$COUNT -lt 5",
+                        "steps": [{"type": "bash", "run": "echo tick"}],
+                    },
+                    {
+                        "type": "parallel",
+                        "name": "run-parallel",
+                        "steps": [
+                            {"type": "bash", "run": "echo a"},
+                            {"type": "bash", "run": "echo b"},
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    with patch("workflow_service._workflow_path", return_value=tmp_path / "workflows.yml"):
+        write_workflows(payload)
+        result = read_workflows()
+
+    workflow = result["workflows"][0]
+    assert workflow["description"] == "Exercises every supported field"
+    assert workflow["params"] == [
+        {"name": "TARGET_ENV", "description": "Target environment", "required": True}
+    ]
+
+    agent_step, for_step, while_step, parallel_step = workflow["steps"]
+
+    assert agent_step["type"] == "agent"
+    assert agent_step["name"] == "run-agent"
+    assert agent_step["when"] == "$SHOULD_RUN == 1"
+    assert agent_step["model"] == "claude-sonnet-5"
+    assert agent_step["capture"] == "AGENT_RESULT"
+    assert agent_step["expandPrompt"] is True
+    assert agent_step["expandFields"] is True
+    assert agent_step["dangerouslySkipPermissions"] is True
+
+    assert for_step["type"] == "for"
+    assert for_step["name"] == "loop-items"
+    assert for_step["when"] == "$ITEMS != ''"
+    assert for_step["in"] == "ITEMS"
+    assert for_step["item"] == "ITEM"
+    assert for_step["steps"] == [{"type": "bash", "run": "echo $ITEM"}]
+
+    assert while_step["type"] == "while"
+    assert while_step["name"] == "loop-while"
+    assert while_step["condition"] == "$COUNT -lt 5"
+    assert while_step["steps"] == [{"type": "bash", "run": "echo tick"}]
+
+    assert parallel_step["type"] == "parallel"
+    assert parallel_step["name"] == "run-parallel"
+    assert parallel_step["steps"] == [
+        {"type": "bash", "run": "echo a"},
+        {"type": "bash", "run": "echo b"},
+    ]

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -36,7 +36,9 @@ def _as_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
-def _normalize_common_step_fields(step: dict[str, Any], normalized: dict[str, Any]) -> None:
+def _normalize_common_step_fields(
+    step: dict[str, Any], normalized: dict[str, Any]
+) -> None:
     name = _as_string(step.get("name"))
     when = _as_string(step.get("when"))
     if name:

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -36,24 +36,59 @@ def _as_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def _normalize_common_step_fields(step: dict[str, Any], normalized: dict[str, Any]) -> None:
+    name = _as_string(step.get("name"))
+    when = _as_string(step.get("when"))
+    if name:
+        normalized["name"] = name
+    if when:
+        normalized["when"] = when
+
+
+def _normalize_nested_steps(step: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_steps = step.get("steps")
+    nested: list[dict[str, Any]] = []
+    if isinstance(raw_steps, list):
+        for raw_step in raw_steps:
+            normalized_step = _normalize_step(raw_step)
+            if normalized_step:
+                nested.append(normalized_step)
+    return nested
+
+
 def _normalize_step(step: Any) -> dict[str, Any]:
     if not isinstance(step, dict):
         return {}
     step_type = _as_string(step.get("type"))
     if step_type == "bash":
         run = _as_string(step.get("run"))
-        return {"type": "bash", "run": run or ""}
+        normalized: dict[str, Any] = {"type": "bash", "run": run or ""}
+        _normalize_common_step_fields(step, normalized)
+        return normalized
     if step_type == "agent":
-        normalized: dict[str, str] = {"type": "agent"}
+        normalized = {"type": "agent"}
         agent = _as_string(step.get("agent"))
         command = _as_string(step.get("command"))
         prompt = _as_string(step.get("prompt"))
+        model = _as_string(step.get("model"))
+        capture = _as_string(step.get("capture"))
         if agent:
             normalized["agent"] = agent
         if command:
             normalized["command"] = command
         if prompt:
             normalized["prompt"] = prompt
+        if model:
+            normalized["model"] = model
+        if capture:
+            normalized["capture"] = capture
+        if _as_bool(step.get("expandPrompt")):
+            normalized["expandPrompt"] = True
+        if _as_bool(step.get("expandFields")):
+            normalized["expandFields"] = True
+        if _as_bool(step.get("dangerouslySkipPermissions")):
+            normalized["dangerouslySkipPermissions"] = True
+        _normalize_common_step_fields(step, normalized)
         return normalized
     if step_type == "vars":
         var_name = _as_string(step.get("varName"))
@@ -68,11 +103,56 @@ def _normalize_step(step: Any) -> dict[str, Any]:
                     values[normalized_key] = normalized_value
         if var_name and run is not None and var_name not in values:
             values[var_name] = run
-        normalized: dict[str, Any] = {"type": "vars"}
+        normalized = {"type": "vars"}
         if values:
             normalized["values"] = values
+        _normalize_common_step_fields(step, normalized)
+        return normalized
+    if step_type == "for":
+        in_var = _as_string(step.get("in"))
+        item = _as_string(step.get("item"))
+        nested_steps = _normalize_nested_steps(step)
+        if not (in_var and item and nested_steps):
+            return {}
+        normalized = {"type": "for", "in": in_var, "item": item, "steps": nested_steps}
+        _normalize_common_step_fields(step, normalized)
+        return normalized
+    if step_type == "while":
+        condition = _as_string(step.get("condition"))
+        nested_steps = _normalize_nested_steps(step)
+        if not (condition and nested_steps):
+            return {}
+        normalized = {"type": "while", "condition": condition, "steps": nested_steps}
+        _normalize_common_step_fields(step, normalized)
+        return normalized
+    if step_type == "parallel":
+        nested_steps = _normalize_nested_steps(step)
+        if not nested_steps:
+            return {}
+        normalized = {"type": "parallel", "steps": nested_steps}
+        _normalize_common_step_fields(step, normalized)
         return normalized
     return {}
+
+
+def _normalize_workflow_params(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_params = workflow.get("params")
+    params: list[dict[str, Any]] = []
+    if not isinstance(raw_params, list):
+        return params
+    for raw_param in raw_params:
+        if not isinstance(raw_param, dict):
+            continue
+        name = _as_string(raw_param.get("name"))
+        if not name:
+            continue
+        param: dict[str, Any] = {"name": name}
+        description = _as_string(raw_param.get("description"))
+        if description:
+            param["description"] = description
+        param["required"] = _as_bool(raw_param.get("required"), default=False)
+        params.append(param)
+    return params
 
 
 def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
@@ -98,6 +178,15 @@ def _normalize_workflow(workflow: Any, index: int) -> dict[str, Any] | None:
         "schedule": schedule,
         "steps": steps,
     }
+
+    description = _as_string(workflow.get("description"))
+    if description:
+        normalized_workflow["description"] = description
+
+    params = _normalize_workflow_params(workflow)
+    if params:
+        normalized_workflow["params"] = params
+
     if shell_script_path:
         normalized_workflow["shellScriptPath"] = shell_script_path
 


### PR DESCRIPTION
## Issues fixed
- #727 (partial — Phase 2 slice) — workflow normalization now preserves the full flowsh-cli step/field schema; added `GET /api/workflows/schema`
- #725 — triaged, **not actionable in this repo**; recommend closing (see below)

## Summary of changes

**#727 slice**: `workflow_service.py`'s `_normalize_step`/`_normalize_workflow` previously only recognized `bash`/`agent`/`vars` step types and a small field subset, **silently dropping** any `for`/`while`/`parallel` step or extended agent field (`model`/`capture`/`expandPrompt`/`expandFields`/`dangerouslySkipPermissions`) or workflow-level `description`/`params` on every save/read round-trip — a real data-loss bug for anyone hand-editing or scripting `workflows.yml` with these fields (all already supported by the flowsh-cli engine since the prior Phase 0/1 merge). Fixed:
- All step types (`bash`, `agent`, `vars`, `for`, `while`, `parallel`) now round-trip correctly, including recursively normalized nested `steps` for `for`/`while`/`parallel`.
- Common `name`/`when` fields preserved on every step type.
- Extended agent fields (`model`, `capture`, `expandPrompt`, `expandFields`, `dangerouslySkipPermissions`) preserved.
- Workflow-level `description` and `params` (`name`/`description`/`required`, matching flowsh-cli's `WorkflowParam` model verified against the installed package) preserved.
- Added `GET /api/workflows/schema` returning `flowsh_cli.models.workflow_schema_yaml()` as `text/yaml`, for tooling/introspection.

**#725**: Investigated thoroughly, **no code changes**. Conclusive evidence the 65 reported vulnerabilities are not reproducible from or caused by anything in this repo:
- No `Dockerfile` exists anywhere in the repo.
- None of the vulnerable version strings named in the issue (`cryptography 41.0.7`, `requests 2.31.0`, `urllib3 2.0.7`, etc.) appear in `packages/pybackend/uv.lock` — the project already pins current safe versions of every one of those that's an actual dependency.
- Packages like `twisted`, `configobj`, `httplib2` aren't project dependencies at all (don't appear in `uv.lock`).
- No CI workflow does a raw system-level `pip install` — everything flows through `uv sync`/`uv run` into a project-scoped venv.
- Conclusion: this finding originated from a `pip-audit` scan of a bare system/CI-runner/local-machine Python interpreter outside this project's dependency management, exactly as the issue's own body already stated. **Recommend closing #725** with an explanatory comment (drafted in this PR's issue thread).

## Validation commands run

```
# round-trip regression test — verified fail-before/pass-after against the bug
pytest packages/pybackend/tests/unit/test_workflow_service.py::test_normalize_payload_round_trips_full_flowsh_schema
# before fix: KeyError: 'description' (FAILED) — proves the bug is real
# after fix: 1 passed

make qa-quick-backend     # 480 passed, 1 skipped
make qa-quick             # frontend + backend, all green (re-verified by pre-push hook)
```

## E2E coverage

Real, unmocked, in-process FastAPI `TestClient` E2E chain (ports 3000/5173 already occupied by a running made instance — left untouched per policy; no server ports bound):
1. `GET /api/workflows/schema` → 200, `text/yaml`, real flowsh-cli JSON schema serialized as YAML.
2. `PUT /api/workflows` with a payload exercising `agent` (with `model`/`capture`/`expandPrompt`) and `parallel` (nested `bash` children) steps plus workflow-level `description`/`params` → 200.
3. `GET /api/workflows` → round-trip confirmed: `description`, `params`, step types, and all extended agent fields survive unchanged through the real save/read HTTP cycle, not just the internal function.

## Risks / follow-ups

- Verified `flowsh_cli.models.WorkflowParam`'s exact fields (`name: str`, `description: str | None`, `required: bool = False`) directly against the installed package before merging — the implementation matches exactly, no drift risk.
- Frontend UI still doesn't expose these new step types/fields — that's the next Phase 2/3 slice on #727 (UI editors for `for`/`while`/`parallel`/`when`/`params`, then retiring the LLM-prompt harness template). This PR is backend-only groundwork.
- #725 recommended for closure with the drafted comment; no code risk since nothing was changed.

## Unrelated issues created
- None this round.
