### PR TITLE
Consolidate WorkflowStep/WorkflowDefinition types into shared module (#735)

### DIFF
--- a/packages/frontend/src/components/WorkflowBuilderPanel.tsx
+++ b/packages/frontend/src/components/WorkflowBuilderPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { MentionPathTextarea } from "./MentionPathTextarea";
 import { Modal } from "./Modal";
 import { AvailableAgent } from "../hooks/useApi";
+import type { WorkflowStep, WorkflowDefinition } from "../types/workflow";
 import { ArrowDownIcon } from "./icons/ArrowDownIcon";
 import { CheckboxIcon } from "./icons/CheckboxIcon";
 import { ClockIcon } from "./icons/ClockIcon";
@@ -13,29 +14,7 @@ import { TrashIcon } from "./icons/TrashIcon";
 import { XIcon } from "./icons/XIcon";
 import { workflowShellScriptPath } from "../utils/workflowHarnessPrompt";
 
-export type WorkflowStep = {
-  type: "agent" | "bash" | "vars" | "for" | "while" | "parallel";
-  agent?: string;
-  varName?: string;
-  command?: string;
-  prompt?: string;
-  run?: string;
-  values?: Record<string, string>;
-  when?: string;
-  in?: string;
-  item?: string;
-  condition?: string;
-  steps?: WorkflowStep[];
-};
-
-export type WorkflowDefinition = {
-  id: string;
-  name: string;
-  enabled: boolean;
-  schedule: string | null;
-  shellScriptPath?: string;
-  steps: WorkflowStep[];
-};
+export type { WorkflowStep, WorkflowDefinition };
 
 type WorkflowBuilderPanelProps = {
   loadWorkflows: () => Promise<{ workflows: WorkflowDefinition[] }>;

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -1,3 +1,5 @@
+import type { WorkflowStep, WorkflowDefinition } from "../types/workflow";
+
 const API_BASE =
   (import.meta.env?.VITE_API_BASE as string | undefined) || "/api";
 
@@ -299,20 +301,7 @@ export type TemplateApplyResponse = {
   template: string;
 };
 
-export type WorkflowStep = {
-  type: "agent" | "bash" | "vars" | "for" | "while" | "parallel";
-  agent?: string;
-  varName?: string;
-  command?: string;
-  prompt?: string;
-  run?: string;
-  values?: Record<string, string>;
-  when?: string;
-  in?: string;
-  item?: string;
-  condition?: string;
-  steps?: WorkflowStep[];
-};
+export type { WorkflowStep, WorkflowDefinition };
 
 export type WorkspaceWorkflowSummary = {
   repository: string;
@@ -345,14 +334,6 @@ export type CronClockSummary = {
   successfulJobsSinceStartup: number;
 };
 
-export type WorkflowDefinition = {
-  id: string;
-  name: string;
-  enabled: boolean;
-  schedule: string | null;
-  shellScriptPath?: string;
-  steps: WorkflowStep[];
-};
 
 export type WorkflowLogSummary = {
   name: string;

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -334,7 +334,6 @@ export type CronClockSummary = {
   successfulJobsSinceStartup: number;
 };
 
-
 export type WorkflowLogSummary = {
   name: string;
   location: "var" | "tmp" | string;

--- a/packages/frontend/src/types/workflow.ts
+++ b/packages/frontend/src/types/workflow.ts
@@ -1,0 +1,23 @@
+export type WorkflowStep = {
+  type: "agent" | "bash" | "vars" | "for" | "while" | "parallel";
+  agent?: string;
+  varName?: string;
+  command?: string;
+  prompt?: string;
+  run?: string;
+  values?: Record<string, string>;
+  when?: string;
+  in?: string;
+  item?: string;
+  condition?: string;
+  steps?: WorkflowStep[];
+};
+
+export type WorkflowDefinition = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: string | null;
+  shellScriptPath?: string;
+  steps: WorkflowStep[];
+};


### PR DESCRIPTION
## Issues fixed
- #735 — Frontend: `WorkflowStep`/`WorkflowDefinition` types duplicated across `useApi.ts` and `WorkflowBuilderPanel.tsx`

## Summary of changes

Created `packages/frontend/src/types/workflow.ts` as the single canonical source for `WorkflowStep`/`WorkflowDefinition`. Both `useApi.ts` and `WorkflowBuilderPanel.tsx` now import from it and re-export the same names locally (`export type { WorkflowStep, WorkflowDefinition };`) to preserve backward compatibility for existing importers (`HarnessesTab.tsx`, `workflowHarnessPrompt.ts`/`.test.ts`) without needing to touch their import paths.

The two prior independent declarations were already byte-identical (last synced during the #727 frontend step-editor PR), so this was a pure mechanical consolidation — zero JSX/logic change, zero behavior change.

## Validation commands run

```
grep -rn "WorkflowStep\|WorkflowDefinition" packages/frontend/src --include="*.ts" --include="*.tsx" -l
# same 6 files before/after (5 pre-existing + new types/workflow.ts) — confirms no importer missed

npm run build:frontend         # tsc && vite build — succeeded, zero type errors
npm run test:serial --workspace packages/frontend   # 28 test files, 172/172 passed
npm run lint (frontend)        # 0 errors, 29 pre-existing warnings (unrelated to this change)
make qa-quick                  # frontend + backend, 480 backend tests, all green (pre-push hook re-verified)
```

## E2E coverage

This is a pure type-level refactor (no runtime/JSX change), so the highest-value validation is the real production build succeeding with zero type errors (proves every consumer of these types still typechecks) plus the full existing test suite passing unchanged. Ports 3000/5173 were occupied by a running made instance (left untouched per policy) — did not spin up an additional Playwright run for a change with zero behavioral surface, since the prior PR (#736) already exercised the live app with these exact type shapes moments before this refactor.

## Risks / follow-ups

- None — this closes #735 as originally scoped.
- This lands as **Stage 1 of 2** for the remaining #727 work: the next PR (params UI + extended agent-field UI + retiring the LLM-prompt template) will build directly on this consolidated type module instead of re-encountering the duplication.

## Unrelated issues created
- None this round.
