### PR TITLE
Fix credentialed CORS wildcard configuration

### DIFF
--- a/packages/pybackend/app.py
+++ b/packages/pybackend/app.py
@@ -117,6 +117,7 @@ from config import (
     get_workspace_home,
     get_backend_host,
     get_backend_port,
+    get_cors_origins,
 )
 from fastapi.staticfiles import StaticFiles
 from lite_router import router as lite_router
@@ -153,8 +154,8 @@ async def lifespan(_: FastAPI):
 app = FastAPI(title="MADE Python Backend", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=get_cors_origins(),
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/packages/pybackend/config.py
+++ b/packages/pybackend/config.py
@@ -33,3 +33,12 @@ def get_backend_host() -> str:
 
 def get_backend_port() -> int:
     return int(os.environ.get("MADE_BACKEND_PORT", 3000))
+
+
+def get_cors_origins() -> list[str]:
+    default_origins = ["http://localhost:5173", "http://127.0.0.1:5173"]
+    configured_origins = os.environ.get("MADE_ALLOWED_ORIGINS")
+    if not configured_origins:
+        return default_origins
+    origins = [origin.strip() for origin in configured_origins.split(",") if origin.strip()]
+    return origins or default_origins

--- a/packages/pybackend/tests/unit/test_unit.py
+++ b/packages/pybackend/tests/unit/test_unit.py
@@ -1205,3 +1205,40 @@ class TestAgentService:
             with _processing_lock:
                 _processing_channels.pop(stale_key, None)
                 _active_processes.pop(stale_key, None)
+
+
+class TestCorsOrigins:
+    """Tests for CORS origin configuration."""
+
+    def test_default_origins_local_dev(self, monkeypatch):
+        monkeypatch.delenv("MADE_ALLOWED_ORIGINS", raising=False)
+
+        from config import get_cors_origins
+
+        assert get_cors_origins() == [
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ]
+
+    def test_custom_origins_from_env(self, monkeypatch):
+        monkeypatch.setenv(
+            "MADE_ALLOWED_ORIGINS",
+            "https://app.example.com, https://admin.example.com",
+        )
+
+        from config import get_cors_origins
+
+        assert get_cors_origins() == [
+            "https://app.example.com",
+            "https://admin.example.com",
+        ]
+
+    def test_empty_or_whitespace_only_env_falls_back_to_defaults(self, monkeypatch):
+        from config import get_cors_origins
+
+        for value in ("", "   ,  "):
+            monkeypatch.setenv("MADE_ALLOWED_ORIGINS", value)
+            assert get_cors_origins() == [
+                "http://localhost:5173",
+                "http://127.0.0.1:5173",
+            ]


### PR DESCRIPTION
Fixes #751

## What changed

- Read CORS origins from the comma-separated `MADE_ALLOWED_ORIGINS` environment variable.
- Default to the local frontend development origins.
- Disable credentialed CORS responses so the backend no longer combines credentials with a wildcard-style configuration.
- Add unit coverage for default, custom, and empty origin configuration.

## Root cause

The backend registered `allow_origins=["*"]` together with `allow_credentials=True`, which can reflect arbitrary request origins in credentialed CORS responses.

## Validation

- Added focused unit tests in `packages/pybackend/tests/unit/test_unit.py`.
- Reviewed the generated commit diff for the scoped three-file change.