### PR TITLE
Couple workflow_service.py normalization to flowsh-cli schema + drift-detection tests (#739)

### DIFF
--- a/packages/pybackend/tests/unit/test_workflow_service.py
+++ b/packages/pybackend/tests/unit/test_workflow_service.py
@@ -2,8 +2,24 @@ from pathlib import Path
 from unittest.mock import patch
 
 import yaml
+from flowsh_cli.models import (
+    AgentStep,
+    BashStep,
+    ForStep,
+    ParallelStep,
+    VarsStep,
+    WhileStep,
+    WorkflowParam,
+)
 
-from workflow_service import _normalize_payload, list_workspace_workflows, read_workflows, write_workflows
+from workflow_service import (
+    _normalize_payload,
+    _normalize_step,
+    _normalize_workflow_params,
+    list_workspace_workflows,
+    read_workflows,
+    write_workflows,
+)
 
 
 def test_normalize_payload_keeps_shell_script_path():
@@ -381,3 +397,162 @@ def test_normalize_payload_round_trips_full_flowsh_schema(tmp_path):
         {"type": "bash", "run": "echo a"},
         {"type": "bash", "run": "echo b"},
     ]
+
+
+# ---------------------------------------------------------------------------
+# drift detection — introspects flowsh-cli's real schema at test-run time
+# (#739). If flowsh-cli adds a new field to a step model or WorkflowParam in
+# a future version bump, this test's own expectations grow automatically
+# (they are derived from `model_cls.model_fields`, not hand-copied here) and
+# it starts failing until workflow_service.py's normalization is updated to
+# preserve that new field.
+# ---------------------------------------------------------------------------
+
+# Known-valid sample value per flowsh-cli field name, chosen to satisfy each
+# model's own field validators (e.g. `capture` must match ^[A-Z_][A-Z0-9_]*$).
+# This is the only hand-maintained part of the test: supplying a value that
+# passes validation for a *known* field. The set of fields checked is never
+# hand-maintained — it always comes from `model_cls.model_fields`.
+_SAMPLE_FIELD_VALUES: dict[str, object] = {
+    "name": "step-name",
+    "when": "$FLAG == 1",
+    "prompt": "Do the thing",
+    "agent": "opencode",
+    "model": "claude-sonnet-5",
+    "command": "run",
+    "capture": "AGENT_RESULT",
+    "dangerouslySkipPermissions": True,
+    "expandPrompt": True,
+    "expandFields": True,
+    "in_": "ITEMS",
+    "item": "ITEM",
+    "condition": "$COUNT -lt 5",
+    "description": "A workflow parameter",
+    "required": True,
+}
+
+
+def _external_key(model_cls, field_name: str) -> str:
+    field_info = model_cls.model_fields[field_name]
+    alias = field_info.validation_alias
+    if isinstance(alias, str):
+        return alias
+    choices = getattr(alias, "choices", None)
+    if choices:
+        return choices[0]
+    return field_name
+
+
+def _build_step_payload(model_cls, step_type: str, structural: dict) -> dict:
+    payload = {"type": step_type, **structural}
+    for field_name in model_cls.model_fields:
+        if field_name in ("type", "steps") or field_name in structural:
+            continue
+        key = _external_key(model_cls, field_name)
+        if key in payload:
+            continue
+        payload[key] = _SAMPLE_FIELD_VALUES[field_name]
+    return payload
+
+
+def test_normalize_step_preserves_every_bash_step_field_from_flowsh_schema():
+    payload = _build_step_payload(BashStep, "bash", {"run": "echo hi"})
+
+    normalized = _normalize_step(payload)
+
+    for field_name in BashStep.model_fields:
+        if field_name == "type":
+            continue
+        key = _external_key(BashStep, field_name)
+        assert key in normalized, f"BashStep field '{key}' was dropped by normalization"
+        assert normalized[key] == payload[key]
+
+
+def test_normalize_step_preserves_every_vars_step_field_from_flowsh_schema():
+    payload = {"type": "vars", "name": "step-name", "when": "$FLAG == 1", "values": {"RELEASE": "echo stable"}}
+
+    normalized = _normalize_step(payload)
+
+    for field_name in VarsStep.model_fields:
+        if field_name == "type":
+            continue
+        key = _external_key(VarsStep, field_name)
+        assert key in normalized, f"VarsStep field '{key}' was dropped by normalization"
+        assert normalized[key] == payload[key]
+
+
+def test_normalize_step_preserves_every_agent_step_field_from_flowsh_schema():
+    payload = _build_step_payload(AgentStep, "agent", {})
+
+    normalized = _normalize_step(payload)
+
+    for field_name in AgentStep.model_fields:
+        if field_name == "type":
+            continue
+        key = _external_key(AgentStep, field_name)
+        assert key in normalized, f"AgentStep field '{key}' was dropped by normalization"
+        assert normalized[key] == payload[key]
+
+
+def test_normalize_step_preserves_every_for_step_field_from_flowsh_schema():
+    nested = [{"type": "bash", "run": "echo hi"}]
+    payload = _build_step_payload(ForStep, "for", {"steps": nested})
+
+    normalized = _normalize_step(payload)
+
+    for field_name in ForStep.model_fields:
+        if field_name == "type":
+            continue
+        key = _external_key(ForStep, field_name)
+        assert key in normalized, f"ForStep field '{key}' was dropped by normalization"
+        if key == "steps":
+            assert len(normalized[key]) == len(nested)
+            continue
+        assert normalized[key] == payload[key]
+
+
+def test_normalize_step_preserves_every_while_step_field_from_flowsh_schema():
+    nested = [{"type": "bash", "run": "echo hi"}]
+    payload = _build_step_payload(WhileStep, "while", {"steps": nested})
+
+    normalized = _normalize_step(payload)
+
+    for field_name in WhileStep.model_fields:
+        if field_name == "type":
+            continue
+        key = _external_key(WhileStep, field_name)
+        assert key in normalized, f"WhileStep field '{key}' was dropped by normalization"
+        if key == "steps":
+            assert len(normalized[key]) == len(nested)
+            continue
+        assert normalized[key] == payload[key]
+
+
+def test_normalize_step_preserves_every_parallel_step_field_from_flowsh_schema():
+    nested = [{"type": "bash", "run": "echo a"}, {"type": "bash", "run": "echo b"}]
+    payload = _build_step_payload(ParallelStep, "parallel", {"steps": nested})
+
+    normalized = _normalize_step(payload)
+
+    for field_name in ParallelStep.model_fields:
+        if field_name == "type":
+            continue
+        key = _external_key(ParallelStep, field_name)
+        assert key in normalized, f"ParallelStep field '{key}' was dropped by normalization"
+        if key == "steps":
+            assert len(normalized[key]) == len(nested)
+            continue
+        assert normalized[key] == payload[key]
+
+
+def test_normalize_workflow_params_preserves_every_workflow_param_field_from_flowsh_schema():
+    payload = [_build_step_payload(WorkflowParam, "", {"name": "TARGET_ENV"})]
+    payload[0].pop("type", None)
+
+    normalized = _normalize_workflow_params({"params": payload})
+
+    assert len(normalized) == 1
+    for field_name in WorkflowParam.model_fields:
+        key = _external_key(WorkflowParam, field_name)
+        assert key in normalized[0], f"WorkflowParam field '{key}' was dropped by normalization"
+        assert normalized[0][key] == payload[0][key]

