### PR TITLE
feat: single source of truth for model options + add claude-opus-5

### DIFF
--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -532,8 +532,9 @@ export const RepositoryPage: React.FC = () => {
   );
   const normalizedSelectedModel = selectedModel ?? "default";
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
-  const [modelOptions, setModelOptions] =
-    useState<ModelOption[]>(DEFAULT_MODEL_OPTIONS);
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>(
+    DEFAULT_MODEL_OPTIONS,
+  );
   useEffect(() => {
     let cancelled = false;
     fetch("/api/models")

--- a/packages/frontend/src/pages/RepositoryPage.tsx
+++ b/packages/frontend/src/pages/RepositoryPage.tsx
@@ -109,7 +109,11 @@ const splitMentionSearch = (query: string) => {
   };
 };
 
-const MODEL_OPTIONS = [
+type ModelOption = { value: string; label: string; disabled?: boolean };
+
+// Fallback used only if GET /api/models fails; the canonical, single source
+// of truth for the model list lives in packages/pybackend/model_options.py.
+const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   { value: "default", label: "default" },
   { value: "", label: "------ kiro ------", disabled: true },
   { value: "claude-haiku-4.5", label: "claude-haiku-4.5" },
@@ -242,6 +246,28 @@ const MODEL_OPTIONS = [
     label: "openai/gpt-5.6-terra-fast",
   },
 ];
+
+type ApiModelOption = { value: string; label: string; group: string | null };
+
+// Converts the flat /api/models response into the UI shape, inserting
+// disabled "section header" entries before each group's first member (same
+// visual grouping the previous hardcoded list used for "kiro"/"opencode").
+const toModelOptions = (models: ApiModelOption[]): ModelOption[] => {
+  const options: ModelOption[] = [];
+  let lastGroup: string | null = null;
+  for (const model of models) {
+    if (model.group && model.group !== lastGroup) {
+      options.push({
+        value: "",
+        label: `------ ${model.group} ------`,
+        disabled: true,
+      });
+    }
+    lastGroup = model.group;
+    options.push({ value: model.value, label: model.label });
+  }
+  return options;
+};
 
 type HarnessRun = {
   pid: number;
@@ -506,6 +532,28 @@ export const RepositoryPage: React.FC = () => {
   );
   const normalizedSelectedModel = selectedModel ?? "default";
   const normalizedSelectedAgent = selectedAgent ?? DEFAULT_AGENT_VALUE;
+  const [modelOptions, setModelOptions] =
+    useState<ModelOption[]>(DEFAULT_MODEL_OPTIONS);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/models")
+      .then((response) => {
+        if (!response.ok) throw new Error(`status ${response.status}`);
+        return response.json();
+      })
+      .then((data: { models?: ApiModelOption[] }) => {
+        if (cancelled || !Array.isArray(data.models) || !data.models.length) {
+          return;
+        }
+        setModelOptions(toModelOptions(data.models));
+      })
+      .catch(() => {
+        // Keep DEFAULT_MODEL_OPTIONS fallback on network/server failure.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const [availableCommands, setAvailableCommands] = useState<
     CommandDefinition[]
   >([]);
@@ -1890,7 +1938,7 @@ export const RepositoryPage: React.FC = () => {
                   disabled={chatAgentProcessing}
                   aria-label="Model"
                 >
-                  {MODEL_OPTIONS.map((option) => (
+                  {modelOptions.map((option) => (
                     <option
                       key={`${option.label}-${option.value}`}
                       value={option.value}

--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -86,6 +86,7 @@ from cron_service import (
     start_cron_clock,
     stop_cron_clock,
 )
+from model_options import model_options_as_dicts
 from repository_service import (
     apply_repository_template,
     create_repository,
@@ -266,6 +267,17 @@ def dashboard():
         return get_dashboard_summary()
     except Exception as exc:  # pragma: no cover - passthrough errors
         logger.exception("Failed to fetch dashboard summary")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        )
+
+
+@app.get("/api/models")
+async def list_available_models():
+    try:
+        return {"models": model_options_as_dicts()}
+    except Exception as exc:
+        logger.exception("Failed to list available models")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         )

--- a/packages/pybackend/lite_router.py
+++ b/packages/pybackend/lite_router.py
@@ -12,61 +12,16 @@ from agent_service import (
     list_chat_sessions,
     send_agent_message,
 )
+from model_options import MODEL_OPTIONS as _MODEL_OPTIONS
 from repository_service import get_repository_info, list_repositories
 
 router = APIRouter(prefix="/lite")
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
-MODEL_OPTIONS = [
-    ("default", "default"),
-    ("claude-haiku-4.5", "claude-haiku-4.5"),
-    ("claude-opus-4.5", "claude-opus-4.5"),
-    ("claude-sonnet-4", "claude-sonnet-4"),
-    ("claude-sonnet-4.5", "claude-sonnet-4.5"),
-    ("opencode/big-pickle", "opencode/big-pickle"),
-    ("opencode/glm-4.7-free", "opencode/glm-4.7-free"),
-    ("opencode/gpt-5-nano", "opencode/gpt-5-nano"),
-    ("opencode/grok-code", "opencode/grok-code"),
-    ("github-copilot/claude-haiku-4.5", "github-copilot/claude-haiku-4.5"),
-    ("github-copilot/claude-opus-4.5", "github-copilot/claude-opus-4.5"),
-    ("github-copilot/claude-opus-4.6", "github-copilot/claude-opus-4.6"),
-    ("github-copilot/claude-opus-4.6-fast", "github-copilot/claude-opus-4.6-fast"),
-    ("github-copilot/claude-opus-4.7", "github-copilot/claude-opus-4.7"),
-    ("github-copilot/claude-opus-4.7-fast", "github-copilot/claude-opus-4.7-fast"),
-    ("github-copilot/claude-opus-4.8", "github-copilot/claude-opus-4.8"),
-    ("github-copilot/claude-opus-4.8-fast", "github-copilot/claude-opus-4.8-fast"),
-    ("github-copilot/claude-sonnet-4.5", "github-copilot/claude-sonnet-4.5"),
-    ("github-copilot/claude-sonnet-4.6", "github-copilot/claude-sonnet-4.6"),
-    ("github-copilot/claude-sonnet-5", "github-copilot/claude-sonnet-5"),
-    ("github-copilot/gemini-2.5-pro", "github-copilot/gemini-2.5-pro"),
-    ("github-copilot/gemini-3.5-flash", "github-copilot/gemini-3.5-flash"),
-    ("github-copilot/gpt-5-mini", "github-copilot/gpt-5-mini"),
-    ("github-copilot/gpt-5.3-codex", "github-copilot/gpt-5.3-codex"),
-    ("github-copilot/gpt-5.4", "github-copilot/gpt-5.4"),
-    ("github-copilot/gpt-5.4-mini", "github-copilot/gpt-5.4-mini"),
-    ("github-copilot/gpt-5.5", "github-copilot/gpt-5.5"),
-    ("github-copilot/gpt-5.6-luna", "github-copilot/gpt-5.6-luna"),
-    ("github-copilot/gpt-5.6-sol", "github-copilot/gpt-5.6-sol"),
-    ("github-copilot/gpt-5.6-terra", "github-copilot/gpt-5.6-terra"),
-    ("github-copilot/kimi-k2.7-code", "github-copilot/kimi-k2.7-code"),
-    (
-        "github-copilot/mai-code-1-flash-picker",
-        "github-copilot/mai-code-1-flash-picker",
-    ),
-    ("openai/gpt-5.3-codex-spark", "openai/gpt-5.3-codex-spark"),
-    ("openai/gpt-5.4", "openai/gpt-5.4"),
-    ("openai/gpt-5.4-fast", "openai/gpt-5.4-fast"),
-    ("openai/gpt-5.4-mini", "openai/gpt-5.4-mini"),
-    ("openai/gpt-5.4-mini-fast", "openai/gpt-5.4-mini-fast"),
-    ("openai/gpt-5.5", "openai/gpt-5.5"),
-    ("openai/gpt-5.5-fast", "openai/gpt-5.5-fast"),
-    ("openai/gpt-5.6-luna", "openai/gpt-5.6-luna"),
-    ("openai/gpt-5.6-luna-fast", "openai/gpt-5.6-luna-fast"),
-    ("openai/gpt-5.6-sol", "openai/gpt-5.6-sol"),
-    ("openai/gpt-5.6-sol-fast", "openai/gpt-5.6-sol-fast"),
-    ("openai/gpt-5.6-terra", "openai/gpt-5.6-terra"),
-    ("openai/gpt-5.6-terra-fast", "openai/gpt-5.6-terra-fast"),
-]
+# The lite template only needs (value, label) pairs; the canonical list with
+# group metadata lives in model_options.py (single source of truth, also
+# consumed by the /api/models endpoint used by the React frontend).
+MODEL_OPTIONS = [(value, label) for value, label, _group in _MODEL_OPTIONS]
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/packages/pybackend/model_options.py
+++ b/packages/pybackend/model_options.py
@@ -1,0 +1,88 @@
+"""Single source of truth for the AI models offered in agent chat UIs.
+
+Both the server-rendered "lite" chat UI (``lite_router.py``) and the
+``/api/models`` endpoint consumed by the React frontend
+(``RepositoryPage.tsx``) read from :data:`MODEL_OPTIONS` so the model list
+only needs to be maintained in one place.
+
+Each entry is ``(value, label, group)`` where ``group`` is ``None`` for
+ungrouped models and a group name (e.g. ``"kiro"``, ``"opencode"``) for
+models that should be visually grouped under a section header in the UI.
+"""
+
+from __future__ import annotations
+
+ModelOption = tuple[str, str, str | None]
+
+MODEL_OPTIONS: list[ModelOption] = [
+    ("default", "default", None),
+    ("claude-haiku-4.5", "claude-haiku-4.5", "kiro"),
+    ("claude-opus-4.5", "claude-opus-4.5", "kiro"),
+    ("claude-sonnet-4", "claude-sonnet-4", "kiro"),
+    ("claude-sonnet-4.5", "claude-sonnet-4.5", "kiro"),
+    ("opencode/big-pickle", "opencode/big-pickle", "opencode"),
+    ("opencode/glm-4.7-free", "opencode/glm-4.7-free", "opencode"),
+    ("opencode/gpt-5-nano", "opencode/gpt-5-nano", "opencode"),
+    ("opencode/grok-code", "opencode/grok-code", "opencode"),
+    ("github-copilot/claude-haiku-4.5", "github-copilot/claude-haiku-4.5", None),
+    ("github-copilot/claude-opus-4.5", "github-copilot/claude-opus-4.5", None),
+    ("github-copilot/claude-opus-4.6", "github-copilot/claude-opus-4.6", None),
+    (
+        "github-copilot/claude-opus-4.6-fast",
+        "github-copilot/claude-opus-4.6-fast",
+        None,
+    ),
+    ("github-copilot/claude-opus-4.7", "github-copilot/claude-opus-4.7", None),
+    (
+        "github-copilot/claude-opus-4.7-fast",
+        "github-copilot/claude-opus-4.7-fast",
+        None,
+    ),
+    ("github-copilot/claude-opus-4.8", "github-copilot/claude-opus-4.8", None),
+    (
+        "github-copilot/claude-opus-4.8-fast",
+        "github-copilot/claude-opus-4.8-fast",
+        None,
+    ),
+    ("github-copilot/claude-opus-5", "github-copilot/claude-opus-5", None),
+    ("github-copilot/claude-sonnet-4.5", "github-copilot/claude-sonnet-4.5", None),
+    ("github-copilot/claude-sonnet-4.6", "github-copilot/claude-sonnet-4.6", None),
+    ("github-copilot/claude-sonnet-5", "github-copilot/claude-sonnet-5", None),
+    ("github-copilot/gemini-2.5-pro", "github-copilot/gemini-2.5-pro", None),
+    ("github-copilot/gemini-3.5-flash", "github-copilot/gemini-3.5-flash", None),
+    ("github-copilot/gpt-5-mini", "github-copilot/gpt-5-mini", None),
+    ("github-copilot/gpt-5.3-codex", "github-copilot/gpt-5.3-codex", None),
+    ("github-copilot/gpt-5.4", "github-copilot/gpt-5.4", None),
+    ("github-copilot/gpt-5.4-mini", "github-copilot/gpt-5.4-mini", None),
+    ("github-copilot/gpt-5.5", "github-copilot/gpt-5.5", None),
+    ("github-copilot/gpt-5.6-luna", "github-copilot/gpt-5.6-luna", None),
+    ("github-copilot/gpt-5.6-sol", "github-copilot/gpt-5.6-sol", None),
+    ("github-copilot/gpt-5.6-terra", "github-copilot/gpt-5.6-terra", None),
+    ("github-copilot/kimi-k2.7-code", "github-copilot/kimi-k2.7-code", None),
+    (
+        "github-copilot/mai-code-1-flash-picker",
+        "github-copilot/mai-code-1-flash-picker",
+        None,
+    ),
+    ("openai/gpt-5.3-codex-spark", "openai/gpt-5.3-codex-spark", None),
+    ("openai/gpt-5.4", "openai/gpt-5.4", None),
+    ("openai/gpt-5.4-fast", "openai/gpt-5.4-fast", None),
+    ("openai/gpt-5.4-mini", "openai/gpt-5.4-mini", None),
+    ("openai/gpt-5.4-mini-fast", "openai/gpt-5.4-mini-fast", None),
+    ("openai/gpt-5.5", "openai/gpt-5.5", None),
+    ("openai/gpt-5.5-fast", "openai/gpt-5.5-fast", None),
+    ("openai/gpt-5.6-luna", "openai/gpt-5.6-luna", None),
+    ("openai/gpt-5.6-luna-fast", "openai/gpt-5.6-luna-fast", None),
+    ("openai/gpt-5.6-sol", "openai/gpt-5.6-sol", None),
+    ("openai/gpt-5.6-sol-fast", "openai/gpt-5.6-sol-fast", None),
+    ("openai/gpt-5.6-terra", "openai/gpt-5.6-terra", None),
+    ("openai/gpt-5.6-terra-fast", "openai/gpt-5.6-terra-fast", None),
+]
+
+
+def model_options_as_dicts() -> list[dict[str, str | None]]:
+    """Return :data:`MODEL_OPTIONS` as JSON-friendly dicts for the API."""
+    return [
+        {"value": value, "label": label, "group": group}
+        for value, label, group in MODEL_OPTIONS
+    ]

--- a/packages/pybackend/tests/unit/test_api.py
+++ b/packages/pybackend/tests/unit/test_api.py
@@ -100,6 +100,30 @@ class TestAgentsEndpoint:
         assert "Agent error" in response.json()["detail"]
 
 
+class TestModelsEndpoint:
+    """Test the /api/models endpoint (single source of truth for model list)."""
+
+    def test_list_models_success(self):
+        response = client.get("/api/models")
+
+        assert response.status_code == 200
+        models = response.json()["models"]
+        assert len(models) > 0
+        assert all({"value", "label", "group"} <= set(m) for m in models)
+        values = [m["value"] for m in models]
+        assert "default" in values
+        assert "github-copilot/claude-opus-5" in values
+
+    @patch("app.model_options_as_dicts")
+    def test_list_models_error(self, mock_models):
+        mock_models.side_effect = Exception("Models error")
+
+        response = client.get("/api/models")
+
+        assert response.status_code == 500
+        assert "Models error" in response.json()["detail"]
+
+
 class TestRepositoryAgentsEndpoint:
     """Test repository-scoped agents endpoint."""
 


### PR DESCRIPTION
Fixes #741

## Summary

The list of available AI models for agent chats was hardcoded independently in two places:
- `packages/pybackend/lite_router.py` (`MODEL_OPTIONS`) — used by the server-rendered "lite" chat UI
- `packages/frontend/src/pages/RepositoryPage.tsx` (`MODEL_OPTIONS`) — used by the main React chat UI's model dropdown

This PR consolidates both into a single canonical list and adds `claude-opus-5`.

## Changes

- **New `packages/pybackend/model_options.py`**: canonical `MODEL_OPTIONS` list (`value, label, group`), including `github-copilot/claude-opus-5`.
- **`lite_router.py`**: now imports from `model_options.py` instead of maintaining its own duplicate list.
- **`app.py`**: new `GET /api/models` endpoint exposing the canonical list as JSON (`{"models": [{"value", "label", "group"}, ...]}`), following the same pattern as the existing `/api/agents` endpoint.
- **`RepositoryPage.tsx`**: fetches `/api/models` on mount and renders the model dropdown from the response (converting `group` into the existing "------ kiro ------" / "------ opencode ------" disabled section headers), falling back to a small built-in `DEFAULT_MODEL_OPTIONS` list if the request fails.

## Validation

- Backend: `uv run pytest tests/unit` → 489 passed, 1 skipped (added `TestModelsEndpoint` covering success + error paths for `/api/models`).
- Backend: `ruff check` clean on touched files.
- Frontend: `tsc --noEmit` clean; `eslint` clean (0 errors, pre-existing complexity warnings only); `vitest run` → 174 passed (28 files), including existing `RepositoryPage.test.tsx`.
- E2E (real, no mocks): started the backend from this branch on an isolated port and verified with `curl`:
  - `GET /api/models` returns `claude-opus-5` (as `github-copilot/claude-opus-5`).
  - `GET /lite/` and `GET /lite/repo/{name}` render `claude-opus-5` in the lite HTML `<select>`.
- Full `make qa-quick` run via `git push` (pre-push hook): all quality gates passed.

## Risks / follow-ups

- Low risk: additive change plus a straightforward refactor of an existing hardcoded list; frontend has a fallback path if `/api/models` is unreachable.
- Did not modify `vite.config.ts`'s dev-server proxy (hardcoded to `:3000`) to run a full dev-server-to-dev-server E2E check, since the app's own running dev servers on ports 3000/5173 must not be touched/restarted per workspace rules; API-level real-request verification was used instead.

## Unrelated issue found & fixed separately

While validating this change via `git push`, discovered that `scripts/hooks/pre-push` leaks git-injected `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` env vars into `make qa-quick`, causing `test_repository_service.py`'s git-fixture tests to corrupt the real repository (stray commit, truncated README, invalid `core.bare` config). Filed as #742 and fixed in #743 (merged/pending independently of this PR).