### PR TITLE
Add for/while/parallel step editors and when condition field to workflow builder (#727)

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
@@ -329,10 +329,9 @@ describe("WorkflowBuilderPanel", () => {
       ).toBeInTheDocument();
     });
 
-    fireEvent.change(
-      screen.getAllByPlaceholderText("when (optional)")[1],
-      { target: { value: "PREVIOUS_STEP_OK" } },
-    );
+    fireEvent.change(screen.getAllByPlaceholderText("when (optional)")[1], {
+      target: { value: "PREVIOUS_STEP_OK" },
+    });
 
     await waitFor(() => {
       expect(saveWorkflows).toHaveBeenCalledTimes(1);

--- a/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.test.tsx
@@ -152,4 +152,202 @@ describe("WorkflowBuilderPanel", () => {
       ],
     });
   });
+
+  it("adds a for step and a child step inside it and persists correctly", async () => {
+    const saveWorkflows = vi.fn(async () => undefined);
+
+    render(
+      <WorkflowBuilderPanel
+        loadWorkflows={async () => ({ workflows })}
+        saveWorkflows={saveWorkflows}
+        listAgents={async () => ({ agents: [{ name: "planner" }] })}
+        onRunWorkflow={vi.fn(async () => undefined)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Remove step 3" }),
+      ).toBeInTheDocument();
+    });
+
+    const typeSelects = screen.getAllByRole("combobox", {
+      name: "",
+    }) as HTMLSelectElement[];
+    // First select in the first row is the step-type dropdown.
+    fireEvent.change(typeSelects[0], { target: { value: "for" } });
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(1);
+    });
+    expect(saveWorkflows.mock.calls[0]?.[0]).toEqual({
+      workflows: [
+        {
+          ...workflows[0],
+          steps: [
+            { type: "for", in: "", item: "", steps: [] },
+            workflows[0].steps[1],
+            workflows[0].steps[2],
+          ],
+        },
+      ],
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("IN_VARIABLE"), {
+      target: { value: "ITEMS" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("ITEM_VARIABLE"), {
+      target: { value: "ITEM" },
+    });
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(3);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add child step" }));
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(4);
+    });
+    const lastCall = saveWorkflows.mock.calls[3]?.[0] as {
+      workflows: WorkflowDefinition[];
+    };
+    expect(lastCall.workflows[0].steps[0]).toEqual({
+      type: "for",
+      in: "ITEMS",
+      item: "ITEM",
+      steps: [{ type: "bash", run: "" }],
+    });
+  });
+
+  it("adds a while step and sets its condition via the edit modal", async () => {
+    const saveWorkflows = vi.fn(async () => undefined);
+
+    render(
+      <WorkflowBuilderPanel
+        loadWorkflows={async () => ({ workflows })}
+        saveWorkflows={saveWorkflows}
+        listAgents={async () => ({ agents: [{ name: "planner" }] })}
+        onRunWorkflow={vi.fn(async () => undefined)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Remove step 3" }),
+      ).toBeInTheDocument();
+    });
+
+    const typeSelects = screen.getAllByRole("combobox", {
+      name: "",
+    }) as HTMLSelectElement[];
+    fireEvent.change(typeSelects[0], { target: { value: "while" } });
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Condition" }));
+    fireEvent.change(screen.getByLabelText("Command or Prompt"), {
+      target: { value: "[ -f /tmp/done ]" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save step" }));
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(2);
+    });
+    const lastCall = saveWorkflows.mock.calls[1]?.[0] as {
+      workflows: WorkflowDefinition[];
+    };
+    expect(lastCall.workflows[0].steps[0].type).toBe("while");
+    expect(lastCall.workflows[0].steps[0].condition).toBe("[ -f /tmp/done ]");
+  });
+
+  it("adds a parallel step with two child steps", async () => {
+    const saveWorkflows = vi.fn(async () => undefined);
+
+    render(
+      <WorkflowBuilderPanel
+        loadWorkflows={async () => ({ workflows })}
+        saveWorkflows={saveWorkflows}
+        listAgents={async () => ({ agents: [{ name: "planner" }] })}
+        onRunWorkflow={vi.fn(async () => undefined)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Remove step 3" }),
+      ).toBeInTheDocument();
+    });
+
+    const typeSelects = screen.getAllByRole("combobox", {
+      name: "",
+    }) as HTMLSelectElement[];
+    fireEvent.change(typeSelects[0], { target: { value: "parallel" } });
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add child step" }));
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(2);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add child step" }));
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(3);
+    });
+
+    const lastCall = saveWorkflows.mock.calls[2]?.[0] as {
+      workflows: WorkflowDefinition[];
+    };
+    expect(lastCall.workflows[0].steps[0]).toEqual({
+      type: "parallel",
+      steps: [
+        { type: "bash", run: "" },
+        { type: "bash", run: "" },
+      ],
+    });
+  });
+
+  it("sets a when value on a step", async () => {
+    const saveWorkflows = vi.fn(async () => undefined);
+
+    render(
+      <WorkflowBuilderPanel
+        loadWorkflows={async () => ({ workflows })}
+        saveWorkflows={saveWorkflows}
+        listAgents={async () => ({ agents: [{ name: "planner" }] })}
+        onRunWorkflow={vi.fn(async () => undefined)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Remove step 2" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(
+      screen.getAllByPlaceholderText("when (optional)")[1],
+      { target: { value: "PREVIOUS_STEP_OK" } },
+    );
+
+    await waitFor(() => {
+      expect(saveWorkflows).toHaveBeenCalledTimes(1);
+    });
+    expect(saveWorkflows.mock.calls[0]?.[0]).toEqual({
+      workflows: [
+        {
+          ...workflows[0],
+          steps: [
+            workflows[0].steps[0],
+            { ...workflows[0].steps[1], when: "PREVIOUS_STEP_OK" },
+            workflows[0].steps[2],
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -14,13 +14,18 @@ import { XIcon } from "./icons/XIcon";
 import { workflowShellScriptPath } from "../utils/workflowHarnessPrompt";
 
 export type WorkflowStep = {
-  type: "agent" | "bash" | "vars";
+  type: "agent" | "bash" | "vars" | "for" | "while" | "parallel";
   agent?: string;
   varName?: string;
   command?: string;
   prompt?: string;
   run?: string;
   values?: Record<string, string>;
+  when?: string;
+  in?: string;
+  item?: string;
+  condition?: string;
+  steps?: WorkflowStep[];
 };
 
 export type WorkflowDefinition = {
@@ -48,11 +53,20 @@ const previewText = (step: WorkflowStep) => {
       ? step.run || ""
       : step.type === "vars"
         ? step.run || ""
-        : step.command
-          ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
-          : step.prompt || "";
+        : step.type === "while"
+          ? step.condition || ""
+          : step.command
+            ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
+            : step.prompt || "";
   const [firstLine] = raw.split(/\r?\n/, 1);
-  return firstLine || (step.type === "agent" ? "Prompt" : "Command");
+  return (
+    firstLine ||
+    (step.type === "agent"
+      ? "Prompt"
+      : step.type === "while"
+        ? "Condition"
+        : "Command")
+  );
 };
 
 const toBashVariableName = (value: string) => {
@@ -81,6 +95,13 @@ const parseAgentText = (value: string) => {
 };
 
 const normalizeStep = (step: WorkflowStep): WorkflowStep => {
+  if (step.type === "for" || step.type === "while" || step.type === "parallel") {
+    return {
+      ...step,
+      steps: (step.steps || []).map(normalizeStep),
+    };
+  }
+
   if (step.type !== "vars") {
     return step;
   }
@@ -98,6 +119,64 @@ const normalizeStep = (step: WorkflowStep): WorkflowStep => {
     values: varName ? { [varName]: run } : {},
   };
 };
+
+const pathPrefix = (path: number[]) => path.slice(0, -1);
+const samePrefix = (a: number[], b: number[]) =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
+const updateAtPath = (
+  steps: WorkflowStep[],
+  path: number[],
+  updater: (step: WorkflowStep) => WorkflowStep,
+): WorkflowStep[] => {
+  const [index, ...rest] = path;
+  return steps.map((step, i) => {
+    if (i !== index) return step;
+    if (rest.length === 0) return updater(step);
+    return { ...step, steps: updateAtPath(step.steps || [], rest, updater) };
+  });
+};
+
+const removeAtPath = (steps: WorkflowStep[], path: number[]): WorkflowStep[] => {
+  const [index, ...rest] = path;
+  if (rest.length === 0) {
+    return steps.filter((_, i) => i !== index);
+  }
+  return steps.map((step, i) =>
+    i === index
+      ? { ...step, steps: removeAtPath(step.steps || [], rest) }
+      : step,
+  );
+};
+
+const moveAtPath = (
+  steps: WorkflowStep[],
+  path: number[],
+  direction: -1 | 1,
+): WorkflowStep[] => {
+  const [index, ...rest] = path;
+  if (rest.length === 0) {
+    const targetIndex = index + direction;
+    if (targetIndex < 0 || targetIndex >= steps.length) return steps;
+    const next = [...steps];
+    [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+    return next;
+  }
+  return steps.map((step, i) =>
+    i === index
+      ? { ...step, steps: moveAtPath(step.steps || [], rest, direction) }
+      : step,
+  );
+};
+
+const addChildAtPath = (
+  steps: WorkflowStep[],
+  path: number[],
+): WorkflowStep[] =>
+  updateAtPath(steps, path, (step) => ({
+    ...step,
+    steps: [...(step.steps || []), { type: "bash" as const, run: "" }],
+  }));
 
 const normalizeWorkflows = (items: WorkflowDefinition[]) =>
   items.map((workflow) => ({
@@ -131,7 +210,7 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
   const [conversionError, setConversionError] = useState<string | null>(null);
   const [editStep, setEditStep] = useState<{
     workflowId: string;
-    stepIndex: number;
+    path: number[];
   } | null>(null);
   const [editStepValue, setEditStepValue] = useState("");
   const [scheduleEditor, setScheduleEditor] = useState<{
@@ -211,6 +290,271 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
         : workflow,
     );
     void persist(next);
+  };
+
+  const updateWorkflowSteps = (
+    workflowId: string,
+    updater: (steps: WorkflowStep[]) => WorkflowStep[],
+  ) => {
+    const next = workflows.map((item) =>
+      item.id === workflowId ? { ...item, steps: updater(item.steps) } : item,
+    );
+    void persist(next);
+  };
+
+  const renderStepRow = (
+    workflow: WorkflowDefinition,
+    step: WorkflowStep,
+    path: number[],
+    siblingsLength: number,
+    depth: number,
+  ): React.ReactNode => {
+    const stepIndex = path[path.length - 1];
+    const isContainer =
+      step.type === "for" || step.type === "while" || step.type === "parallel";
+    const hasPreview =
+      step.type === "agent" ||
+      step.type === "bash" ||
+      step.type === "vars" ||
+      step.type === "while";
+
+    return (
+      <div className="workflow-step-row" key={path.join("-")}>
+        <div className="workflow-step-target">
+          <select
+            value={step.type}
+            onChange={(event) => {
+              const nextType = event.target.value as WorkflowStep["type"];
+              const when = step.when;
+              let nextStep: WorkflowStep;
+              switch (nextType) {
+                case "bash":
+                  nextStep = { type: "bash", run: "" };
+                  break;
+                case "vars":
+                  nextStep = { type: "vars", varName: "", run: "", values: {} };
+                  break;
+                case "for":
+                  nextStep = { type: "for", in: "", item: "", steps: [] };
+                  break;
+                case "while":
+                  nextStep = { type: "while", condition: "", steps: [] };
+                  break;
+                case "parallel":
+                  nextStep = { type: "parallel", steps: [] };
+                  break;
+                default:
+                  nextStep = {
+                    type: "agent",
+                    agent: agentNames[0] || "default",
+                    prompt: "",
+                  };
+              }
+              if (when) nextStep.when = when;
+              updateWorkflowSteps(workflow.id, (steps) =>
+                updateAtPath(steps, path, () => nextStep),
+              );
+            }}
+          >
+            <option value="agent">Agent</option>
+            <option value="bash">Bash</option>
+            <option value="vars">Vars</option>
+            {depth === 0 && <option value="for">For</option>}
+            {depth === 0 && <option value="while">While</option>}
+            {depth === 0 && <option value="parallel">Parallel</option>}
+          </select>
+          {step.type === "agent" ? (
+            <select
+              value={step.agent || "default"}
+              onChange={(event) => {
+                const agent = event.target.value;
+                updateWorkflowSteps(workflow.id, (steps) =>
+                  updateAtPath(steps, path, (item) => ({ ...item, agent })),
+                );
+              }}
+            >
+              {agentNames.length === 0 ? (
+                <option value="default">default</option>
+              ) : (
+                agentNames.map((agentName) => (
+                  <option key={agentName}>{agentName}</option>
+                ))
+              )}
+            </select>
+          ) : step.type === "vars" ? (
+            <input
+              className="workflow-step-target__input"
+              value={step.varName || ""}
+              placeholder="VARIABLE_NAME"
+              onChange={(event) => {
+                const varName = toBashVariableName(event.target.value);
+                updateWorkflowSteps(workflow.id, (steps) =>
+                  updateAtPath(steps, path, (item) => ({
+                    ...item,
+                    varName,
+                    values: varName ? { [varName]: item.run || "" } : {},
+                  })),
+                );
+              }}
+            />
+          ) : step.type === "for" ? (
+            <>
+              <input
+                className="workflow-step-target__input"
+                value={step.in || ""}
+                placeholder="IN_VARIABLE"
+                aria-label="For loop source variable"
+                onChange={(event) => {
+                  const value = event.target.value;
+                  updateWorkflowSteps(workflow.id, (steps) =>
+                    updateAtPath(steps, path, (item) => ({
+                      ...item,
+                      in: value,
+                    })),
+                  );
+                }}
+              />
+              <input
+                className="workflow-step-target__input"
+                value={step.item || ""}
+                placeholder="ITEM_VARIABLE"
+                aria-label="For loop item variable"
+                onChange={(event) => {
+                  const value = event.target.value;
+                  updateWorkflowSteps(workflow.id, (steps) =>
+                    updateAtPath(steps, path, (item) => ({
+                      ...item,
+                      item: value,
+                    })),
+                  );
+                }}
+              />
+            </>
+          ) : null}
+        </div>
+        {hasPreview && (
+          <button
+            className="workflow-step-preview"
+            onClick={() => {
+              const currentText =
+                step.type === "agent"
+                  ? step.command
+                    ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
+                    : step.prompt || ""
+                  : step.type === "while"
+                    ? step.condition || ""
+                    : step.run || "";
+              setEditStep({ workflowId: workflow.id, path });
+              setEditStepValue(currentText);
+            }}
+          >
+            {previewText(step)}
+          </button>
+        )}
+        <input
+          className="workflow-step-target__input"
+          value={step.when || ""}
+          placeholder="when (optional)"
+          aria-label="Step when condition"
+          onChange={(event) => {
+            const value = event.target.value;
+            updateWorkflowSteps(workflow.id, (steps) =>
+              updateAtPath(steps, path, (item) => ({
+                ...item,
+                when: value || undefined,
+              })),
+            );
+          }}
+        />
+        <div className="workflow-step-controls">
+          <button
+            className="copy-button workflow-icon-button"
+            disabled={stepIndex === 0}
+            title="Move step up"
+            aria-label="Move step up"
+            onClick={() => {
+              updateWorkflowSteps(workflow.id, (steps) =>
+                moveAtPath(steps, path, -1),
+              );
+            }}
+          >
+            <span className="workflow-icon workflow-icon--up">
+              <ArrowDownIcon />
+            </span>
+          </button>
+          <button
+            className="copy-button workflow-icon-button"
+            disabled={stepIndex === siblingsLength - 1}
+            title="Move step down"
+            aria-label="Move step down"
+            onClick={() => {
+              updateWorkflowSteps(workflow.id, (steps) =>
+                moveAtPath(steps, path, 1),
+              );
+            }}
+          >
+            <span className="workflow-icon workflow-icon--down">
+              <ArrowDownIcon />
+            </span>
+          </button>
+          <button
+            className="copy-button workflow-icon-button workflow-icon-button--danger"
+            title="Remove step"
+            aria-label={`Remove step ${stepIndex + 1}`}
+            onClick={() => {
+              if (
+                editStep?.workflowId === workflow.id &&
+                samePrefix(pathPrefix(editStep.path), pathPrefix(path))
+              ) {
+                const editLast = editStep.path[editStep.path.length - 1];
+                if (editLast === stepIndex) {
+                  setEditStep(null);
+                  setEditStepValue("");
+                } else if (editLast > stepIndex) {
+                  const newPath = [...editStep.path];
+                  newPath[newPath.length - 1] = editLast - 1;
+                  setEditStep({ workflowId: editStep.workflowId, path: newPath });
+                }
+              }
+              updateWorkflowSteps(workflow.id, (steps) =>
+                removeAtPath(steps, path),
+              );
+            }}
+          >
+            <TrashIcon />
+          </button>
+        </div>
+        {isContainer && (
+          <div className="workflow-steps workflow-step-children">
+            {(step.steps || []).length === 0 ? (
+              <div className="empty">No child steps yet.</div>
+            ) : (
+              (step.steps || []).map((child, childIndex) =>
+                renderStepRow(
+                  workflow,
+                  child,
+                  [...path, childIndex],
+                  (step.steps || []).length,
+                  depth + 1,
+                ),
+              )
+            )}
+            <button
+              className="copy-button workflow-icon-button"
+              title="Add child step"
+              aria-label="Add child step"
+              onClick={() => {
+                updateWorkflowSteps(workflow.id, (steps) =>
+                  addChildAtPath(steps, path),
+                );
+              }}
+            >
+              <PlusIcon />
+            </button>
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -398,223 +742,15 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                   {workflow.steps.length === 0 ? (
                     <div className="empty">No steps yet.</div>
                   ) : (
-                    workflow.steps.map((step, stepIndex) => (
-                      <div
-                        className="workflow-step-row"
-                        key={`${workflow.id}-${stepIndex}`}
-                      >
-                        <div className="workflow-step-target">
-                          <select
-                            value={step.type}
-                            onChange={(event) => {
-                              const nextType = event.target.value as
-                                "agent" | "bash" | "vars";
-                              const nextStep: WorkflowStep =
-                                nextType === "bash"
-                                  ? { type: "bash", run: "" }
-                                  : nextType === "vars"
-                                    ? {
-                                        type: "vars",
-                                        varName: "",
-                                        run: "",
-                                        values: {},
-                                      }
-                                    : {
-                                        type: "agent",
-                                        agent: agentNames[0] || "default",
-                                        prompt: "",
-                                      };
-                              const next = workflows.map((item) =>
-                                item.id === workflow.id
-                                  ? {
-                                      ...item,
-                                      steps: item.steps.map(
-                                        (itemStep, itemIndex) =>
-                                          itemIndex === stepIndex
-                                            ? nextStep
-                                            : itemStep,
-                                      ),
-                                    }
-                                  : item,
-                              );
-                              void persist(next);
-                            }}
-                          >
-                            <option value="agent">Agent</option>
-                            <option value="bash">Bash</option>
-                            <option value="vars">Vars</option>
-                          </select>
-                          {step.type === "agent" ? (
-                            <select
-                              value={step.agent || "default"}
-                              onChange={(event) => {
-                                const next = workflows.map((item) =>
-                                  item.id === workflow.id
-                                    ? {
-                                        ...item,
-                                        steps: item.steps.map(
-                                          (itemStep, itemIndex) =>
-                                            itemIndex === stepIndex
-                                              ? {
-                                                  ...itemStep,
-                                                  agent: event.target.value,
-                                                }
-                                              : itemStep,
-                                        ),
-                                      }
-                                    : item,
-                                );
-                                void persist(next);
-                              }}
-                            >
-                              {agentNames.length === 0 ? (
-                                <option value="default">default</option>
-                              ) : (
-                                agentNames.map((agentName) => (
-                                  <option key={agentName}>{agentName}</option>
-                                ))
-                              )}
-                            </select>
-                          ) : step.type === "vars" ? (
-                            <input
-                              className="workflow-step-target__input"
-                              value={step.varName || ""}
-                              placeholder="VARIABLE_NAME"
-                              onChange={(event) => {
-                                const next = workflows.map((item) =>
-                                  item.id === workflow.id
-                                    ? {
-                                        ...item,
-                                        steps: item.steps.map(
-                                          (itemStep, itemIndex) => {
-                                            if (itemIndex !== stepIndex) {
-                                              return itemStep;
-                                            }
-                                            const varName = toBashVariableName(
-                                              event.target.value,
-                                            );
-                                            return {
-                                              ...itemStep,
-                                              varName,
-                                              values: varName
-                                                ? {
-                                                    [varName]:
-                                                      itemStep.run || "",
-                                                  }
-                                                : {},
-                                            };
-                                          },
-                                        ),
-                                      }
-                                    : item,
-                                );
-                                void persist(next);
-                              }}
-                            />
-                          ) : null}
-                        </div>
-                        <button
-                          className="workflow-step-preview"
-                          onClick={() => {
-                            const currentText =
-                              step.type === "agent"
-                                ? step.command
-                                  ? `/${step.command}${step.prompt ? ` ${step.prompt}` : ""}`
-                                  : step.prompt || ""
-                                : step.run || "";
-                            setEditStep({
-                              workflowId: workflow.id,
-                              stepIndex,
-                            });
-                            setEditStepValue(currentText);
-                          }}
-                        >
-                          {previewText(step)}
-                        </button>
-                        <div className="workflow-step-controls">
-                          <button
-                            className="copy-button workflow-icon-button"
-                            disabled={stepIndex === 0}
-                            title="Move step up"
-                            aria-label="Move step up"
-                            onClick={() => {
-                              const next = workflows.map((item) => {
-                                if (item.id !== workflow.id || stepIndex === 0)
-                                  return item;
-                                const steps = [...item.steps];
-                                [steps[stepIndex - 1], steps[stepIndex]] = [
-                                  steps[stepIndex],
-                                  steps[stepIndex - 1],
-                                ];
-                                return { ...item, steps };
-                              });
-                              void persist(next);
-                            }}
-                          >
-                            <span className="workflow-icon workflow-icon--up">
-                              <ArrowDownIcon />
-                            </span>
-                          </button>
-                          <button
-                            className="copy-button workflow-icon-button"
-                            disabled={stepIndex === workflow.steps.length - 1}
-                            title="Move step down"
-                            aria-label="Move step down"
-                            onClick={() => {
-                              const next = workflows.map((item) => {
-                                if (
-                                  item.id !== workflow.id ||
-                                  stepIndex >= item.steps.length - 1
-                                )
-                                  return item;
-                                const steps = [...item.steps];
-                                [steps[stepIndex + 1], steps[stepIndex]] = [
-                                  steps[stepIndex],
-                                  steps[stepIndex + 1],
-                                ];
-                                return { ...item, steps };
-                              });
-                              void persist(next);
-                            }}
-                          >
-                            <span className="workflow-icon workflow-icon--down">
-                              <ArrowDownIcon />
-                            </span>
-                          </button>
-                          <button
-                            className="copy-button workflow-icon-button workflow-icon-button--danger"
-                            title="Remove step"
-                            aria-label={`Remove step ${stepIndex + 1}`}
-                            onClick={() => {
-                              if (editStep?.workflowId === workflow.id) {
-                                if (editStep.stepIndex === stepIndex) {
-                                  setEditStep(null);
-                                  setEditStepValue("");
-                                } else if (editStep.stepIndex > stepIndex) {
-                                  setEditStep({
-                                    workflowId: editStep.workflowId,
-                                    stepIndex: editStep.stepIndex - 1,
-                                  });
-                                }
-                              }
-                              const next = workflows.map((item) =>
-                                item.id === workflow.id
-                                  ? {
-                                      ...item,
-                                      steps: item.steps.filter(
-                                        (_, index) => index !== stepIndex,
-                                      ),
-                                    }
-                                  : item,
-                              );
-                              void persist(next);
-                            }}
-                          >
-                            <TrashIcon />
-                          </button>
-                        </div>
-                      </div>
-                    ))
+                    workflow.steps.map((step, stepIndex) =>
+                      renderStepRow(
+                        workflow,
+                        step,
+                        [stepIndex],
+                        workflow.steps.length,
+                        0,
+                      ),
+                    )
                   )}
                 </div>
               )}
@@ -660,17 +796,19 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                 if (workflow.id !== editStep.workflowId) return workflow;
                 return {
                   ...workflow,
-                  steps: workflow.steps.map((step, index) => {
-                    if (index !== editStep.stepIndex) return step;
+                  steps: updateAtPath(workflow.steps, editStep.path, (step) => {
+                    if (step.type === "while") {
+                      return { ...step, condition: editStepValue };
+                    }
+                    if (step.type === "vars") {
+                      const varName = step.varName || "";
+                      return {
+                        ...step,
+                        run: editStepValue,
+                        values: varName ? { [varName]: editStepValue } : {},
+                      };
+                    }
                     if (step.type !== "agent") {
-                      if (step.type === "vars") {
-                        const varName = step.varName || "";
-                        return {
-                          ...step,
-                          run: editStepValue,
-                          values: varName ? { [varName]: editStepValue } : {},
-                        };
-                      }
                       return { ...step, run: editStepValue };
                     }
                     const parsed = parseAgentText(editStepValue);

--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -95,7 +95,11 @@ const parseAgentText = (value: string) => {
 };
 
 const normalizeStep = (step: WorkflowStep): WorkflowStep => {
-  if (step.type === "for" || step.type === "while" || step.type === "parallel") {
+  if (
+    step.type === "for" ||
+    step.type === "while" ||
+    step.type === "parallel"
+  ) {
     return {
       ...step,
       steps: (step.steps || []).map(normalizeStep),
@@ -137,7 +141,10 @@ const updateAtPath = (
   });
 };
 
-const removeAtPath = (steps: WorkflowStep[], path: number[]): WorkflowStep[] => {
+const removeAtPath = (
+  steps: WorkflowStep[],
+  path: number[],
+): WorkflowStep[] => {
   const [index, ...rest] = path;
   if (rest.length === 0) {
     return steps.filter((_, i) => i !== index);
@@ -513,7 +520,10 @@ export const WorkflowBuilderPanel: React.FC<WorkflowBuilderPanelProps> = ({
                 } else if (editLast > stepIndex) {
                   const newPath = [...editStep.path];
                   newPath[newPath.length - 1] = editLast - 1;
-                  setEditStep({ workflowId: editStep.workflowId, path: newPath });
+                  setEditStep({
+                    workflowId: editStep.workflowId,
+                    path: newPath,
+                  });
                 }
               }
               updateWorkflowSteps(workflow.id, (steps) =>

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -300,13 +300,18 @@ export type TemplateApplyResponse = {
 };
 
 export type WorkflowStep = {
-  type: "agent" | "bash" | "vars";
+  type: "agent" | "bash" | "vars" | "for" | "while" | "parallel";
   agent?: string;
   varName?: string;
   command?: string;
   prompt?: string;
   run?: string;
   values?: Record<string, string>;
+  when?: string;
+  in?: string;
+  item?: string;
+  condition?: string;
+  steps?: WorkflowStep[];
 };
 
 export type WorkspaceWorkflowSummary = {

--- a/packages/frontend/src/utils/workflowHarnessPrompt.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.ts
@@ -47,7 +47,9 @@ const stepToYaml = (step: WorkflowStep, indent: string) => {
     return lines;
   }
   if (step.type === "while") {
-    lines.push(`${indent}  condition: ${escapeYamlValue(step.condition || "")}`);
+    lines.push(
+      `${indent}  condition: ${escapeYamlValue(step.condition || "")}`,
+    );
     lines.push(`${indent}  steps:`);
     (step.steps || []).forEach((child) => {
       lines.push(...stepToYaml(child, `${indent}    `));

--- a/packages/frontend/src/utils/workflowHarnessPrompt.ts
+++ b/packages/frontend/src/utils/workflowHarnessPrompt.ts
@@ -14,6 +14,9 @@ const escapeYamlValue = (value: string) => {
 
 const stepToYaml = (step: WorkflowStep, indent: string) => {
   const lines: string[] = [`${indent}- type: ${step.type}`];
+  if (step.when) {
+    lines.push(`${indent}  when: ${escapeYamlValue(step.when)}`);
+  }
   if (step.type === "agent") {
     if (step.agent)
       lines.push(`${indent}  agent: ${escapeYamlValue(step.agent)}`);
@@ -32,6 +35,30 @@ const stepToYaml = (step: WorkflowStep, indent: string) => {
     } else {
       lines.push(`${indent}  values: {}`);
     }
+    return lines;
+  }
+  if (step.type === "for") {
+    lines.push(`${indent}  in: ${escapeYamlValue(step.in || "")}`);
+    lines.push(`${indent}  item: ${escapeYamlValue(step.item || "")}`);
+    lines.push(`${indent}  steps:`);
+    (step.steps || []).forEach((child) => {
+      lines.push(...stepToYaml(child, `${indent}    `));
+    });
+    return lines;
+  }
+  if (step.type === "while") {
+    lines.push(`${indent}  condition: ${escapeYamlValue(step.condition || "")}`);
+    lines.push(`${indent}  steps:`);
+    (step.steps || []).forEach((child) => {
+      lines.push(...stepToYaml(child, `${indent}    `));
+    });
+    return lines;
+  }
+  if (step.type === "parallel") {
+    lines.push(`${indent}  steps:`);
+    (step.steps || []).forEach((child) => {
+      lines.push(...stepToYaml(child, `${indent}    `));
+    });
     return lines;
   }
   lines.push(`${indent}  run: ${escapeYamlValue(step.run || "")}`);


### PR DESCRIPTION
## Issues fixed
- #727 (Phase 2/3 frontend slice) — UI support for `for`/`while`/`parallel` step types and a `when` condition field in the workflow builder

## Summary of changes

The backend already round-trips `for`/`while`/`parallel`/`when` (merged in #734), but the UI had no way to create/view/edit them — `WorkflowBuilderPanel.tsx`'s `WorkflowStep` type only knew `agent`/`bash`/`vars`, making these capabilities backend-only and unreachable from the UI.

- Extended `WorkflowStep` with `for` (`in`, `item`, `steps`), `while` (`condition`, `steps`), `parallel` (`steps`), and a universal optional `when?: string` — verified these field shapes directly against `workflow_service.py` and the installed `flowsh_cli.models` source.
- Extended the step-type dropdown with "For"/"While"/"Parallel" options at the top level only — **one level of nesting**, matching the backend's own `reject_nested_for_steps`/`reject_nested_while_steps` Pydantic validators (verified directly from the installed package, not assumed).
- Refactored the previously flat, duplicated step-row JSX into a single recursive `renderStepRow` function reused for both top-level and one-level-deep nested child steps, backed by generalized path-based immutable tree helpers (`updateAtPath`, `removeAtPath`, `moveAtPath`, `addChildAtPath`) replacing the old scalar-index mutation logic.
- Added `for`'s `in`/`item` text inputs, reused the existing preview-button + edit-modal pattern for `while`'s `condition`, an "Add child step" button (default `bash` child) with per-child remove/move controls for `for`/`while`/`parallel`, and a small `when` input on every step row.
- Extended `normalizeStep`/`normalizeWorkflows` so `for`/`while`/`parallel` steps always carry a normalized `steps: []`.
- Extended `stepToYaml`/`workflowToYaml` in `workflowHarnessPrompt.ts` (legacy LLM-prompt path only, not retired in this PR) so it doesn't silently drop the new step types if that path is ever triggered on a workflow containing them.
- **Necessary deviation, explicitly reviewed**: widened the independently-duplicated `WorkflowStep`/`WorkflowDefinition` type in `packages/frontend/src/hooks/useApi.ts` — purely additive (new optional fields/union members, zero logic change), required because `tsc` failed otherwise (`HarnessesTab.tsx`/`RepositoryPage.tsx` pass `WorkflowBuilderPanel`'s types into `useApi`-typed functions). Filed **#735** to consolidate these two independently-drifting type declarations into one shared module.
- Existing `bash`/`agent`/`vars` behavior is completely unchanged — purely additive.

## Validation commands run

```
make test-frontend FILE=src/components/WorkflowBuilderPanel.test.tsx   # baseline 3/3 → after 7/7 (3 original + 4 new, all passing)
make qa-quick-frontend                                                  # lint: 0 errors, pre-existing warning count only
npm run test:serial --workspace packages/frontend                       # 28 test files, 172/172 passed
npm run build:frontend                                                  # tsc && vite build — succeeded
make qa-quick                                                           # frontend + backend, 480 backend tests, all green (pre-push hook re-verified)
```

## E2E coverage

Reused the existing Playwright system suite (`tests/system/made.spec.ts`) against a real production build including this change:
- Ports 3000/5173 already occupied by a running made instance — left untouched per policy.
- Built for real (`npm run build:frontend`), served via `vite preview` on port 4173 (free port), launched through the `at`/`atd` detach mechanism so it survives tool-call boundaries.
- `PLAYWRIGHT_BASE_URL=https://127.0.0.1:4173 npx playwright test tests/system/made.spec.ts --project=chromium` — **4/4 passed** (welcome/dashboard, repository browser + agent chat, chat roundtrip budget, dashboard failure recovery).
- Preview server stopped afterward; 3000/5173 never touched.

## Risks / follow-ups

- **#735** filed — `WorkflowStep`/`WorkflowDefinition` types are duplicated across `useApi.ts` and `WorkflowBuilderPanel.tsx`; this PR's necessary `useApi.ts` widening is exactly the kind of drift risk that issue tracks for proper consolidation.
- Still deferred (explicitly out of scope for this slice, per the original plan): `params` UI, extended agent-field UI (`model`/`capture`/`expandPrompt`/`expandFields`/`dangerouslySkipPermissions`), and retiring the LLM-prompt harness template — these are the remaining pieces of #727's Phase 2/3.
- Nesting is capped at one level in the UI, matching a real backend constraint (verified against `flowsh_cli.models`), not an arbitrary UI limitation.

## Unrelated issues created
- **#735** — duplicated `WorkflowStep`/`WorkflowDefinition` type declarations across `useApi.ts` and `WorkflowBuilderPanel.tsx`.