--- a/packages/pybackend/workflow_service.py
+++ b/packages/pybackend/workflow_service.py
@@ -5,6 +5,13 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from flowsh_cli.models import (
+    AgentStep,
+    BaseStep,
+    WorkflowParam as FlowshWorkflowParam,
+)
+from pydantic import AliasChoices
+from pydantic.fields import FieldInfo
 
 from config import ensure_directory, get_made_directory, get_workspace_home
 from task_service import list_scheduled_tasks
@@ -12,6 +19,57 @@ from task_service import list_scheduled_tasks
 logger = logging.getLogger(__name__)
 
 DEFAULT_WORKFLOW_NAME = "New workflow"
+
+# Fields handled structurally elsewhere (required-field checks, nested
+# steps, dict-shaped values) rather than by the generic scalar/bool copier
+# below. Everything NOT in this set is derived directly from flowsh-cli's
+# own pydantic models, so a future flowsh-cli field addition flows through
+# `_copy_model_fields` automatically without a hand edit here.
+_COMMON_STEP_SKIP = {"type"}
+_AGENT_STEP_SKIP = {"type", "prompt"}
+_WORKFLOW_PARAM_SKIP = {"name", "required"}
+
+
+def _field_external_key(field_name: str, field_info: FieldInfo) -> str:
+    """Resolve the wire-format (YAML/JSON) key for a pydantic field.
+
+    Mirrors flowsh-cli's own aliasing (e.g. ForStep.in_ -> "in") so made's
+    normalized dicts use the same keys flowsh-cli's schema expects.
+    """
+    alias = field_info.validation_alias
+    if isinstance(alias, str):
+        return alias
+    if isinstance(alias, AliasChoices) and alias.choices:
+        first_choice = alias.choices[0]
+        if isinstance(first_choice, str):
+            return first_choice
+    return field_name
+
+
+def _copy_model_fields(
+    model_cls: type,
+    source: dict[str, Any],
+    target: dict[str, Any],
+    skip: set[str],
+) -> None:
+    """Copy simple str/bool fields declared on `model_cls` from `source` into
+    `target`, deriving the field set from flowsh-cli's own pydantic model
+    (`model_cls.model_fields`) instead of a hand-maintained list. This is the
+    mechanism that keeps made's normalization coupled to flowsh-cli's schema:
+    a field added to a flowsh-cli step/param model is picked up here without
+    a corresponding manual edit in made.
+    """
+    for field_name, field_info in model_cls.model_fields.items():
+        if field_name in skip:
+            continue
+        key = _field_external_key(field_name, field_info)
+        if field_info.annotation is bool:
+            if _as_bool(source.get(key)):
+                target[key] = True
+            continue
+        value = _as_string(source.get(key))
+        if value:
+            target[key] = value
 
 
 def _workflow_path(repo_name: str | None = None) -> Path:
