### PR TITLE
Prevent repository file path traversal

### DIFF
--- a/packages/pybackend/repository_service.py
+++ b/packages/pybackend/repository_service.py
@@ -320,49 +320,56 @@ def list_repository_files(repo_name: str, path: str = ".") -> FileNode:
     return build_directory_node(target_path, repo_path)
 
 
+def _repository_file_path(repo_name: str, file_path: str) -> Path:
+    repo_root = (get_workspace_home() / repo_name).resolve()
+    normalized = (file_path or "").strip()
+    if not normalized:
+        raise ValueError("File path is required")
+    candidate = (repo_root / normalized).resolve()
+    if repo_root not in [candidate, *candidate.parents]:
+        raise ValueError("Path must stay within repository directory")
+    return candidate
+
+
 def read_repository_file(repo_name: str, file_path: str) -> str:
-    workspace = get_workspace_home()
-    target = workspace / repo_name / file_path
+    target = _repository_file_path(repo_name, file_path)
     return target.read_text(encoding="utf-8")
 
 
 def write_repository_file(repo_name: str, file_path: str, content: str) -> None:
-    workspace = get_workspace_home()
-    target = workspace / repo_name / file_path
+    target = _repository_file_path(repo_name, file_path)
     logger.info("Writing repository file '%s' in '%s'", file_path, repo_name)
     target.write_text(content, encoding="utf-8")
 
 
 def create_repository_file(repo_name: str, file_path: str, content: str = "") -> None:
-    workspace = get_workspace_home()
-    target = workspace / repo_name / file_path
+    target = _repository_file_path(repo_name, file_path)
     target.parent.mkdir(parents=True, exist_ok=True)
     logger.info("Creating repository file '%s' in '%s'", file_path, repo_name)
     target.write_text(content, encoding="utf-8")
 
 
 def write_repository_file_bytes(repo_name: str, file_path: str, content: bytes) -> None:
-    workspace = get_workspace_home()
-    target = workspace / repo_name / file_path
+    target = _repository_file_path(repo_name, file_path)
     target.parent.mkdir(parents=True, exist_ok=True)
     logger.info("Uploading repository file '%s' in '%s'", file_path, repo_name)
     target.write_bytes(content)
 
 
 def rename_repository_file(repo_name: str, old_path: str, new_path: str) -> None:
-    workspace = get_workspace_home()
+    old_target = _repository_file_path(repo_name, old_path)
+    new_target = _repository_file_path(repo_name, new_path)
     logger.info(
         "Renaming repository file from '%s' to '%s' in '%s'",
         old_path,
         new_path,
         repo_name,
     )
-    (workspace / repo_name / old_path).rename(workspace / repo_name / new_path)
+    old_target.rename(new_target)
 
 
 def delete_repository_file(repo_name: str, file_path: str) -> None:
-    workspace = get_workspace_home()
-    target = workspace / repo_name / file_path
+    target = _repository_file_path(repo_name, file_path)
     logger.info("Deleting repository path '%s' in '%s'", file_path, repo_name)
     if target.is_dir():
         for child in list(target.iterdir()):

--- a/packages/pybackend/tests/unit/test_repository_service.py
+++ b/packages/pybackend/tests/unit/test_repository_service.py
@@ -13,6 +13,12 @@ def clear_git_status_cache():
 
 from repository_service import (
     apply_repository_template,
+    create_repository_file,
+    delete_repository_file,
+    read_repository_file,
+    rename_repository_file,
+    write_repository_file,
+    write_repository_file_bytes,
     clone_repository,
     create_repository_worktree,
     delete_repository,
@@ -594,3 +600,68 @@ def test_invalidate_git_status_cache(monkeypatch, tmp_path):
     svc.invalidate_git_status_cache("nonexistent")
 
     svc._git_status_cache.clear()
+
+
+@pytest.fixture
+def repository_with_safe_files(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    repo = workspace / "myrepo"
+    repo.mkdir(parents=True)
+    (repo / "safe.txt").write_text("hello", encoding="utf-8")
+    (repo / "subdir").mkdir()
+    (repo / "subdir" / "nested.txt").write_text("nested", encoding="utf-8")
+    monkeypatch.setattr("repository_service.get_workspace_home", lambda: workspace)
+    return workspace, repo
+
+
+class TestRepositoryFilePathValidation:
+    """Verify repository file operations reject paths outside the repository."""
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["../outside.txt", "../../outside.txt", "subdir/../../outside.txt", "/etc/passwd"],
+    )
+    def test_read_rejects_traversal(self, repository_with_safe_files, bad_path):
+        with pytest.raises(ValueError, match="must stay within"):
+            read_repository_file("myrepo", bad_path)
+
+    @pytest.mark.parametrize("bad_path", ["../outside.txt", "../../outside.txt"])
+    def test_write_rejects_traversal(self, repository_with_safe_files, bad_path):
+        with pytest.raises(ValueError, match="must stay within"):
+            write_repository_file("myrepo", bad_path, "pwned")
+
+    @pytest.mark.parametrize("bad_path", ["../outside.txt", "../../outside.txt"])
+    def test_create_rejects_traversal(self, repository_with_safe_files, bad_path):
+        with pytest.raises(ValueError, match="must stay within"):
+            create_repository_file("myrepo", bad_path, "pwned")
+
+    @pytest.mark.parametrize("bad_path", ["../outside.bin", "../../outside.bin"])
+    def test_upload_rejects_traversal(self, repository_with_safe_files, bad_path):
+        with pytest.raises(ValueError, match="must stay within"):
+            write_repository_file_bytes("myrepo", bad_path, b"pwned")
+
+    @pytest.mark.parametrize(
+        "old_path,new_path",
+        [
+            ("../old.txt", "new.txt"),
+            ("old.txt", "../new.txt"),
+            ("../old.txt", "../new.txt"),
+        ],
+    )
+    def test_rename_rejects_traversal(
+        self, repository_with_safe_files, old_path, new_path
+    ):
+        with pytest.raises(ValueError, match="must stay within"):
+            rename_repository_file("myrepo", old_path, new_path)
+
+    @pytest.mark.parametrize("bad_path", ["../outside.txt", "../../outside"])
+    def test_delete_rejects_traversal(self, repository_with_safe_files, bad_path):
+        with pytest.raises(ValueError, match="must stay within"):
+            delete_repository_file("myrepo", bad_path)
+
+    def test_read_allows_valid_nested_path(self, repository_with_safe_files):
+        assert read_repository_file("myrepo", "subdir/nested.txt") == "nested"
+
+    def test_empty_path_is_rejected(self, repository_with_safe_files):
+        with pytest.raises(ValueError, match="required"):
+            read_repository_file("myrepo", "")


### PR DESCRIPTION
Fixes #750

## What changed

- Add a shared `_repository_file_path` helper that resolves paths and enforces repository-root containment.
- Apply it to repository file read, write, create, byte-upload, rename, and delete operations.
- Validate both source and destination paths for renames.
- Add unit coverage for traversal attempts across all six operations and valid nested reads.

## Root cause

The six file operations joined user-controlled paths directly to the workspace repository path without resolving and checking containment, allowing paths such as `../../etc/passwd` to escape the repository root.

## Validation

- Added focused unit tests in `packages/pybackend/tests/unit/test_repository_service.py`.
- Reviewed the generated commit diff for the scoped two-file change.