@@ -39,12 +97,12 @@ def _as_bool(value: Any, default: bool = False) -> bool:
 def _normalize_common_step_fields(
     step: dict[str, Any], normalized: dict[str, Any]
 ) -> None:
-    name = _as_string(step.get("name"))
-    when = _as_string(step.get("when"))
-    if name:
-        normalized["name"] = name
-    if when:
-        normalized["when"] = when
+    """Copy step fields common to every step type (name, when).
+
+    Field set is derived from flowsh-cli's own `BaseStep` model so a future
+    common field addition there is picked up automatically.
+    """
+    _copy_model_fields(BaseStep, step, normalized, _COMMON_STEP_SKIP)
 
 
 def _normalize_nested_steps(step: dict[str, Any]) -> list[dict[str, Any]]:
@@ -69,27 +127,13 @@ def _normalize_step(step: Any) -> dict[str, Any]:
         return normalized
     if step_type == "agent":
         normalized = {"type": "agent"}
-        agent = _as_string(step.get("agent"))
-        command = _as_string(step.get("command"))
         prompt = _as_string(step.get("prompt"))
-        model = _as_string(step.get("model"))
-        capture = _as_string(step.get("capture"))
-        if agent:
-            normalized["agent"] = agent
-        if command:
-            normalized["command"] = command
         if prompt:
             normalized["prompt"] = prompt
-        if model:
-            normalized["model"] = model
-        if capture:
-            normalized["capture"] = capture
-        if _as_bool(step.get("expandPrompt")):
-            normalized["expandPrompt"] = True
-        if _as_bool(step.get("expandFields")):
-            normalized["expandFields"] = True
-        if _as_bool(step.get("dangerouslySkipPermissions")):
-            normalized["dangerouslySkipPermissions"] = True
+        # agent/command/model/capture/expandPrompt/expandFields/
+        # dangerouslySkipPermissions are all derived from AgentStep's own
+        # pydantic field list, not hand-copied one-by-one.
+        _copy_model_fields(AgentStep, step, normalized, _AGENT_STEP_SKIP)
         _normalize_common_step_fields(step, normalized)
         return normalized
     if step_type == "vars":
@@ -149,9 +193,8 @@ def _normalize_workflow_params(workflow: dict[str, Any]) -> list[dict[str, Any]]
         if not name:
             continue
         param: dict[str, Any] = {"name": name}
-        description = _as_string(raw_param.get("description"))
-        if description:
-            param["description"] = description
+        # description is derived from WorkflowParam's own field list.
+        _copy_model_fields(FlowshWorkflowParam, raw_param, param, _WORKFLOW_PARAM_SKIP)
         param["required"] = _as_bool(raw_param.get("required"), default=False)
         params.append(param)
     return params


### PR DESCRIPTION
## Issues fixed
- #739 — `workflow_service.py` hand-mirrors flowsh-cli's schema instead of importing it — will drift again on next flowsh-cli update

## Summary of changes

`workflow_harness_service.py` (the generate-harnesses path) already fully delegates parsing/rendering to `flowsh_cli.models`/`flowsh_cli.render`. But `workflow_service.py` (the save/read round-trip behind `PUT /api/workflows`/`read_workflows()`, used by the UI and cron) had zero `flowsh_cli` import — its normalization was a hand-written, parallel reimplementation of the schema, the same drift risk that caused the original engine fork in the first place.

**Approach taken** (both fix options from the issue, combined):
1. **Structural coupling (issue's approach 1, safe subset)**: `_normalize_common_step_fields`, the `agent` branch of `_normalize_step`, and `_normalize_workflow_params` now derive their field sets from `flowsh_cli.models`' own pydantic classes (`BaseStep`, `AgentStep`, `WorkflowParam`) via `model_fields` introspection, including alias resolution (e.g. `ForStep.in_` → `"in"`, matching flowsh-cli's own convention) — instead of hand-listed field copies. A field added to one of these models in a future flowsh-cli version now flows through automatically, without a corresponding manual edit here.
2. **Deliberately NOT adopted**: full `Workflow`/step-level strict validation (constructing/validating real `flowsh_cli.models.Workflow`/step instances). Verified this would be unsafe: flowsh-cli's `Workflow.id` requires `^wf_[A-Za-z0-9_-]+$` and `steps` requires `min_length=1`, both stricter than made's existing lenient tolerance (fallback ids like `workflow_1`, tolerance of empty `steps: []`). Adopting full strict validation would turn currently-tolerated malformed input into raised exceptions propagating to callers — verified against `app.py`/`cron_service.py`'s actual usage before rejecting this path. Structural/required fields with made-specific lenient semantics (`prompt`, `run`, `values`, `in`/`item`, `condition`, `steps`, param `name`/`required`) remain explicit for this reason.
3. **Drift-detection regression test (issue's approach 2)**: 7 new tests that introspect the real `BashStep`/`VarsStep`/`AgentStep`/`ForStep`/`WhileStep`/`ParallelStep`/`WorkflowParam` field lists **at test-run time** (via `model_cls.model_fields`, not hand-copied into the test) and assert normalization preserves every field present in input. If flowsh-cli adds a new field in a future version, these tests' own expectations grow automatically and start failing until `workflow_service.py` is updated — closing the loop the issue asked for.

## Validation commands run

```
uv run python -m pytest tests/unit/test_workflow_service.py -q
# 21 passed (14 original unchanged + 7 new drift tests)

make qa-quick-backend   # 487 passed, 1 skipped
make qa-quick           # frontend + backend, all green (pre-push hook re-verified)
```

**Drift-test teeth proven**: temporarily removed `capture` from the field-copy logic, reran the agent-step drift test → **failed** with `AssertionError: AgentStep field 'capture' was dropped by normalization`. Reverted → reran → **passed**. This proves the test would actually catch a real regression, not just superficially pass.

## E2E coverage

Real, unmocked, in-process FastAPI `TestClient` round-trip via the actual HTTP endpoints (ports 3000/5173 occupied by a running made instance — left untouched per policy, no server ports bound):
- `PUT /api/workflows` with a payload exercising workflow-level `description`/`params`, an `agent` step with all five extended fields (`model`/`capture`/`expandPrompt`/`expandFields`/`dangerouslySkipPermissions`), and a `for` step with nested children.
- `GET /api/workflows` → confirmed every field survives the real save/read HTTP cycle unchanged.

## Risks / follow-ups

- `maxRuntimeMinutes` remains a made-only field not present in flowsh-cli's `Workflow` model at all — correctly left as manual/explicit handling since it's outside flowsh-cli's schema surface, not a coupling gap.
- The chosen coupling (field-introspection only, no instance validation) is a deliberate middle ground — fully closes the silent-drop risk for scalar/bool fields, while structural fields still need a manual update if flowsh-cli changes their shape (e.g. renames `steps` or changes its type). This residual gap is now caught by the drift tests rather than silently shipping.

## Unrelated issues created
- None this round.
